### PR TITLE
Align inbound collection validation with legacy workflow

### DIFF
--- a/lib/modules/goods_up/collection_task/bloc/inbound_collection_state.dart
+++ b/lib/modules/goods_up/collection_task/bloc/inbound_collection_state.dart
@@ -21,12 +21,15 @@ class InboundCollectionState extends Equatable {
     this.scanStep = InboundScanStep.site,
     this.currentTab = 0,
     this.checkedIds = const [],
+    this.candidateItemIds = const [],
     this.dicMtlQty = const {},
     this.dicSeq = const {},
     this.dicInvMtlQty = const {},
     this.focus = false,
     this.isDangerous = false,
     this.requireDangerousSupplement = false,
+    this.shouldCheckBatch = true,
+    this.allowErpStoreBypass = false,
   });
 
   final CollectionStatus status;
@@ -43,12 +46,15 @@ class InboundCollectionState extends Equatable {
   final InboundScanStep scanStep;
   final int currentTab;
   final List<int> checkedIds;
+  final List<int> candidateItemIds;
   final Map<String, List<dynamic>> dicMtlQty;
   final Map<String, String> dicSeq;
   final Map<String, double> dicInvMtlQty;
   final bool focus;
   final bool isDangerous;
   final bool requireDangerousSupplement;
+  final bool shouldCheckBatch;
+  final bool allowErpStoreBypass;
 
   InboundCollectionState copyWith({
     CollectionStatus? status,
@@ -65,12 +71,15 @@ class InboundCollectionState extends Equatable {
     InboundScanStep? scanStep,
     int? currentTab,
     List<int>? checkedIds,
+    List<int>? candidateItemIds,
     Map<String, List<dynamic>>? dicMtlQty,
     Map<String, String>? dicSeq,
     Map<String, double>? dicInvMtlQty,
     bool? focus,
     bool? isDangerous,
     bool? requireDangerousSupplement,
+    bool? shouldCheckBatch,
+    bool? allowErpStoreBypass,
   }) {
     return InboundCollectionState(
       status: status ?? this.status,
@@ -87,6 +96,7 @@ class InboundCollectionState extends Equatable {
       scanStep: scanStep ?? this.scanStep,
       currentTab: currentTab ?? this.currentTab,
       checkedIds: checkedIds ?? this.checkedIds,
+      candidateItemIds: candidateItemIds ?? this.candidateItemIds,
       dicMtlQty: dicMtlQty ?? this.dicMtlQty,
       dicSeq: dicSeq ?? this.dicSeq,
       dicInvMtlQty: dicInvMtlQty ?? this.dicInvMtlQty,
@@ -94,6 +104,8 @@ class InboundCollectionState extends Equatable {
       isDangerous: isDangerous ?? this.isDangerous,
       requireDangerousSupplement:
           requireDangerousSupplement ?? this.requireDangerousSupplement,
+      shouldCheckBatch: shouldCheckBatch ?? this.shouldCheckBatch,
+      allowErpStoreBypass: allowErpStoreBypass ?? this.allowErpStoreBypass,
     );
   }
 
@@ -113,11 +125,14 @@ class InboundCollectionState extends Equatable {
         scanStep,
         currentTab,
         checkedIds,
+        candidateItemIds,
         dicMtlQty,
         dicSeq,
         dicInvMtlQty,
         focus,
         isDangerous,
         requireDangerousSupplement,
+        shouldCheckBatch,
+        allowErpStoreBypass,
       ];
 }

--- a/lib/modules/goods_up/collection_task/models/inbound_collection_models.dart
+++ b/lib/modules/goods_up/collection_task/models/inbound_collection_models.dart
@@ -19,6 +19,7 @@ class InboundCollectTaskItem extends HiveObject with EquatableMixin {
     this.repertoryQty = 0,
     this.expireDays,
     this.productionDate,
+    this.proType,
   });
 
   factory InboundCollectTaskItem.fromJson(Map<String, dynamic> json) {
@@ -38,6 +39,7 @@ class InboundCollectTaskItem extends HiveObject with EquatableMixin {
       repertoryQty: _parseDouble(json['repqty']),
       expireDays: _parseIntNullable(json['vdays']),
       productionDate: json['pdate']?.toString(),
+      proType: json['protype']?.toString(),
     );
   }
 
@@ -56,6 +58,7 @@ class InboundCollectTaskItem extends HiveObject with EquatableMixin {
   final double repertoryQty;
   final int? expireDays;
   final String? productionDate;
+  final String? proType;
 
   Map<String, dynamic> toJson() {
     return {
@@ -74,6 +77,7 @@ class InboundCollectTaskItem extends HiveObject with EquatableMixin {
       'repqty': repertoryQty,
       'vdays': expireDays,
       'pdate': productionDate,
+      'protype': proType,
     };
   }
 
@@ -94,6 +98,7 @@ class InboundCollectTaskItem extends HiveObject with EquatableMixin {
     repertoryQty,
     expireDays,
     productionDate,
+    proType,
   ];
 }
 


### PR DESCRIPTION
## Summary
- capture inbound `proType` metadata to derive batch-validation and ERP bypass flags when loading or restoring task details
- honor the batch-check flag during material matching, persist the resolved storeroom, and bypass ERP subinventory validation for XN-BL when permitted
- parse `$KW$` formatted site scans before validation to match the legacy UniApp behavior

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68eba2f22bf08330b2ce111bf3e2b7a8