### PR TITLE
Add inbound goods-up collection module skeleton

### DIFF
--- a/lib/app_module.dart
+++ b/lib/app_module.dart
@@ -8,6 +8,7 @@ import 'package:wms_app/modules/home/login/login_page.dart';
 import 'package:wms_app/services/api_service.dart';
 import 'modules/outbound/outbound_module.dart';
 import 'modules/goods_up/goods_up_module.dart';
+import 'modules/inbound/goods_up_task/goods_up_task_module.dart';
 
 /// 应用主模块
 class AppModule extends Module {
@@ -44,5 +45,8 @@ class AppModule extends Module {
 
     // 平库上架模块
     r.module('/goods-up', module: GoodsUpModule());
+
+    // 入库上架采集模块
+    r.module('/inbound/goods-up', module: GoodsUpTaskModule());
   }
 }

--- a/lib/modules/inbound/goods_up_task/bloc/goods_up_collection_bloc.dart
+++ b/lib/modules/inbound/goods_up_task/bloc/goods_up_collection_bloc.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:meta/meta.dart';
+
+import '../models/goods_up_collection_task.dart';
+import '../services/goods_up_collection_service.dart';
+import '../../../../services/user_manager.dart';
+
+@immutable
+abstract class GoodsUpCollectionState {
+  const GoodsUpCollectionState();
+}
+
+class GoodsUpCollectionInitial extends GoodsUpCollectionState {
+  const GoodsUpCollectionInitial();
+}
+
+class GoodsUpCollectionLoadInProgress extends GoodsUpCollectionState {
+  const GoodsUpCollectionLoadInProgress();
+}
+
+class GoodsUpCollectionLoadSuccess extends GoodsUpCollectionState {
+  const GoodsUpCollectionLoadSuccess(this.tasks);
+
+  final List<GoodsUpCollectionTask> tasks;
+}
+
+class GoodsUpCollectionLoadFailure extends GoodsUpCollectionState {
+  const GoodsUpCollectionLoadFailure(this.message);
+
+  final String message;
+}
+
+class GoodsUpCollectionBloc extends Cubit<GoodsUpCollectionState> {
+  GoodsUpCollectionBloc({
+    required GoodsUpCollectionService service,
+    required UserManager userManager,
+  })  : _service = service,
+        _userManager = userManager,
+        super(const GoodsUpCollectionInitial());
+
+  final GoodsUpCollectionService _service;
+  final UserManager _userManager;
+
+  Future<void> loadTasks() async {
+    emit(const GoodsUpCollectionLoadInProgress());
+    try {
+      final tasks = await _service.fetchPendingTasks(
+        userId: _userManager.currentUser?.userId,
+      );
+      emit(GoodsUpCollectionLoadSuccess(tasks));
+    } catch (error) {
+      emit(GoodsUpCollectionLoadFailure(error.toString()));
+    }
+  }
+}

--- a/lib/modules/inbound/goods_up_task/goods_up_collection_page.dart
+++ b/lib/modules/inbound/goods_up_task/goods_up_collection_page.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'bloc/goods_up_collection_bloc.dart';
+import 'widgets/goods_up_task_summary_card.dart';
+
+class GoodsUpCollectionPage extends StatelessWidget {
+  const GoodsUpCollectionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('入库上架采集')),
+      body: BlocBuilder<GoodsUpCollectionBloc, GoodsUpCollectionState>(
+        builder: (context, state) {
+          if (state is GoodsUpCollectionInitial) {
+            context.read<GoodsUpCollectionBloc>().loadTasks();
+            return const _LoadingIndicator();
+          }
+          if (state is GoodsUpCollectionLoadInProgress) {
+            return const _LoadingIndicator();
+          }
+          if (state is GoodsUpCollectionLoadSuccess) {
+            if (state.tasks.isEmpty) {
+              return const Center(child: Text('暂无待处理的上架任务'));
+            }
+            return ListView.builder(
+              itemCount: state.tasks.length,
+              itemBuilder: (context, index) {
+                final task = state.tasks[index];
+                return GoodsUpTaskSummaryCard(task: task);
+              },
+            );
+          }
+          if (state is GoodsUpCollectionLoadFailure) {
+            return Center(child: Text('加载失败：${state.message}'));
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}
+
+class _LoadingIndicator extends StatelessWidget {
+  const _LoadingIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}

--- a/lib/modules/inbound/goods_up_task/goods_up_task_module.dart
+++ b/lib/modules/inbound/goods_up_task/goods_up_task_module.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../app_module.dart';
+import '../../../../services/dio_client.dart';
+import '../../../../services/user_manager.dart';
+import 'bloc/goods_up_collection_bloc.dart';
+import 'goods_up_collection_page.dart';
+import 'services/goods_up_collection_service.dart';
+
+class GoodsUpTaskModule extends Module {
+  @override
+  List<Module> get imports => [AppModule()];
+
+  @override
+  void binds(Injector i) {
+    i.addSingleton<GoodsUpCollectionService>(
+      () => GoodsUpCollectionService(i.get<DioClient>().dio),
+    );
+
+    i.add<GoodsUpCollectionBloc>(
+      () => GoodsUpCollectionBloc(
+        service: i.get<GoodsUpCollectionService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+  }
+
+  @override
+  void routes(RouteManager r) {
+    r.child(
+      '/collect',
+      child: (_) => BlocProvider(
+        create: (_) => Modular.get<GoodsUpCollectionBloc>(),
+        child: const GoodsUpCollectionPage(),
+      ),
+    );
+  }
+}

--- a/lib/modules/inbound/goods_up_task/models/goods_up_collection_task.dart
+++ b/lib/modules/inbound/goods_up_task/models/goods_up_collection_task.dart
@@ -1,0 +1,11 @@
+class GoodsUpCollectionTask {
+  const GoodsUpCollectionTask({
+    required this.taskNo,
+    required this.materialCode,
+    required this.quantity,
+  });
+
+  final String taskNo;
+  final String materialCode;
+  final double quantity;
+}

--- a/lib/modules/inbound/goods_up_task/services/goods_up_collection_service.dart
+++ b/lib/modules/inbound/goods_up_task/services/goods_up_collection_service.dart
@@ -1,0 +1,14 @@
+import 'package:dio/dio.dart';
+
+import '../models/goods_up_collection_task.dart';
+
+class GoodsUpCollectionService {
+  GoodsUpCollectionService(this._dio);
+
+  final Dio _dio;
+
+  Future<List<GoodsUpCollectionTask>> fetchPendingTasks({int? userId}) async {
+    // TODO: 接入真实的入库上架任务列表接口
+    return Future<List<GoodsUpCollectionTask>>.value(const []);
+  }
+}

--- a/lib/modules/inbound/goods_up_task/widgets/goods_up_task_summary_card.dart
+++ b/lib/modules/inbound/goods_up_task/widgets/goods_up_task_summary_card.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import '../models/goods_up_collection_task.dart';
+
+class GoodsUpTaskSummaryCard extends StatelessWidget {
+  const GoodsUpTaskSummaryCard({super.key, required this.task});
+
+  final GoodsUpCollectionTask task;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(task.taskNo),
+        subtitle: Text(task.materialCode),
+        trailing: Text(task.quantity.toStringAsFixed(2)),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold an inbound goods-up task module with bloc, service, model, page, and widget placeholders
- register the goods-up task module under the /inbound/goods-up route in the app module
- wire dependency bindings inside GoodsUpTaskModule to mirror the outbound collection structure

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ecbb59fe0883308b0ce99ade54893a