### PR TITLE
feat: add goods up cached models and requests

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:wms_app/services/user_manager.dart';
 import 'package:wms_app/modules/home/home_page.dart';
 import 'package:wms_app/modules/outbound/collection_task/models/collection_models.dart';
+import 'package:wms_app/modules/inbound/goods_up_task/models/goods_up_models.dart';
 import 'modules/home/login/login_page.dart';
 import 'app_module.dart';
 
@@ -16,6 +17,9 @@ void main() async {
   Hive.registerAdapter(OutTaskItemAdapter());
   Hive.registerAdapter(BarcodeContentAdapter());
   Hive.registerAdapter(CollectionStockAdapter());
+  Hive.registerAdapter(InTaskItemAdapter());
+  Hive.registerAdapter(UpBarcodeContentAdapter());
+  Hive.registerAdapter(UpCollectionStockAdapter());
   runApp(ModularApp(module: AppModule(), child: const MyApp()));
 }
 

--- a/lib/modules/inbound/goods_up_task/models/goods_up_models.dart
+++ b/lib/modules/inbound/goods_up_task/models/goods_up_models.dart
@@ -1,0 +1,86 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hive/hive.dart';
+
+part 'goods_up_models.freezed.dart';
+part 'goods_up_models.g.dart';
+
+@freezed
+@HiveType(typeId: 3)
+class InTaskItem extends HiveObject with _$InTaskItem {
+  InTaskItem._();
+
+  factory InTaskItem({
+    @JsonKey(name: 'intaskitemid') @HiveField(0) required int inTaskItemId,
+    @JsonKey(name: 'intaskid') @HiveField(1) required int inTaskId,
+    @JsonKey(name: 'intaskno') @HiveField(2) String? inTaskNo,
+    @JsonKey(name: 'matcode') @HiveField(3) String? materialCode,
+    @JsonKey(name: 'matname') @HiveField(4) String? materialName,
+    @JsonKey(name: 'matinnercode') @HiveField(5) String? oldMaterialCode,
+    @JsonKey(name: 'storeroomno') @HiveField(6) String? storeRoomNo,
+    @JsonKey(name: 'storesiteno') @HiveField(7) String? storeSiteNo,
+    @JsonKey(name: 'qty') @HiveField(8) required double quantity,
+    @JsonKey(name: 'collectedqty')
+    @HiveField(9)
+    required double collectedQuantity,
+    @JsonKey(name: 'batchno') @HiveField(10) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(11) String? serialNumber,
+    @JsonKey(name: 'subinventoryCode') @HiveField(12) String? subInventoryCode,
+    @JsonKey(name: 'orderno') @HiveField(13) String? inboundOrderNo,
+    @JsonKey(name: 'taskcomment') @HiveField(14) String? taskComment,
+  }) = _InTaskItem;
+
+  factory InTaskItem.fromJson(Map<String, dynamic> json) =>
+      _$InTaskItemFromJson(json);
+}
+
+@freezed
+@HiveType(typeId: 4)
+class UpBarcodeContent extends HiveObject with _$UpBarcodeContent {
+  UpBarcodeContent._();
+
+  factory UpBarcodeContent({
+    @JsonKey(name: 'matcode') @HiveField(0) String? materialCode,
+    @JsonKey(name: 'matname') @HiveField(1) String? materialName,
+    @JsonKey(name: 'batchno') @HiveField(2) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) String? serialNumber,
+    @JsonKey(name: 'seqctrl') @HiveField(4) String? seqctrl,
+    @JsonKey(name: 'idOld') @HiveField(5) String? idOld,
+    @JsonKey(name: 'qty') @HiveField(6) double? quantity,
+    @JsonKey(name: 'pdate') @HiveField(7) String? productionDate,
+    @JsonKey(name: 'vdays') @HiveField(8) String? validDays,
+    @JsonKey(name: 'dgFlg') @HiveField(9) String? dgFlag,
+  }) = _UpBarcodeContent;
+
+  factory UpBarcodeContent.fromJson(Map<String, dynamic> json) =>
+      _$UpBarcodeContentFromJson(json);
+
+  bool get isEmpty => (materialCode == null || materialCode!.isEmpty);
+
+  bool get isNotEmpty => !isEmpty;
+}
+
+@freezed
+@HiveType(typeId: 5)
+class UpCollectionStock extends HiveObject with _$UpCollectionStock {
+  UpCollectionStock._();
+
+  factory UpCollectionStock({
+    @JsonKey(name: 'stockid') @HiveField(0) required String stockId,
+    @JsonKey(name: 'matcode') @HiveField(1) required String materialCode,
+    @JsonKey(name: 'batchno') @HiveField(2) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) String? serialNumber,
+    @JsonKey(name: 'taskQty') @HiveField(4) double? taskQuantity,
+    @JsonKey(name: 'collectQty') @HiveField(5) double? collectedQuantity,
+    @JsonKey(name: 'taskNo') @HiveField(6) String? taskNo,
+    @JsonKey(name: 'taskid') @HiveField(7) String? taskId,
+    @JsonKey(name: 'storeRoom') @HiveField(8) String? storeRoom,
+    @JsonKey(name: 'storeSite') @HiveField(9) String? storeSite,
+    @JsonKey(name: 'pdate') @HiveField(10) String? productionDate,
+    @JsonKey(name: 'vdays') @HiveField(11) String? validDays,
+    @JsonKey(name: 'erpStore') @HiveField(12) String? erpStore,
+    @JsonKey(name: 'trayNo') @HiveField(13) String? trayNo,
+  }) = _UpCollectionStock;
+
+  factory UpCollectionStock.fromJson(Map<String, dynamic> json) =>
+      _$UpCollectionStockFromJson(json);
+}

--- a/lib/modules/inbound/goods_up_task/models/goods_up_models.freezed.dart
+++ b/lib/modules/inbound/goods_up_task/models/goods_up_models.freezed.dart
@@ -1,0 +1,1511 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'goods_up_models.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+InTaskItem _$InTaskItemFromJson(Map<String, dynamic> json) {
+  return _InTaskItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InTaskItem {
+  @JsonKey(name: 'intaskitemid')
+  @HiveField(0)
+  int get inTaskItemId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'intaskid')
+  @HiveField(1)
+  int get inTaskId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'intaskno')
+  @HiveField(2)
+  String? get inTaskNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matcode')
+  @HiveField(3)
+  String? get materialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matname')
+  @HiveField(4)
+  String? get materialName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matinnercode')
+  @HiveField(5)
+  String? get oldMaterialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storeroomno')
+  @HiveField(6)
+  String? get storeRoomNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storesiteno')
+  @HiveField(7)
+  String? get storeSiteNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'qty')
+  @HiveField(8)
+  double get quantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'collectedqty')
+  @HiveField(9)
+  double get collectedQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'batchno')
+  @HiveField(10)
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sn')
+  @HiveField(11)
+  String? get serialNumber => throw _privateConstructorUsedError;
+  @JsonKey(name: 'subinventoryCode')
+  @HiveField(12)
+  String? get subInventoryCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'orderno')
+  @HiveField(13)
+  String? get inboundOrderNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'taskcomment')
+  @HiveField(14)
+  String? get taskComment => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InTaskItemCopyWith<InTaskItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InTaskItemCopyWith<$Res> {
+  factory $InTaskItemCopyWith(
+    InTaskItem value,
+    $Res Function(InTaskItem) then,
+  ) = _$InTaskItemCopyWithImpl<$Res, InTaskItem>;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'intaskitemid') @HiveField(0) int inTaskItemId,
+    @JsonKey(name: 'intaskid') @HiveField(1) int inTaskId,
+    @JsonKey(name: 'intaskno') @HiveField(2) String? inTaskNo,
+    @JsonKey(name: 'matcode') @HiveField(3) String? materialCode,
+    @JsonKey(name: 'matname') @HiveField(4) String? materialName,
+    @JsonKey(name: 'matinnercode') @HiveField(5) String? oldMaterialCode,
+    @JsonKey(name: 'storeroomno') @HiveField(6) String? storeRoomNo,
+    @JsonKey(name: 'storesiteno') @HiveField(7) String? storeSiteNo,
+    @JsonKey(name: 'qty') @HiveField(8) double quantity,
+    @JsonKey(name: 'collectedqty') @HiveField(9) double collectedQuantity,
+    @JsonKey(name: 'batchno') @HiveField(10) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(11) String? serialNumber,
+    @JsonKey(name: 'subinventoryCode') @HiveField(12) String? subInventoryCode,
+    @JsonKey(name: 'orderno') @HiveField(13) String? inboundOrderNo,
+    @JsonKey(name: 'taskcomment') @HiveField(14) String? taskComment,
+  });
+}
+
+/// @nodoc
+class _$InTaskItemCopyWithImpl<$Res, $Val extends InTaskItem>
+    implements $InTaskItemCopyWith<$Res> {
+  _$InTaskItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? inTaskItemId = null,
+    Object? inTaskId = null,
+    Object? inTaskNo = freezed,
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? oldMaterialCode = freezed,
+    Object? storeRoomNo = freezed,
+    Object? storeSiteNo = freezed,
+    Object? quantity = null,
+    Object? collectedQuantity = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? subInventoryCode = freezed,
+    Object? inboundOrderNo = freezed,
+    Object? taskComment = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            inTaskItemId: null == inTaskItemId
+                ? _value.inTaskItemId
+                : inTaskItemId // ignore: cast_nullable_to_non_nullable
+                      as int,
+            inTaskId: null == inTaskId
+                ? _value.inTaskId
+                : inTaskId // ignore: cast_nullable_to_non_nullable
+                      as int,
+            inTaskNo: freezed == inTaskNo
+                ? _value.inTaskNo
+                : inTaskNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            materialCode: freezed == materialCode
+                ? _value.materialCode
+                : materialCode // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            materialName: freezed == materialName
+                ? _value.materialName
+                : materialName // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            oldMaterialCode: freezed == oldMaterialCode
+                ? _value.oldMaterialCode
+                : oldMaterialCode // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            storeRoomNo: freezed == storeRoomNo
+                ? _value.storeRoomNo
+                : storeRoomNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            storeSiteNo: freezed == storeSiteNo
+                ? _value.storeSiteNo
+                : storeSiteNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            quantity: null == quantity
+                ? _value.quantity
+                : quantity // ignore: cast_nullable_to_non_nullable
+                      as double,
+            collectedQuantity: null == collectedQuantity
+                ? _value.collectedQuantity
+                : collectedQuantity // ignore: cast_nullable_to_non_nullable
+                      as double,
+            batchNo: freezed == batchNo
+                ? _value.batchNo
+                : batchNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            serialNumber: freezed == serialNumber
+                ? _value.serialNumber
+                : serialNumber // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            subInventoryCode: freezed == subInventoryCode
+                ? _value.subInventoryCode
+                : subInventoryCode // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            inboundOrderNo: freezed == inboundOrderNo
+                ? _value.inboundOrderNo
+                : inboundOrderNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            taskComment: freezed == taskComment
+                ? _value.taskComment
+                : taskComment // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$InTaskItemImplCopyWith<$Res>
+    implements $InTaskItemCopyWith<$Res> {
+  factory _$$InTaskItemImplCopyWith(
+    _$InTaskItemImpl value,
+    $Res Function(_$InTaskItemImpl) then,
+  ) = __$$InTaskItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'intaskitemid') @HiveField(0) int inTaskItemId,
+    @JsonKey(name: 'intaskid') @HiveField(1) int inTaskId,
+    @JsonKey(name: 'intaskno') @HiveField(2) String? inTaskNo,
+    @JsonKey(name: 'matcode') @HiveField(3) String? materialCode,
+    @JsonKey(name: 'matname') @HiveField(4) String? materialName,
+    @JsonKey(name: 'matinnercode') @HiveField(5) String? oldMaterialCode,
+    @JsonKey(name: 'storeroomno') @HiveField(6) String? storeRoomNo,
+    @JsonKey(name: 'storesiteno') @HiveField(7) String? storeSiteNo,
+    @JsonKey(name: 'qty') @HiveField(8) double quantity,
+    @JsonKey(name: 'collectedqty') @HiveField(9) double collectedQuantity,
+    @JsonKey(name: 'batchno') @HiveField(10) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(11) String? serialNumber,
+    @JsonKey(name: 'subinventoryCode') @HiveField(12) String? subInventoryCode,
+    @JsonKey(name: 'orderno') @HiveField(13) String? inboundOrderNo,
+    @JsonKey(name: 'taskcomment') @HiveField(14) String? taskComment,
+  });
+}
+
+/// @nodoc
+class __$$InTaskItemImplCopyWithImpl<$Res>
+    extends _$InTaskItemCopyWithImpl<$Res, _$InTaskItemImpl>
+    implements _$$InTaskItemImplCopyWith<$Res> {
+  __$$InTaskItemImplCopyWithImpl(
+    _$InTaskItemImpl _value,
+    $Res Function(_$InTaskItemImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? inTaskItemId = null,
+    Object? inTaskId = null,
+    Object? inTaskNo = freezed,
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? oldMaterialCode = freezed,
+    Object? storeRoomNo = freezed,
+    Object? storeSiteNo = freezed,
+    Object? quantity = null,
+    Object? collectedQuantity = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? subInventoryCode = freezed,
+    Object? inboundOrderNo = freezed,
+    Object? taskComment = freezed,
+  }) {
+    return _then(
+      _$InTaskItemImpl(
+        inTaskItemId: null == inTaskItemId
+            ? _value.inTaskItemId
+            : inTaskItemId // ignore: cast_nullable_to_non_nullable
+                  as int,
+        inTaskId: null == inTaskId
+            ? _value.inTaskId
+            : inTaskId // ignore: cast_nullable_to_non_nullable
+                  as int,
+        inTaskNo: freezed == inTaskNo
+            ? _value.inTaskNo
+            : inTaskNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        materialCode: freezed == materialCode
+            ? _value.materialCode
+            : materialCode // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        materialName: freezed == materialName
+            ? _value.materialName
+            : materialName // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        oldMaterialCode: freezed == oldMaterialCode
+            ? _value.oldMaterialCode
+            : oldMaterialCode // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        storeRoomNo: freezed == storeRoomNo
+            ? _value.storeRoomNo
+            : storeRoomNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        storeSiteNo: freezed == storeSiteNo
+            ? _value.storeSiteNo
+            : storeSiteNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        quantity: null == quantity
+            ? _value.quantity
+            : quantity // ignore: cast_nullable_to_non_nullable
+                  as double,
+        collectedQuantity: null == collectedQuantity
+            ? _value.collectedQuantity
+            : collectedQuantity // ignore: cast_nullable_to_non_nullable
+                  as double,
+        batchNo: freezed == batchNo
+            ? _value.batchNo
+            : batchNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        serialNumber: freezed == serialNumber
+            ? _value.serialNumber
+            : serialNumber // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        subInventoryCode: freezed == subInventoryCode
+            ? _value.subInventoryCode
+            : subInventoryCode // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        inboundOrderNo: freezed == inboundOrderNo
+            ? _value.inboundOrderNo
+            : inboundOrderNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        taskComment: freezed == taskComment
+            ? _value.taskComment
+            : taskComment // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InTaskItemImpl extends _InTaskItem {
+  _$InTaskItemImpl({
+    @JsonKey(name: 'intaskitemid') @HiveField(0) required this.inTaskItemId,
+    @JsonKey(name: 'intaskid') @HiveField(1) required this.inTaskId,
+    @JsonKey(name: 'intaskno') @HiveField(2) this.inTaskNo,
+    @JsonKey(name: 'matcode') @HiveField(3) this.materialCode,
+    @JsonKey(name: 'matname') @HiveField(4) this.materialName,
+    @JsonKey(name: 'matinnercode') @HiveField(5) this.oldMaterialCode,
+    @JsonKey(name: 'storeroomno') @HiveField(6) this.storeRoomNo,
+    @JsonKey(name: 'storesiteno') @HiveField(7) this.storeSiteNo,
+    @JsonKey(name: 'qty') @HiveField(8) required this.quantity,
+    @JsonKey(name: 'collectedqty')
+    @HiveField(9)
+    required this.collectedQuantity,
+    @JsonKey(name: 'batchno') @HiveField(10) this.batchNo,
+    @JsonKey(name: 'sn') @HiveField(11) this.serialNumber,
+    @JsonKey(name: 'subinventoryCode') @HiveField(12) this.subInventoryCode,
+    @JsonKey(name: 'orderno') @HiveField(13) this.inboundOrderNo,
+    @JsonKey(name: 'taskcomment') @HiveField(14) this.taskComment,
+  }) : super._();
+
+  factory _$InTaskItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InTaskItemImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'intaskitemid')
+  @HiveField(0)
+  final int inTaskItemId;
+  @override
+  @JsonKey(name: 'intaskid')
+  @HiveField(1)
+  final int inTaskId;
+  @override
+  @JsonKey(name: 'intaskno')
+  @HiveField(2)
+  final String? inTaskNo;
+  @override
+  @JsonKey(name: 'matcode')
+  @HiveField(3)
+  final String? materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  @HiveField(4)
+  final String? materialName;
+  @override
+  @JsonKey(name: 'matinnercode')
+  @HiveField(5)
+  final String? oldMaterialCode;
+  @override
+  @JsonKey(name: 'storeroomno')
+  @HiveField(6)
+  final String? storeRoomNo;
+  @override
+  @JsonKey(name: 'storesiteno')
+  @HiveField(7)
+  final String? storeSiteNo;
+  @override
+  @JsonKey(name: 'qty')
+  @HiveField(8)
+  final double quantity;
+  @override
+  @JsonKey(name: 'collectedqty')
+  @HiveField(9)
+  final double collectedQuantity;
+  @override
+  @JsonKey(name: 'batchno')
+  @HiveField(10)
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  @HiveField(11)
+  final String? serialNumber;
+  @override
+  @JsonKey(name: 'subinventoryCode')
+  @HiveField(12)
+  final String? subInventoryCode;
+  @override
+  @JsonKey(name: 'orderno')
+  @HiveField(13)
+  final String? inboundOrderNo;
+  @override
+  @JsonKey(name: 'taskcomment')
+  @HiveField(14)
+  final String? taskComment;
+
+  @override
+  String toString() {
+    return 'InTaskItem(inTaskItemId: $inTaskItemId, inTaskId: $inTaskId, inTaskNo: $inTaskNo, materialCode: $materialCode, materialName: $materialName, oldMaterialCode: $oldMaterialCode, storeRoomNo: $storeRoomNo, storeSiteNo: $storeSiteNo, quantity: $quantity, collectedQuantity: $collectedQuantity, batchNo: $batchNo, serialNumber: $serialNumber, subInventoryCode: $subInventoryCode, inboundOrderNo: $inboundOrderNo, taskComment: $taskComment)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InTaskItemImpl &&
+            (identical(other.inTaskItemId, inTaskItemId) ||
+                other.inTaskItemId == inTaskItemId) &&
+            (identical(other.inTaskId, inTaskId) ||
+                other.inTaskId == inTaskId) &&
+            (identical(other.inTaskNo, inTaskNo) ||
+                other.inTaskNo == inTaskNo) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.oldMaterialCode, oldMaterialCode) ||
+                other.oldMaterialCode == oldMaterialCode) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity) &&
+            (identical(other.collectedQuantity, collectedQuantity) ||
+                other.collectedQuantity == collectedQuantity) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNumber, serialNumber) ||
+                other.serialNumber == serialNumber) &&
+            (identical(other.subInventoryCode, subInventoryCode) ||
+                other.subInventoryCode == subInventoryCode) &&
+            (identical(other.inboundOrderNo, inboundOrderNo) ||
+                other.inboundOrderNo == inboundOrderNo) &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    inTaskItemId,
+    inTaskId,
+    inTaskNo,
+    materialCode,
+    materialName,
+    oldMaterialCode,
+    storeRoomNo,
+    storeSiteNo,
+    quantity,
+    collectedQuantity,
+    batchNo,
+    serialNumber,
+    subInventoryCode,
+    inboundOrderNo,
+    taskComment,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InTaskItemImplCopyWith<_$InTaskItemImpl> get copyWith =>
+      __$$InTaskItemImplCopyWithImpl<_$InTaskItemImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InTaskItemImplToJson(this);
+  }
+}
+
+abstract class _InTaskItem extends InTaskItem {
+  factory _InTaskItem({
+    @JsonKey(name: 'intaskitemid')
+    @HiveField(0)
+    required final int inTaskItemId,
+    @JsonKey(name: 'intaskid') @HiveField(1) required final int inTaskId,
+    @JsonKey(name: 'intaskno') @HiveField(2) final String? inTaskNo,
+    @JsonKey(name: 'matcode') @HiveField(3) final String? materialCode,
+    @JsonKey(name: 'matname') @HiveField(4) final String? materialName,
+    @JsonKey(name: 'matinnercode') @HiveField(5) final String? oldMaterialCode,
+    @JsonKey(name: 'storeroomno') @HiveField(6) final String? storeRoomNo,
+    @JsonKey(name: 'storesiteno') @HiveField(7) final String? storeSiteNo,
+    @JsonKey(name: 'qty') @HiveField(8) required final double quantity,
+    @JsonKey(name: 'collectedqty')
+    @HiveField(9)
+    required final double collectedQuantity,
+    @JsonKey(name: 'batchno') @HiveField(10) final String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(11) final String? serialNumber,
+    @JsonKey(name: 'subinventoryCode')
+    @HiveField(12)
+    final String? subInventoryCode,
+    @JsonKey(name: 'orderno') @HiveField(13) final String? inboundOrderNo,
+    @JsonKey(name: 'taskcomment') @HiveField(14) final String? taskComment,
+  }) = _$InTaskItemImpl;
+  _InTaskItem._() : super._();
+
+  factory _InTaskItem.fromJson(Map<String, dynamic> json) =
+      _$InTaskItemImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'intaskitemid')
+  @HiveField(0)
+  int get inTaskItemId;
+  @override
+  @JsonKey(name: 'intaskid')
+  @HiveField(1)
+  int get inTaskId;
+  @override
+  @JsonKey(name: 'intaskno')
+  @HiveField(2)
+  String? get inTaskNo;
+  @override
+  @JsonKey(name: 'matcode')
+  @HiveField(3)
+  String? get materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  @HiveField(4)
+  String? get materialName;
+  @override
+  @JsonKey(name: 'matinnercode')
+  @HiveField(5)
+  String? get oldMaterialCode;
+  @override
+  @JsonKey(name: 'storeroomno')
+  @HiveField(6)
+  String? get storeRoomNo;
+  @override
+  @JsonKey(name: 'storesiteno')
+  @HiveField(7)
+  String? get storeSiteNo;
+  @override
+  @JsonKey(name: 'qty')
+  @HiveField(8)
+  double get quantity;
+  @override
+  @JsonKey(name: 'collectedqty')
+  @HiveField(9)
+  double get collectedQuantity;
+  @override
+  @JsonKey(name: 'batchno')
+  @HiveField(10)
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  @HiveField(11)
+  String? get serialNumber;
+  @override
+  @JsonKey(name: 'subinventoryCode')
+  @HiveField(12)
+  String? get subInventoryCode;
+  @override
+  @JsonKey(name: 'orderno')
+  @HiveField(13)
+  String? get inboundOrderNo;
+  @override
+  @JsonKey(name: 'taskcomment')
+  @HiveField(14)
+  String? get taskComment;
+  @override
+  @JsonKey(ignore: true)
+  _$$InTaskItemImplCopyWith<_$InTaskItemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+UpBarcodeContent _$UpBarcodeContentFromJson(Map<String, dynamic> json) {
+  return _UpBarcodeContent.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UpBarcodeContent {
+  @JsonKey(name: 'matcode')
+  @HiveField(0)
+  String? get materialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matname')
+  @HiveField(1)
+  String? get materialName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'batchno')
+  @HiveField(2)
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sn')
+  @HiveField(3)
+  String? get serialNumber => throw _privateConstructorUsedError;
+  @JsonKey(name: 'seqctrl')
+  @HiveField(4)
+  String? get seqctrl => throw _privateConstructorUsedError;
+  @JsonKey(name: 'idOld')
+  @HiveField(5)
+  String? get idOld => throw _privateConstructorUsedError;
+  @JsonKey(name: 'qty')
+  @HiveField(6)
+  double? get quantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'pdate')
+  @HiveField(7)
+  String? get productionDate => throw _privateConstructorUsedError;
+  @JsonKey(name: 'vdays')
+  @HiveField(8)
+  String? get validDays => throw _privateConstructorUsedError;
+  @JsonKey(name: 'dgFlg')
+  @HiveField(9)
+  String? get dgFlag => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $UpBarcodeContentCopyWith<UpBarcodeContent> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UpBarcodeContentCopyWith<$Res> {
+  factory $UpBarcodeContentCopyWith(
+    UpBarcodeContent value,
+    $Res Function(UpBarcodeContent) then,
+  ) = _$UpBarcodeContentCopyWithImpl<$Res, UpBarcodeContent>;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'matcode') @HiveField(0) String? materialCode,
+    @JsonKey(name: 'matname') @HiveField(1) String? materialName,
+    @JsonKey(name: 'batchno') @HiveField(2) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) String? serialNumber,
+    @JsonKey(name: 'seqctrl') @HiveField(4) String? seqctrl,
+    @JsonKey(name: 'idOld') @HiveField(5) String? idOld,
+    @JsonKey(name: 'qty') @HiveField(6) double? quantity,
+    @JsonKey(name: 'pdate') @HiveField(7) String? productionDate,
+    @JsonKey(name: 'vdays') @HiveField(8) String? validDays,
+    @JsonKey(name: 'dgFlg') @HiveField(9) String? dgFlag,
+  });
+}
+
+/// @nodoc
+class _$UpBarcodeContentCopyWithImpl<$Res, $Val extends UpBarcodeContent>
+    implements $UpBarcodeContentCopyWith<$Res> {
+  _$UpBarcodeContentCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? seqctrl = freezed,
+    Object? idOld = freezed,
+    Object? quantity = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? dgFlag = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            materialCode: freezed == materialCode
+                ? _value.materialCode
+                : materialCode // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            materialName: freezed == materialName
+                ? _value.materialName
+                : materialName // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            batchNo: freezed == batchNo
+                ? _value.batchNo
+                : batchNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            serialNumber: freezed == serialNumber
+                ? _value.serialNumber
+                : serialNumber // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            seqctrl: freezed == seqctrl
+                ? _value.seqctrl
+                : seqctrl // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            idOld: freezed == idOld
+                ? _value.idOld
+                : idOld // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            quantity: freezed == quantity
+                ? _value.quantity
+                : quantity // ignore: cast_nullable_to_non_nullable
+                      as double?,
+            productionDate: freezed == productionDate
+                ? _value.productionDate
+                : productionDate // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            validDays: freezed == validDays
+                ? _value.validDays
+                : validDays // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            dgFlag: freezed == dgFlag
+                ? _value.dgFlag
+                : dgFlag // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$UpBarcodeContentImplCopyWith<$Res>
+    implements $UpBarcodeContentCopyWith<$Res> {
+  factory _$$UpBarcodeContentImplCopyWith(
+    _$UpBarcodeContentImpl value,
+    $Res Function(_$UpBarcodeContentImpl) then,
+  ) = __$$UpBarcodeContentImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'matcode') @HiveField(0) String? materialCode,
+    @JsonKey(name: 'matname') @HiveField(1) String? materialName,
+    @JsonKey(name: 'batchno') @HiveField(2) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) String? serialNumber,
+    @JsonKey(name: 'seqctrl') @HiveField(4) String? seqctrl,
+    @JsonKey(name: 'idOld') @HiveField(5) String? idOld,
+    @JsonKey(name: 'qty') @HiveField(6) double? quantity,
+    @JsonKey(name: 'pdate') @HiveField(7) String? productionDate,
+    @JsonKey(name: 'vdays') @HiveField(8) String? validDays,
+    @JsonKey(name: 'dgFlg') @HiveField(9) String? dgFlag,
+  });
+}
+
+/// @nodoc
+class __$$UpBarcodeContentImplCopyWithImpl<$Res>
+    extends _$UpBarcodeContentCopyWithImpl<$Res, _$UpBarcodeContentImpl>
+    implements _$$UpBarcodeContentImplCopyWith<$Res> {
+  __$$UpBarcodeContentImplCopyWithImpl(
+    _$UpBarcodeContentImpl _value,
+    $Res Function(_$UpBarcodeContentImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? seqctrl = freezed,
+    Object? idOld = freezed,
+    Object? quantity = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? dgFlag = freezed,
+  }) {
+    return _then(
+      _$UpBarcodeContentImpl(
+        materialCode: freezed == materialCode
+            ? _value.materialCode
+            : materialCode // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        materialName: freezed == materialName
+            ? _value.materialName
+            : materialName // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        batchNo: freezed == batchNo
+            ? _value.batchNo
+            : batchNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        serialNumber: freezed == serialNumber
+            ? _value.serialNumber
+            : serialNumber // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        seqctrl: freezed == seqctrl
+            ? _value.seqctrl
+            : seqctrl // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        idOld: freezed == idOld
+            ? _value.idOld
+            : idOld // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        quantity: freezed == quantity
+            ? _value.quantity
+            : quantity // ignore: cast_nullable_to_non_nullable
+                  as double?,
+        productionDate: freezed == productionDate
+            ? _value.productionDate
+            : productionDate // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        validDays: freezed == validDays
+            ? _value.validDays
+            : validDays // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        dgFlag: freezed == dgFlag
+            ? _value.dgFlag
+            : dgFlag // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$UpBarcodeContentImpl extends _UpBarcodeContent {
+  _$UpBarcodeContentImpl({
+    @JsonKey(name: 'matcode') @HiveField(0) this.materialCode,
+    @JsonKey(name: 'matname') @HiveField(1) this.materialName,
+    @JsonKey(name: 'batchno') @HiveField(2) this.batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) this.serialNumber,
+    @JsonKey(name: 'seqctrl') @HiveField(4) this.seqctrl,
+    @JsonKey(name: 'idOld') @HiveField(5) this.idOld,
+    @JsonKey(name: 'qty') @HiveField(6) this.quantity,
+    @JsonKey(name: 'pdate') @HiveField(7) this.productionDate,
+    @JsonKey(name: 'vdays') @HiveField(8) this.validDays,
+    @JsonKey(name: 'dgFlg') @HiveField(9) this.dgFlag,
+  }) : super._();
+
+  factory _$UpBarcodeContentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UpBarcodeContentImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'matcode')
+  @HiveField(0)
+  final String? materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  @HiveField(1)
+  final String? materialName;
+  @override
+  @JsonKey(name: 'batchno')
+  @HiveField(2)
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  @HiveField(3)
+  final String? serialNumber;
+  @override
+  @JsonKey(name: 'seqctrl')
+  @HiveField(4)
+  final String? seqctrl;
+  @override
+  @JsonKey(name: 'idOld')
+  @HiveField(5)
+  final String? idOld;
+  @override
+  @JsonKey(name: 'qty')
+  @HiveField(6)
+  final double? quantity;
+  @override
+  @JsonKey(name: 'pdate')
+  @HiveField(7)
+  final String? productionDate;
+  @override
+  @JsonKey(name: 'vdays')
+  @HiveField(8)
+  final String? validDays;
+  @override
+  @JsonKey(name: 'dgFlg')
+  @HiveField(9)
+  final String? dgFlag;
+
+  @override
+  String toString() {
+    return 'UpBarcodeContent(materialCode: $materialCode, materialName: $materialName, batchNo: $batchNo, serialNumber: $serialNumber, seqctrl: $seqctrl, idOld: $idOld, quantity: $quantity, productionDate: $productionDate, validDays: $validDays, dgFlag: $dgFlag)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UpBarcodeContentImpl &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNumber, serialNumber) ||
+                other.serialNumber == serialNumber) &&
+            (identical(other.seqctrl, seqctrl) || other.seqctrl == seqctrl) &&
+            (identical(other.idOld, idOld) || other.idOld == idOld) &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity) &&
+            (identical(other.productionDate, productionDate) ||
+                other.productionDate == productionDate) &&
+            (identical(other.validDays, validDays) ||
+                other.validDays == validDays) &&
+            (identical(other.dgFlag, dgFlag) || other.dgFlag == dgFlag));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    materialCode,
+    materialName,
+    batchNo,
+    serialNumber,
+    seqctrl,
+    idOld,
+    quantity,
+    productionDate,
+    validDays,
+    dgFlag,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UpBarcodeContentImplCopyWith<_$UpBarcodeContentImpl> get copyWith =>
+      __$$UpBarcodeContentImplCopyWithImpl<_$UpBarcodeContentImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$UpBarcodeContentImplToJson(this);
+  }
+}
+
+abstract class _UpBarcodeContent extends UpBarcodeContent {
+  factory _UpBarcodeContent({
+    @JsonKey(name: 'matcode') @HiveField(0) final String? materialCode,
+    @JsonKey(name: 'matname') @HiveField(1) final String? materialName,
+    @JsonKey(name: 'batchno') @HiveField(2) final String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) final String? serialNumber,
+    @JsonKey(name: 'seqctrl') @HiveField(4) final String? seqctrl,
+    @JsonKey(name: 'idOld') @HiveField(5) final String? idOld,
+    @JsonKey(name: 'qty') @HiveField(6) final double? quantity,
+    @JsonKey(name: 'pdate') @HiveField(7) final String? productionDate,
+    @JsonKey(name: 'vdays') @HiveField(8) final String? validDays,
+    @JsonKey(name: 'dgFlg') @HiveField(9) final String? dgFlag,
+  }) = _$UpBarcodeContentImpl;
+  _UpBarcodeContent._() : super._();
+
+  factory _UpBarcodeContent.fromJson(Map<String, dynamic> json) =
+      _$UpBarcodeContentImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'matcode')
+  @HiveField(0)
+  String? get materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  @HiveField(1)
+  String? get materialName;
+  @override
+  @JsonKey(name: 'batchno')
+  @HiveField(2)
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  @HiveField(3)
+  String? get serialNumber;
+  @override
+  @JsonKey(name: 'seqctrl')
+  @HiveField(4)
+  String? get seqctrl;
+  @override
+  @JsonKey(name: 'idOld')
+  @HiveField(5)
+  String? get idOld;
+  @override
+  @JsonKey(name: 'qty')
+  @HiveField(6)
+  double? get quantity;
+  @override
+  @JsonKey(name: 'pdate')
+  @HiveField(7)
+  String? get productionDate;
+  @override
+  @JsonKey(name: 'vdays')
+  @HiveField(8)
+  String? get validDays;
+  @override
+  @JsonKey(name: 'dgFlg')
+  @HiveField(9)
+  String? get dgFlag;
+  @override
+  @JsonKey(ignore: true)
+  _$$UpBarcodeContentImplCopyWith<_$UpBarcodeContentImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+UpCollectionStock _$UpCollectionStockFromJson(Map<String, dynamic> json) {
+  return _UpCollectionStock.fromJson(json);
+}
+
+/// @nodoc
+mixin _$UpCollectionStock {
+  @JsonKey(name: 'stockid')
+  @HiveField(0)
+  String get stockId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matcode')
+  @HiveField(1)
+  String get materialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'batchno')
+  @HiveField(2)
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sn')
+  @HiveField(3)
+  String? get serialNumber => throw _privateConstructorUsedError;
+  @JsonKey(name: 'taskQty')
+  @HiveField(4)
+  double? get taskQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'collectQty')
+  @HiveField(5)
+  double? get collectedQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'taskNo')
+  @HiveField(6)
+  String? get taskNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'taskid')
+  @HiveField(7)
+  String? get taskId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storeRoom')
+  @HiveField(8)
+  String? get storeRoom => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storeSite')
+  @HiveField(9)
+  String? get storeSite => throw _privateConstructorUsedError;
+  @JsonKey(name: 'pdate')
+  @HiveField(10)
+  String? get productionDate => throw _privateConstructorUsedError;
+  @JsonKey(name: 'vdays')
+  @HiveField(11)
+  String? get validDays => throw _privateConstructorUsedError;
+  @JsonKey(name: 'erpStore')
+  @HiveField(12)
+  String? get erpStore => throw _privateConstructorUsedError;
+  @JsonKey(name: 'trayNo')
+  @HiveField(13)
+  String? get trayNo => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $UpCollectionStockCopyWith<UpCollectionStock> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $UpCollectionStockCopyWith<$Res> {
+  factory $UpCollectionStockCopyWith(
+    UpCollectionStock value,
+    $Res Function(UpCollectionStock) then,
+  ) = _$UpCollectionStockCopyWithImpl<$Res, UpCollectionStock>;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'stockid') @HiveField(0) String stockId,
+    @JsonKey(name: 'matcode') @HiveField(1) String materialCode,
+    @JsonKey(name: 'batchno') @HiveField(2) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) String? serialNumber,
+    @JsonKey(name: 'taskQty') @HiveField(4) double? taskQuantity,
+    @JsonKey(name: 'collectQty') @HiveField(5) double? collectedQuantity,
+    @JsonKey(name: 'taskNo') @HiveField(6) String? taskNo,
+    @JsonKey(name: 'taskid') @HiveField(7) String? taskId,
+    @JsonKey(name: 'storeRoom') @HiveField(8) String? storeRoom,
+    @JsonKey(name: 'storeSite') @HiveField(9) String? storeSite,
+    @JsonKey(name: 'pdate') @HiveField(10) String? productionDate,
+    @JsonKey(name: 'vdays') @HiveField(11) String? validDays,
+    @JsonKey(name: 'erpStore') @HiveField(12) String? erpStore,
+    @JsonKey(name: 'trayNo') @HiveField(13) String? trayNo,
+  });
+}
+
+/// @nodoc
+class _$UpCollectionStockCopyWithImpl<$Res, $Val extends UpCollectionStock>
+    implements $UpCollectionStockCopyWith<$Res> {
+  _$UpCollectionStockCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? stockId = null,
+    Object? materialCode = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? taskQuantity = freezed,
+    Object? collectedQuantity = freezed,
+    Object? taskNo = freezed,
+    Object? taskId = freezed,
+    Object? storeRoom = freezed,
+    Object? storeSite = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? erpStore = freezed,
+    Object? trayNo = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            stockId: null == stockId
+                ? _value.stockId
+                : stockId // ignore: cast_nullable_to_non_nullable
+                      as String,
+            materialCode: null == materialCode
+                ? _value.materialCode
+                : materialCode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            batchNo: freezed == batchNo
+                ? _value.batchNo
+                : batchNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            serialNumber: freezed == serialNumber
+                ? _value.serialNumber
+                : serialNumber // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            taskQuantity: freezed == taskQuantity
+                ? _value.taskQuantity
+                : taskQuantity // ignore: cast_nullable_to_non_nullable
+                      as double?,
+            collectedQuantity: freezed == collectedQuantity
+                ? _value.collectedQuantity
+                : collectedQuantity // ignore: cast_nullable_to_non_nullable
+                      as double?,
+            taskNo: freezed == taskNo
+                ? _value.taskNo
+                : taskNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            taskId: freezed == taskId
+                ? _value.taskId
+                : taskId // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            storeRoom: freezed == storeRoom
+                ? _value.storeRoom
+                : storeRoom // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            storeSite: freezed == storeSite
+                ? _value.storeSite
+                : storeSite // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            productionDate: freezed == productionDate
+                ? _value.productionDate
+                : productionDate // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            validDays: freezed == validDays
+                ? _value.validDays
+                : validDays // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            erpStore: freezed == erpStore
+                ? _value.erpStore
+                : erpStore // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            trayNo: freezed == trayNo
+                ? _value.trayNo
+                : trayNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$UpCollectionStockImplCopyWith<$Res>
+    implements $UpCollectionStockCopyWith<$Res> {
+  factory _$$UpCollectionStockImplCopyWith(
+    _$UpCollectionStockImpl value,
+    $Res Function(_$UpCollectionStockImpl) then,
+  ) = __$$UpCollectionStockImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'stockid') @HiveField(0) String stockId,
+    @JsonKey(name: 'matcode') @HiveField(1) String materialCode,
+    @JsonKey(name: 'batchno') @HiveField(2) String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) String? serialNumber,
+    @JsonKey(name: 'taskQty') @HiveField(4) double? taskQuantity,
+    @JsonKey(name: 'collectQty') @HiveField(5) double? collectedQuantity,
+    @JsonKey(name: 'taskNo') @HiveField(6) String? taskNo,
+    @JsonKey(name: 'taskid') @HiveField(7) String? taskId,
+    @JsonKey(name: 'storeRoom') @HiveField(8) String? storeRoom,
+    @JsonKey(name: 'storeSite') @HiveField(9) String? storeSite,
+    @JsonKey(name: 'pdate') @HiveField(10) String? productionDate,
+    @JsonKey(name: 'vdays') @HiveField(11) String? validDays,
+    @JsonKey(name: 'erpStore') @HiveField(12) String? erpStore,
+    @JsonKey(name: 'trayNo') @HiveField(13) String? trayNo,
+  });
+}
+
+/// @nodoc
+class __$$UpCollectionStockImplCopyWithImpl<$Res>
+    extends _$UpCollectionStockCopyWithImpl<$Res, _$UpCollectionStockImpl>
+    implements _$$UpCollectionStockImplCopyWith<$Res> {
+  __$$UpCollectionStockImplCopyWithImpl(
+    _$UpCollectionStockImpl _value,
+    $Res Function(_$UpCollectionStockImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? stockId = null,
+    Object? materialCode = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? taskQuantity = freezed,
+    Object? collectedQuantity = freezed,
+    Object? taskNo = freezed,
+    Object? taskId = freezed,
+    Object? storeRoom = freezed,
+    Object? storeSite = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? erpStore = freezed,
+    Object? trayNo = freezed,
+  }) {
+    return _then(
+      _$UpCollectionStockImpl(
+        stockId: null == stockId
+            ? _value.stockId
+            : stockId // ignore: cast_nullable_to_non_nullable
+                  as String,
+        materialCode: null == materialCode
+            ? _value.materialCode
+            : materialCode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        batchNo: freezed == batchNo
+            ? _value.batchNo
+            : batchNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        serialNumber: freezed == serialNumber
+            ? _value.serialNumber
+            : serialNumber // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        taskQuantity: freezed == taskQuantity
+            ? _value.taskQuantity
+            : taskQuantity // ignore: cast_nullable_to_non_nullable
+                  as double?,
+        collectedQuantity: freezed == collectedQuantity
+            ? _value.collectedQuantity
+            : collectedQuantity // ignore: cast_nullable_to_non_nullable
+                  as double?,
+        taskNo: freezed == taskNo
+            ? _value.taskNo
+            : taskNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        taskId: freezed == taskId
+            ? _value.taskId
+            : taskId // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        storeRoom: freezed == storeRoom
+            ? _value.storeRoom
+            : storeRoom // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        storeSite: freezed == storeSite
+            ? _value.storeSite
+            : storeSite // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        productionDate: freezed == productionDate
+            ? _value.productionDate
+            : productionDate // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        validDays: freezed == validDays
+            ? _value.validDays
+            : validDays // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        erpStore: freezed == erpStore
+            ? _value.erpStore
+            : erpStore // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        trayNo: freezed == trayNo
+            ? _value.trayNo
+            : trayNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$UpCollectionStockImpl extends _UpCollectionStock {
+  _$UpCollectionStockImpl({
+    @JsonKey(name: 'stockid') @HiveField(0) required this.stockId,
+    @JsonKey(name: 'matcode') @HiveField(1) required this.materialCode,
+    @JsonKey(name: 'batchno') @HiveField(2) this.batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) this.serialNumber,
+    @JsonKey(name: 'taskQty') @HiveField(4) this.taskQuantity,
+    @JsonKey(name: 'collectQty') @HiveField(5) this.collectedQuantity,
+    @JsonKey(name: 'taskNo') @HiveField(6) this.taskNo,
+    @JsonKey(name: 'taskid') @HiveField(7) this.taskId,
+    @JsonKey(name: 'storeRoom') @HiveField(8) this.storeRoom,
+    @JsonKey(name: 'storeSite') @HiveField(9) this.storeSite,
+    @JsonKey(name: 'pdate') @HiveField(10) this.productionDate,
+    @JsonKey(name: 'vdays') @HiveField(11) this.validDays,
+    @JsonKey(name: 'erpStore') @HiveField(12) this.erpStore,
+    @JsonKey(name: 'trayNo') @HiveField(13) this.trayNo,
+  }) : super._();
+
+  factory _$UpCollectionStockImpl.fromJson(Map<String, dynamic> json) =>
+      _$$UpCollectionStockImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'stockid')
+  @HiveField(0)
+  final String stockId;
+  @override
+  @JsonKey(name: 'matcode')
+  @HiveField(1)
+  final String materialCode;
+  @override
+  @JsonKey(name: 'batchno')
+  @HiveField(2)
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  @HiveField(3)
+  final String? serialNumber;
+  @override
+  @JsonKey(name: 'taskQty')
+  @HiveField(4)
+  final double? taskQuantity;
+  @override
+  @JsonKey(name: 'collectQty')
+  @HiveField(5)
+  final double? collectedQuantity;
+  @override
+  @JsonKey(name: 'taskNo')
+  @HiveField(6)
+  final String? taskNo;
+  @override
+  @JsonKey(name: 'taskid')
+  @HiveField(7)
+  final String? taskId;
+  @override
+  @JsonKey(name: 'storeRoom')
+  @HiveField(8)
+  final String? storeRoom;
+  @override
+  @JsonKey(name: 'storeSite')
+  @HiveField(9)
+  final String? storeSite;
+  @override
+  @JsonKey(name: 'pdate')
+  @HiveField(10)
+  final String? productionDate;
+  @override
+  @JsonKey(name: 'vdays')
+  @HiveField(11)
+  final String? validDays;
+  @override
+  @JsonKey(name: 'erpStore')
+  @HiveField(12)
+  final String? erpStore;
+  @override
+  @JsonKey(name: 'trayNo')
+  @HiveField(13)
+  final String? trayNo;
+
+  @override
+  String toString() {
+    return 'UpCollectionStock(stockId: $stockId, materialCode: $materialCode, batchNo: $batchNo, serialNumber: $serialNumber, taskQuantity: $taskQuantity, collectedQuantity: $collectedQuantity, taskNo: $taskNo, taskId: $taskId, storeRoom: $storeRoom, storeSite: $storeSite, productionDate: $productionDate, validDays: $validDays, erpStore: $erpStore, trayNo: $trayNo)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$UpCollectionStockImpl &&
+            (identical(other.stockId, stockId) || other.stockId == stockId) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNumber, serialNumber) ||
+                other.serialNumber == serialNumber) &&
+            (identical(other.taskQuantity, taskQuantity) ||
+                other.taskQuantity == taskQuantity) &&
+            (identical(other.collectedQuantity, collectedQuantity) ||
+                other.collectedQuantity == collectedQuantity) &&
+            (identical(other.taskNo, taskNo) || other.taskNo == taskNo) &&
+            (identical(other.taskId, taskId) || other.taskId == taskId) &&
+            (identical(other.storeRoom, storeRoom) ||
+                other.storeRoom == storeRoom) &&
+            (identical(other.storeSite, storeSite) ||
+                other.storeSite == storeSite) &&
+            (identical(other.productionDate, productionDate) ||
+                other.productionDate == productionDate) &&
+            (identical(other.validDays, validDays) ||
+                other.validDays == validDays) &&
+            (identical(other.erpStore, erpStore) ||
+                other.erpStore == erpStore) &&
+            (identical(other.trayNo, trayNo) || other.trayNo == trayNo));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    stockId,
+    materialCode,
+    batchNo,
+    serialNumber,
+    taskQuantity,
+    collectedQuantity,
+    taskNo,
+    taskId,
+    storeRoom,
+    storeSite,
+    productionDate,
+    validDays,
+    erpStore,
+    trayNo,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$UpCollectionStockImplCopyWith<_$UpCollectionStockImpl> get copyWith =>
+      __$$UpCollectionStockImplCopyWithImpl<_$UpCollectionStockImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$UpCollectionStockImplToJson(this);
+  }
+}
+
+abstract class _UpCollectionStock extends UpCollectionStock {
+  factory _UpCollectionStock({
+    @JsonKey(name: 'stockid') @HiveField(0) required final String stockId,
+    @JsonKey(name: 'matcode') @HiveField(1) required final String materialCode,
+    @JsonKey(name: 'batchno') @HiveField(2) final String? batchNo,
+    @JsonKey(name: 'sn') @HiveField(3) final String? serialNumber,
+    @JsonKey(name: 'taskQty') @HiveField(4) final double? taskQuantity,
+    @JsonKey(name: 'collectQty') @HiveField(5) final double? collectedQuantity,
+    @JsonKey(name: 'taskNo') @HiveField(6) final String? taskNo,
+    @JsonKey(name: 'taskid') @HiveField(7) final String? taskId,
+    @JsonKey(name: 'storeRoom') @HiveField(8) final String? storeRoom,
+    @JsonKey(name: 'storeSite') @HiveField(9) final String? storeSite,
+    @JsonKey(name: 'pdate') @HiveField(10) final String? productionDate,
+    @JsonKey(name: 'vdays') @HiveField(11) final String? validDays,
+    @JsonKey(name: 'erpStore') @HiveField(12) final String? erpStore,
+    @JsonKey(name: 'trayNo') @HiveField(13) final String? trayNo,
+  }) = _$UpCollectionStockImpl;
+  _UpCollectionStock._() : super._();
+
+  factory _UpCollectionStock.fromJson(Map<String, dynamic> json) =
+      _$UpCollectionStockImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'stockid')
+  @HiveField(0)
+  String get stockId;
+  @override
+  @JsonKey(name: 'matcode')
+  @HiveField(1)
+  String get materialCode;
+  @override
+  @JsonKey(name: 'batchno')
+  @HiveField(2)
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  @HiveField(3)
+  String? get serialNumber;
+  @override
+  @JsonKey(name: 'taskQty')
+  @HiveField(4)
+  double? get taskQuantity;
+  @override
+  @JsonKey(name: 'collectQty')
+  @HiveField(5)
+  double? get collectedQuantity;
+  @override
+  @JsonKey(name: 'taskNo')
+  @HiveField(6)
+  String? get taskNo;
+  @override
+  @JsonKey(name: 'taskid')
+  @HiveField(7)
+  String? get taskId;
+  @override
+  @JsonKey(name: 'storeRoom')
+  @HiveField(8)
+  String? get storeRoom;
+  @override
+  @JsonKey(name: 'storeSite')
+  @HiveField(9)
+  String? get storeSite;
+  @override
+  @JsonKey(name: 'pdate')
+  @HiveField(10)
+  String? get productionDate;
+  @override
+  @JsonKey(name: 'vdays')
+  @HiveField(11)
+  String? get validDays;
+  @override
+  @JsonKey(name: 'erpStore')
+  @HiveField(12)
+  String? get erpStore;
+  @override
+  @JsonKey(name: 'trayNo')
+  @HiveField(13)
+  String? get trayNo;
+  @override
+  @JsonKey(ignore: true)
+  _$$UpCollectionStockImplCopyWith<_$UpCollectionStockImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/inbound/goods_up_task/models/goods_up_models.g.dart
+++ b/lib/modules/inbound/goods_up_task/models/goods_up_models.g.dart
@@ -1,0 +1,327 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'goods_up_models.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class InTaskItemAdapter extends TypeAdapter<InTaskItem> {
+  @override
+  final int typeId = 3;
+
+  @override
+  InTaskItem read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return InTaskItem(
+      inTaskItemId: fields[0] as int,
+      inTaskId: fields[1] as int,
+      inTaskNo: fields[2] as String?,
+      materialCode: fields[3] as String?,
+      materialName: fields[4] as String?,
+      oldMaterialCode: fields[5] as String?,
+      storeRoomNo: fields[6] as String?,
+      storeSiteNo: fields[7] as String?,
+      quantity: fields[8] as double,
+      collectedQuantity: fields[9] as double,
+      batchNo: fields[10] as String?,
+      serialNumber: fields[11] as String?,
+      subInventoryCode: fields[12] as String?,
+      inboundOrderNo: fields[13] as String?,
+      taskComment: fields[14] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, InTaskItem obj) {
+    writer
+      ..writeByte(15)
+      ..writeByte(0)
+      ..write(obj.inTaskItemId)
+      ..writeByte(1)
+      ..write(obj.inTaskId)
+      ..writeByte(2)
+      ..write(obj.inTaskNo)
+      ..writeByte(3)
+      ..write(obj.materialCode)
+      ..writeByte(4)
+      ..write(obj.materialName)
+      ..writeByte(5)
+      ..write(obj.oldMaterialCode)
+      ..writeByte(6)
+      ..write(obj.storeRoomNo)
+      ..writeByte(7)
+      ..write(obj.storeSiteNo)
+      ..writeByte(8)
+      ..write(obj.quantity)
+      ..writeByte(9)
+      ..write(obj.collectedQuantity)
+      ..writeByte(10)
+      ..write(obj.batchNo)
+      ..writeByte(11)
+      ..write(obj.serialNumber)
+      ..writeByte(12)
+      ..write(obj.subInventoryCode)
+      ..writeByte(13)
+      ..write(obj.inboundOrderNo)
+      ..writeByte(14)
+      ..write(obj.taskComment);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InTaskItemAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class UpBarcodeContentAdapter extends TypeAdapter<UpBarcodeContent> {
+  @override
+  final int typeId = 4;
+
+  @override
+  UpBarcodeContent read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return UpBarcodeContent(
+      materialCode: fields[0] as String?,
+      materialName: fields[1] as String?,
+      batchNo: fields[2] as String?,
+      serialNumber: fields[3] as String?,
+      seqctrl: fields[4] as String?,
+      idOld: fields[5] as String?,
+      quantity: fields[6] as double?,
+      productionDate: fields[7] as String?,
+      validDays: fields[8] as String?,
+      dgFlag: fields[9] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, UpBarcodeContent obj) {
+    writer
+      ..writeByte(10)
+      ..writeByte(0)
+      ..write(obj.materialCode)
+      ..writeByte(1)
+      ..write(obj.materialName)
+      ..writeByte(2)
+      ..write(obj.batchNo)
+      ..writeByte(3)
+      ..write(obj.serialNumber)
+      ..writeByte(4)
+      ..write(obj.seqctrl)
+      ..writeByte(5)
+      ..write(obj.idOld)
+      ..writeByte(6)
+      ..write(obj.quantity)
+      ..writeByte(7)
+      ..write(obj.productionDate)
+      ..writeByte(8)
+      ..write(obj.validDays)
+      ..writeByte(9)
+      ..write(obj.dgFlag);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UpBarcodeContentAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class UpCollectionStockAdapter extends TypeAdapter<UpCollectionStock> {
+  @override
+  final int typeId = 5;
+
+  @override
+  UpCollectionStock read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return UpCollectionStock(
+      stockId: fields[0] as String,
+      materialCode: fields[1] as String,
+      batchNo: fields[2] as String?,
+      serialNumber: fields[3] as String?,
+      taskQuantity: fields[4] as double?,
+      collectedQuantity: fields[5] as double?,
+      taskNo: fields[6] as String?,
+      taskId: fields[7] as String?,
+      storeRoom: fields[8] as String?,
+      storeSite: fields[9] as String?,
+      productionDate: fields[10] as String?,
+      validDays: fields[11] as String?,
+      erpStore: fields[12] as String?,
+      trayNo: fields[13] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, UpCollectionStock obj) {
+    writer
+      ..writeByte(14)
+      ..writeByte(0)
+      ..write(obj.stockId)
+      ..writeByte(1)
+      ..write(obj.materialCode)
+      ..writeByte(2)
+      ..write(obj.batchNo)
+      ..writeByte(3)
+      ..write(obj.serialNumber)
+      ..writeByte(4)
+      ..write(obj.taskQuantity)
+      ..writeByte(5)
+      ..write(obj.collectedQuantity)
+      ..writeByte(6)
+      ..write(obj.taskNo)
+      ..writeByte(7)
+      ..write(obj.taskId)
+      ..writeByte(8)
+      ..write(obj.storeRoom)
+      ..writeByte(9)
+      ..write(obj.storeSite)
+      ..writeByte(10)
+      ..write(obj.productionDate)
+      ..writeByte(11)
+      ..write(obj.validDays)
+      ..writeByte(12)
+      ..write(obj.erpStore)
+      ..writeByte(13)
+      ..write(obj.trayNo);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UpCollectionStockAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InTaskItemImpl _$$InTaskItemImplFromJson(Map<String, dynamic> json) =>
+    _$InTaskItemImpl(
+      inTaskItemId: (json['intaskitemid'] as num).toInt(),
+      inTaskId: (json['intaskid'] as num).toInt(),
+      inTaskNo: json['intaskno'] as String?,
+      materialCode: json['matcode'] as String?,
+      materialName: json['matname'] as String?,
+      oldMaterialCode: json['matinnercode'] as String?,
+      storeRoomNo: json['storeroomno'] as String?,
+      storeSiteNo: json['storesiteno'] as String?,
+      quantity: (json['qty'] as num).toDouble(),
+      collectedQuantity: (json['collectedqty'] as num).toDouble(),
+      batchNo: json['batchno'] as String?,
+      serialNumber: json['sn'] as String?,
+      subInventoryCode: json['subinventoryCode'] as String?,
+      inboundOrderNo: json['orderno'] as String?,
+      taskComment: json['taskcomment'] as String?,
+    );
+
+Map<String, dynamic> _$$InTaskItemImplToJson(_$InTaskItemImpl instance) =>
+    <String, dynamic>{
+      'intaskitemid': instance.inTaskItemId,
+      'intaskid': instance.inTaskId,
+      'intaskno': instance.inTaskNo,
+      'matcode': instance.materialCode,
+      'matname': instance.materialName,
+      'matinnercode': instance.oldMaterialCode,
+      'storeroomno': instance.storeRoomNo,
+      'storesiteno': instance.storeSiteNo,
+      'qty': instance.quantity,
+      'collectedqty': instance.collectedQuantity,
+      'batchno': instance.batchNo,
+      'sn': instance.serialNumber,
+      'subinventoryCode': instance.subInventoryCode,
+      'orderno': instance.inboundOrderNo,
+      'taskcomment': instance.taskComment,
+    };
+
+_$UpBarcodeContentImpl _$$UpBarcodeContentImplFromJson(
+  Map<String, dynamic> json,
+) => _$UpBarcodeContentImpl(
+  materialCode: json['matcode'] as String?,
+  materialName: json['matname'] as String?,
+  batchNo: json['batchno'] as String?,
+  serialNumber: json['sn'] as String?,
+  seqctrl: json['seqctrl'] as String?,
+  idOld: json['idOld'] as String?,
+  quantity: (json['qty'] as num?)?.toDouble(),
+  productionDate: json['pdate'] as String?,
+  validDays: json['vdays'] as String?,
+  dgFlag: json['dgFlg'] as String?,
+);
+
+Map<String, dynamic> _$$UpBarcodeContentImplToJson(
+  _$UpBarcodeContentImpl instance,
+) => <String, dynamic>{
+  'matcode': instance.materialCode,
+  'matname': instance.materialName,
+  'batchno': instance.batchNo,
+  'sn': instance.serialNumber,
+  'seqctrl': instance.seqctrl,
+  'idOld': instance.idOld,
+  'qty': instance.quantity,
+  'pdate': instance.productionDate,
+  'vdays': instance.validDays,
+  'dgFlg': instance.dgFlag,
+};
+
+_$UpCollectionStockImpl _$$UpCollectionStockImplFromJson(
+  Map<String, dynamic> json,
+) => _$UpCollectionStockImpl(
+  stockId: json['stockid'] as String,
+  materialCode: json['matcode'] as String,
+  batchNo: json['batchno'] as String?,
+  serialNumber: json['sn'] as String?,
+  taskQuantity: (json['taskQty'] as num?)?.toDouble(),
+  collectedQuantity: (json['collectQty'] as num?)?.toDouble(),
+  taskNo: json['taskNo'] as String?,
+  taskId: json['taskid'] as String?,
+  storeRoom: json['storeRoom'] as String?,
+  storeSite: json['storeSite'] as String?,
+  productionDate: json['pdate'] as String?,
+  validDays: json['vdays'] as String?,
+  erpStore: json['erpStore'] as String?,
+  trayNo: json['trayNo'] as String?,
+);
+
+Map<String, dynamic> _$$UpCollectionStockImplToJson(
+  _$UpCollectionStockImpl instance,
+) => <String, dynamic>{
+  'stockid': instance.stockId,
+  'matcode': instance.materialCode,
+  'batchno': instance.batchNo,
+  'sn': instance.serialNumber,
+  'taskQty': instance.taskQuantity,
+  'collectQty': instance.collectedQuantity,
+  'taskNo': instance.taskNo,
+  'taskid': instance.taskId,
+  'storeRoom': instance.storeRoom,
+  'storeSite': instance.storeSite,
+  'pdate': instance.productionDate,
+  'vdays': instance.validDays,
+  'erpStore': instance.erpStore,
+  'trayNo': instance.trayNo,
+};

--- a/lib/modules/inbound/goods_up_task/models/goods_up_request.dart
+++ b/lib/modules/inbound/goods_up_task/models/goods_up_request.dart
@@ -1,0 +1,55 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'goods_up_request.freezed.dart';
+part 'goods_up_request.g.dart';
+
+/// 入库上架任务明细查询入参
+@freezed
+class GoodsUpTaskItemQueryRequest with _$GoodsUpTaskItemQueryRequest {
+  const factory GoodsUpTaskItemQueryRequest({
+    /// 入库任务号
+    @JsonKey(name: 'intaskno') @Default('') String inTaskNo,
+
+    /// 库房编号
+    @JsonKey(name: 'storeroomno') @Default('') String storeRoomNo,
+
+    /// 强制库位标志
+    @JsonKey(name: 'forcesite') @Default('') String forceSite,
+
+    /// 强制批次标志
+    @JsonKey(name: 'forcebatch') @Default('') String forceBatch,
+
+    /// 任务备注
+    @JsonKey(name: 'taskcomment') @Default('') String taskComment,
+
+    /// 完成标志
+    @JsonKey(name: 'taskFinishFlag') @Default('0') String taskFinishFlag,
+
+    /// 库房标签
+    @JsonKey(name: 'roomtag') @Default('0') String roomTag,
+
+    /// 工作站
+    @JsonKey(name: 'workstation') @Default('') String workStation,
+
+    /// 完成标志（兼容字段）
+    @JsonKey(name: 'finshFlg') @Default('0') String finishFlag,
+
+    /// 排序类型
+    @JsonKey(name: 'sortType') @Default('') String sortType,
+
+    /// 排序字段
+    @JsonKey(name: 'sortColumn') @Default('') String sortColumn,
+
+    /// 搜索关键字
+    @JsonKey(name: 'searchKey') @Default('') String searchKey,
+
+    /// 节拍标志
+    @JsonKey(name: 'beatflag') @Default('N') String beatFlag,
+
+    /// 采集人
+    @JsonKey(name: 'collecter') @Default(0) int collecter,
+  }) = _GoodsUpTaskItemQueryRequest;
+
+  factory GoodsUpTaskItemQueryRequest.fromJson(Map<String, dynamic> json) =>
+      _$GoodsUpTaskItemQueryRequestFromJson(json);
+}

--- a/lib/modules/inbound/goods_up_task/models/goods_up_request.freezed.dart
+++ b/lib/modules/inbound/goods_up_task/models/goods_up_request.freezed.dart
@@ -1,0 +1,584 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'goods_up_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+GoodsUpTaskItemQueryRequest _$GoodsUpTaskItemQueryRequestFromJson(
+  Map<String, dynamic> json,
+) {
+  return _GoodsUpTaskItemQueryRequest.fromJson(json);
+}
+
+/// @nodoc
+mixin _$GoodsUpTaskItemQueryRequest {
+  /// 入库任务号
+  @JsonKey(name: 'intaskno')
+  String get inTaskNo => throw _privateConstructorUsedError;
+
+  /// 库房编号
+  @JsonKey(name: 'storeroomno')
+  String get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 强制库位标志
+  @JsonKey(name: 'forcesite')
+  String get forceSite => throw _privateConstructorUsedError;
+
+  /// 强制批次标志
+  @JsonKey(name: 'forcebatch')
+  String get forceBatch => throw _privateConstructorUsedError;
+
+  /// 任务备注
+  @JsonKey(name: 'taskcomment')
+  String get taskComment => throw _privateConstructorUsedError;
+
+  /// 完成标志
+  @JsonKey(name: 'taskFinishFlag')
+  String get taskFinishFlag => throw _privateConstructorUsedError;
+
+  /// 库房标签
+  @JsonKey(name: 'roomtag')
+  String get roomTag => throw _privateConstructorUsedError;
+
+  /// 工作站
+  @JsonKey(name: 'workstation')
+  String get workStation => throw _privateConstructorUsedError;
+
+  /// 完成标志（兼容字段）
+  @JsonKey(name: 'finshFlg')
+  String get finishFlag => throw _privateConstructorUsedError;
+
+  /// 排序类型
+  @JsonKey(name: 'sortType')
+  String get sortType => throw _privateConstructorUsedError;
+
+  /// 排序字段
+  @JsonKey(name: 'sortColumn')
+  String get sortColumn => throw _privateConstructorUsedError;
+
+  /// 搜索关键字
+  @JsonKey(name: 'searchKey')
+  String get searchKey => throw _privateConstructorUsedError;
+
+  /// 节拍标志
+  @JsonKey(name: 'beatflag')
+  String get beatFlag => throw _privateConstructorUsedError;
+
+  /// 采集人
+  @JsonKey(name: 'collecter')
+  int get collecter => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $GoodsUpTaskItemQueryRequestCopyWith<GoodsUpTaskItemQueryRequest>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GoodsUpTaskItemQueryRequestCopyWith<$Res> {
+  factory $GoodsUpTaskItemQueryRequestCopyWith(
+    GoodsUpTaskItemQueryRequest value,
+    $Res Function(GoodsUpTaskItemQueryRequest) then,
+  ) =
+      _$GoodsUpTaskItemQueryRequestCopyWithImpl<
+        $Res,
+        GoodsUpTaskItemQueryRequest
+      >;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'intaskno') String inTaskNo,
+    @JsonKey(name: 'storeroomno') String storeRoomNo,
+    @JsonKey(name: 'forcesite') String forceSite,
+    @JsonKey(name: 'forcebatch') String forceBatch,
+    @JsonKey(name: 'taskcomment') String taskComment,
+    @JsonKey(name: 'taskFinishFlag') String taskFinishFlag,
+    @JsonKey(name: 'roomtag') String roomTag,
+    @JsonKey(name: 'workstation') String workStation,
+    @JsonKey(name: 'finshFlg') String finishFlag,
+    @JsonKey(name: 'sortType') String sortType,
+    @JsonKey(name: 'sortColumn') String sortColumn,
+    @JsonKey(name: 'searchKey') String searchKey,
+    @JsonKey(name: 'beatflag') String beatFlag,
+    @JsonKey(name: 'collecter') int collecter,
+  });
+}
+
+/// @nodoc
+class _$GoodsUpTaskItemQueryRequestCopyWithImpl<
+  $Res,
+  $Val extends GoodsUpTaskItemQueryRequest
+>
+    implements $GoodsUpTaskItemQueryRequestCopyWith<$Res> {
+  _$GoodsUpTaskItemQueryRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? inTaskNo = null,
+    Object? storeRoomNo = null,
+    Object? forceSite = null,
+    Object? forceBatch = null,
+    Object? taskComment = null,
+    Object? taskFinishFlag = null,
+    Object? roomTag = null,
+    Object? workStation = null,
+    Object? finishFlag = null,
+    Object? sortType = null,
+    Object? sortColumn = null,
+    Object? searchKey = null,
+    Object? beatFlag = null,
+    Object? collecter = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            inTaskNo: null == inTaskNo
+                ? _value.inTaskNo
+                : inTaskNo // ignore: cast_nullable_to_non_nullable
+                      as String,
+            storeRoomNo: null == storeRoomNo
+                ? _value.storeRoomNo
+                : storeRoomNo // ignore: cast_nullable_to_non_nullable
+                      as String,
+            forceSite: null == forceSite
+                ? _value.forceSite
+                : forceSite // ignore: cast_nullable_to_non_nullable
+                      as String,
+            forceBatch: null == forceBatch
+                ? _value.forceBatch
+                : forceBatch // ignore: cast_nullable_to_non_nullable
+                      as String,
+            taskComment: null == taskComment
+                ? _value.taskComment
+                : taskComment // ignore: cast_nullable_to_non_nullable
+                      as String,
+            taskFinishFlag: null == taskFinishFlag
+                ? _value.taskFinishFlag
+                : taskFinishFlag // ignore: cast_nullable_to_non_nullable
+                      as String,
+            roomTag: null == roomTag
+                ? _value.roomTag
+                : roomTag // ignore: cast_nullable_to_non_nullable
+                      as String,
+            workStation: null == workStation
+                ? _value.workStation
+                : workStation // ignore: cast_nullable_to_non_nullable
+                      as String,
+            finishFlag: null == finishFlag
+                ? _value.finishFlag
+                : finishFlag // ignore: cast_nullable_to_non_nullable
+                      as String,
+            sortType: null == sortType
+                ? _value.sortType
+                : sortType // ignore: cast_nullable_to_non_nullable
+                      as String,
+            sortColumn: null == sortColumn
+                ? _value.sortColumn
+                : sortColumn // ignore: cast_nullable_to_non_nullable
+                      as String,
+            searchKey: null == searchKey
+                ? _value.searchKey
+                : searchKey // ignore: cast_nullable_to_non_nullable
+                      as String,
+            beatFlag: null == beatFlag
+                ? _value.beatFlag
+                : beatFlag // ignore: cast_nullable_to_non_nullable
+                      as String,
+            collecter: null == collecter
+                ? _value.collecter
+                : collecter // ignore: cast_nullable_to_non_nullable
+                      as int,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$GoodsUpTaskItemQueryRequestImplCopyWith<$Res>
+    implements $GoodsUpTaskItemQueryRequestCopyWith<$Res> {
+  factory _$$GoodsUpTaskItemQueryRequestImplCopyWith(
+    _$GoodsUpTaskItemQueryRequestImpl value,
+    $Res Function(_$GoodsUpTaskItemQueryRequestImpl) then,
+  ) = __$$GoodsUpTaskItemQueryRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'intaskno') String inTaskNo,
+    @JsonKey(name: 'storeroomno') String storeRoomNo,
+    @JsonKey(name: 'forcesite') String forceSite,
+    @JsonKey(name: 'forcebatch') String forceBatch,
+    @JsonKey(name: 'taskcomment') String taskComment,
+    @JsonKey(name: 'taskFinishFlag') String taskFinishFlag,
+    @JsonKey(name: 'roomtag') String roomTag,
+    @JsonKey(name: 'workstation') String workStation,
+    @JsonKey(name: 'finshFlg') String finishFlag,
+    @JsonKey(name: 'sortType') String sortType,
+    @JsonKey(name: 'sortColumn') String sortColumn,
+    @JsonKey(name: 'searchKey') String searchKey,
+    @JsonKey(name: 'beatflag') String beatFlag,
+    @JsonKey(name: 'collecter') int collecter,
+  });
+}
+
+/// @nodoc
+class __$$GoodsUpTaskItemQueryRequestImplCopyWithImpl<$Res>
+    extends
+        _$GoodsUpTaskItemQueryRequestCopyWithImpl<
+          $Res,
+          _$GoodsUpTaskItemQueryRequestImpl
+        >
+    implements _$$GoodsUpTaskItemQueryRequestImplCopyWith<$Res> {
+  __$$GoodsUpTaskItemQueryRequestImplCopyWithImpl(
+    _$GoodsUpTaskItemQueryRequestImpl _value,
+    $Res Function(_$GoodsUpTaskItemQueryRequestImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? inTaskNo = null,
+    Object? storeRoomNo = null,
+    Object? forceSite = null,
+    Object? forceBatch = null,
+    Object? taskComment = null,
+    Object? taskFinishFlag = null,
+    Object? roomTag = null,
+    Object? workStation = null,
+    Object? finishFlag = null,
+    Object? sortType = null,
+    Object? sortColumn = null,
+    Object? searchKey = null,
+    Object? beatFlag = null,
+    Object? collecter = null,
+  }) {
+    return _then(
+      _$GoodsUpTaskItemQueryRequestImpl(
+        inTaskNo: null == inTaskNo
+            ? _value.inTaskNo
+            : inTaskNo // ignore: cast_nullable_to_non_nullable
+                  as String,
+        storeRoomNo: null == storeRoomNo
+            ? _value.storeRoomNo
+            : storeRoomNo // ignore: cast_nullable_to_non_nullable
+                  as String,
+        forceSite: null == forceSite
+            ? _value.forceSite
+            : forceSite // ignore: cast_nullable_to_non_nullable
+                  as String,
+        forceBatch: null == forceBatch
+            ? _value.forceBatch
+            : forceBatch // ignore: cast_nullable_to_non_nullable
+                  as String,
+        taskComment: null == taskComment
+            ? _value.taskComment
+            : taskComment // ignore: cast_nullable_to_non_nullable
+                  as String,
+        taskFinishFlag: null == taskFinishFlag
+            ? _value.taskFinishFlag
+            : taskFinishFlag // ignore: cast_nullable_to_non_nullable
+                  as String,
+        roomTag: null == roomTag
+            ? _value.roomTag
+            : roomTag // ignore: cast_nullable_to_non_nullable
+                  as String,
+        workStation: null == workStation
+            ? _value.workStation
+            : workStation // ignore: cast_nullable_to_non_nullable
+                  as String,
+        finishFlag: null == finishFlag
+            ? _value.finishFlag
+            : finishFlag // ignore: cast_nullable_to_non_nullable
+                  as String,
+        sortType: null == sortType
+            ? _value.sortType
+            : sortType // ignore: cast_nullable_to_non_nullable
+                  as String,
+        sortColumn: null == sortColumn
+            ? _value.sortColumn
+            : sortColumn // ignore: cast_nullable_to_non_nullable
+                  as String,
+        searchKey: null == searchKey
+            ? _value.searchKey
+            : searchKey // ignore: cast_nullable_to_non_nullable
+                  as String,
+        beatFlag: null == beatFlag
+            ? _value.beatFlag
+            : beatFlag // ignore: cast_nullable_to_non_nullable
+                  as String,
+        collecter: null == collecter
+            ? _value.collecter
+            : collecter // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GoodsUpTaskItemQueryRequestImpl
+    implements _GoodsUpTaskItemQueryRequest {
+  const _$GoodsUpTaskItemQueryRequestImpl({
+    @JsonKey(name: 'intaskno') this.inTaskNo = '',
+    @JsonKey(name: 'storeroomno') this.storeRoomNo = '',
+    @JsonKey(name: 'forcesite') this.forceSite = '',
+    @JsonKey(name: 'forcebatch') this.forceBatch = '',
+    @JsonKey(name: 'taskcomment') this.taskComment = '',
+    @JsonKey(name: 'taskFinishFlag') this.taskFinishFlag = '0',
+    @JsonKey(name: 'roomtag') this.roomTag = '0',
+    @JsonKey(name: 'workstation') this.workStation = '',
+    @JsonKey(name: 'finshFlg') this.finishFlag = '0',
+    @JsonKey(name: 'sortType') this.sortType = '',
+    @JsonKey(name: 'sortColumn') this.sortColumn = '',
+    @JsonKey(name: 'searchKey') this.searchKey = '',
+    @JsonKey(name: 'beatflag') this.beatFlag = 'N',
+    @JsonKey(name: 'collecter') this.collecter = 0,
+  });
+
+  factory _$GoodsUpTaskItemQueryRequestImpl.fromJson(
+    Map<String, dynamic> json,
+  ) => _$$GoodsUpTaskItemQueryRequestImplFromJson(json);
+
+  /// 入库任务号
+  @override
+  @JsonKey(name: 'intaskno')
+  final String inTaskNo;
+
+  /// 库房编号
+  @override
+  @JsonKey(name: 'storeroomno')
+  final String storeRoomNo;
+
+  /// 强制库位标志
+  @override
+  @JsonKey(name: 'forcesite')
+  final String forceSite;
+
+  /// 强制批次标志
+  @override
+  @JsonKey(name: 'forcebatch')
+  final String forceBatch;
+
+  /// 任务备注
+  @override
+  @JsonKey(name: 'taskcomment')
+  final String taskComment;
+
+  /// 完成标志
+  @override
+  @JsonKey(name: 'taskFinishFlag')
+  final String taskFinishFlag;
+
+  /// 库房标签
+  @override
+  @JsonKey(name: 'roomtag')
+  final String roomTag;
+
+  /// 工作站
+  @override
+  @JsonKey(name: 'workstation')
+  final String workStation;
+
+  /// 完成标志（兼容字段）
+  @override
+  @JsonKey(name: 'finshFlg')
+  final String finishFlag;
+
+  /// 排序类型
+  @override
+  @JsonKey(name: 'sortType')
+  final String sortType;
+
+  /// 排序字段
+  @override
+  @JsonKey(name: 'sortColumn')
+  final String sortColumn;
+
+  /// 搜索关键字
+  @override
+  @JsonKey(name: 'searchKey')
+  final String searchKey;
+
+  /// 节拍标志
+  @override
+  @JsonKey(name: 'beatflag')
+  final String beatFlag;
+
+  /// 采集人
+  @override
+  @JsonKey(name: 'collecter')
+  final int collecter;
+
+  @override
+  String toString() {
+    return 'GoodsUpTaskItemQueryRequest(inTaskNo: $inTaskNo, storeRoomNo: $storeRoomNo, forceSite: $forceSite, forceBatch: $forceBatch, taskComment: $taskComment, taskFinishFlag: $taskFinishFlag, roomTag: $roomTag, workStation: $workStation, finishFlag: $finishFlag, sortType: $sortType, sortColumn: $sortColumn, searchKey: $searchKey, beatFlag: $beatFlag, collecter: $collecter)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GoodsUpTaskItemQueryRequestImpl &&
+            (identical(other.inTaskNo, inTaskNo) ||
+                other.inTaskNo == inTaskNo) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.forceSite, forceSite) ||
+                other.forceSite == forceSite) &&
+            (identical(other.forceBatch, forceBatch) ||
+                other.forceBatch == forceBatch) &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment) &&
+            (identical(other.taskFinishFlag, taskFinishFlag) ||
+                other.taskFinishFlag == taskFinishFlag) &&
+            (identical(other.roomTag, roomTag) || other.roomTag == roomTag) &&
+            (identical(other.workStation, workStation) ||
+                other.workStation == workStation) &&
+            (identical(other.finishFlag, finishFlag) ||
+                other.finishFlag == finishFlag) &&
+            (identical(other.sortType, sortType) ||
+                other.sortType == sortType) &&
+            (identical(other.sortColumn, sortColumn) ||
+                other.sortColumn == sortColumn) &&
+            (identical(other.searchKey, searchKey) ||
+                other.searchKey == searchKey) &&
+            (identical(other.beatFlag, beatFlag) ||
+                other.beatFlag == beatFlag) &&
+            (identical(other.collecter, collecter) ||
+                other.collecter == collecter));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    inTaskNo,
+    storeRoomNo,
+    forceSite,
+    forceBatch,
+    taskComment,
+    taskFinishFlag,
+    roomTag,
+    workStation,
+    finishFlag,
+    sortType,
+    sortColumn,
+    searchKey,
+    beatFlag,
+    collecter,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$GoodsUpTaskItemQueryRequestImplCopyWith<_$GoodsUpTaskItemQueryRequestImpl>
+  get copyWith =>
+      __$$GoodsUpTaskItemQueryRequestImplCopyWithImpl<
+        _$GoodsUpTaskItemQueryRequestImpl
+      >(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GoodsUpTaskItemQueryRequestImplToJson(this);
+  }
+}
+
+abstract class _GoodsUpTaskItemQueryRequest
+    implements GoodsUpTaskItemQueryRequest {
+  const factory _GoodsUpTaskItemQueryRequest({
+    @JsonKey(name: 'intaskno') final String inTaskNo,
+    @JsonKey(name: 'storeroomno') final String storeRoomNo,
+    @JsonKey(name: 'forcesite') final String forceSite,
+    @JsonKey(name: 'forcebatch') final String forceBatch,
+    @JsonKey(name: 'taskcomment') final String taskComment,
+    @JsonKey(name: 'taskFinishFlag') final String taskFinishFlag,
+    @JsonKey(name: 'roomtag') final String roomTag,
+    @JsonKey(name: 'workstation') final String workStation,
+    @JsonKey(name: 'finshFlg') final String finishFlag,
+    @JsonKey(name: 'sortType') final String sortType,
+    @JsonKey(name: 'sortColumn') final String sortColumn,
+    @JsonKey(name: 'searchKey') final String searchKey,
+    @JsonKey(name: 'beatflag') final String beatFlag,
+    @JsonKey(name: 'collecter') final int collecter,
+  }) = _$GoodsUpTaskItemQueryRequestImpl;
+
+  factory _GoodsUpTaskItemQueryRequest.fromJson(Map<String, dynamic> json) =
+      _$GoodsUpTaskItemQueryRequestImpl.fromJson;
+
+  @override
+  /// 入库任务号
+  @JsonKey(name: 'intaskno')
+  String get inTaskNo;
+  @override
+  /// 库房编号
+  @JsonKey(name: 'storeroomno')
+  String get storeRoomNo;
+  @override
+  /// 强制库位标志
+  @JsonKey(name: 'forcesite')
+  String get forceSite;
+  @override
+  /// 强制批次标志
+  @JsonKey(name: 'forcebatch')
+  String get forceBatch;
+  @override
+  /// 任务备注
+  @JsonKey(name: 'taskcomment')
+  String get taskComment;
+  @override
+  /// 完成标志
+  @JsonKey(name: 'taskFinishFlag')
+  String get taskFinishFlag;
+  @override
+  /// 库房标签
+  @JsonKey(name: 'roomtag')
+  String get roomTag;
+  @override
+  /// 工作站
+  @JsonKey(name: 'workstation')
+  String get workStation;
+  @override
+  /// 完成标志（兼容字段）
+  @JsonKey(name: 'finshFlg')
+  String get finishFlag;
+  @override
+  /// 排序类型
+  @JsonKey(name: 'sortType')
+  String get sortType;
+  @override
+  /// 排序字段
+  @JsonKey(name: 'sortColumn')
+  String get sortColumn;
+  @override
+  /// 搜索关键字
+  @JsonKey(name: 'searchKey')
+  String get searchKey;
+  @override
+  /// 节拍标志
+  @JsonKey(name: 'beatflag')
+  String get beatFlag;
+  @override
+  /// 采集人
+  @JsonKey(name: 'collecter')
+  int get collecter;
+  @override
+  @JsonKey(ignore: true)
+  _$$GoodsUpTaskItemQueryRequestImplCopyWith<_$GoodsUpTaskItemQueryRequestImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/inbound/goods_up_task/models/goods_up_request.g.dart
+++ b/lib/modules/inbound/goods_up_task/models/goods_up_request.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'goods_up_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$GoodsUpTaskItemQueryRequestImpl _$$GoodsUpTaskItemQueryRequestImplFromJson(
+  Map<String, dynamic> json,
+) => _$GoodsUpTaskItemQueryRequestImpl(
+  inTaskNo: json['intaskno'] as String? ?? '',
+  storeRoomNo: json['storeroomno'] as String? ?? '',
+  forceSite: json['forcesite'] as String? ?? '',
+  forceBatch: json['forcebatch'] as String? ?? '',
+  taskComment: json['taskcomment'] as String? ?? '',
+  taskFinishFlag: json['taskFinishFlag'] as String? ?? '0',
+  roomTag: json['roomtag'] as String? ?? '0',
+  workStation: json['workstation'] as String? ?? '',
+  finishFlag: json['finshFlg'] as String? ?? '0',
+  sortType: json['sortType'] as String? ?? '',
+  sortColumn: json['sortColumn'] as String? ?? '',
+  searchKey: json['searchKey'] as String? ?? '',
+  beatFlag: json['beatflag'] as String? ?? 'N',
+  collecter: (json['collecter'] as num?)?.toInt() ?? 0,
+);
+
+Map<String, dynamic> _$$GoodsUpTaskItemQueryRequestImplToJson(
+  _$GoodsUpTaskItemQueryRequestImpl instance,
+) => <String, dynamic>{
+  'intaskno': instance.inTaskNo,
+  'storeroomno': instance.storeRoomNo,
+  'forcesite': instance.forceSite,
+  'forcebatch': instance.forceBatch,
+  'taskcomment': instance.taskComment,
+  'taskFinishFlag': instance.taskFinishFlag,
+  'roomtag': instance.roomTag,
+  'workstation': instance.workStation,
+  'finshFlg': instance.finishFlag,
+  'sortType': instance.sortType,
+  'sortColumn': instance.sortColumn,
+  'searchKey': instance.searchKey,
+  'beatflag': instance.beatFlag,
+  'collecter': instance.collecter,
+};

--- a/lib/modules/inbound/goods_up_task/services/goods_up_cache_manager.dart
+++ b/lib/modules/inbound/goods_up_task/services/goods_up_cache_manager.dart
@@ -1,0 +1,115 @@
+import 'package:hive/hive.dart';
+
+import '../models/goods_up_models.dart';
+
+class GoodsUpCachedState {
+  const GoodsUpCachedState({
+    required this.detailList,
+    required this.stocks,
+    required this.dicSeq,
+    required this.dicMtlQty,
+  });
+
+  final List<InTaskItem> detailList;
+  final List<UpCollectionStock> stocks;
+  final Map<String, String> dicSeq;
+  final Map<String, List<double>> dicMtlQty;
+}
+
+/// 入库上架缓存管理器
+class GoodsUpCacheManager {
+  GoodsUpCacheManager(this.taskId);
+
+  final int taskId;
+  Box<dynamic>? _box;
+
+  Future<Box<dynamic>> _openBox() async {
+    final existing = _box;
+    if (existing != null && existing.isOpen) {
+      return existing;
+    }
+    _box = await Hive.openBox<dynamic>('goods_up_cache_$taskId');
+    return _box!;
+  }
+
+  Future<void> cacheState({
+    required List<InTaskItem> detailList,
+    required List<UpCollectionStock> stocks,
+    required Map<String, String> dicSeq,
+    required Map<String, List<double>> dicMtlQty,
+  }) async {
+    final box = await _openBox();
+    await box.put(
+      'detailList',
+      detailList.map((item) => item.toJson()).toList(),
+    );
+    await box.put('stocks', stocks.map((stock) => stock.toJson()).toList());
+    await box.put('dicSeq', dicSeq);
+    await box.put(
+      'dicMtlQty',
+      dicMtlQty.map(
+        (key, value) => MapEntry(key, value.map((e) => e).toList()),
+      ),
+    );
+    await box.put('updateFlag', '1');
+  }
+
+  Future<GoodsUpCachedState?> restoreState() async {
+    final box = await _openBox();
+    final updateFlag = box.get('updateFlag', defaultValue: '0').toString();
+    if (updateFlag != '1') {
+      return null;
+    }
+
+    final cachedDetailList = List<Map<String, dynamic>>.from(
+      (box.get('detailList', defaultValue: <Map<String, dynamic>>[]) as List)
+          .map((item) => Map<String, dynamic>.from(item as Map)),
+    );
+    final cachedStocks = List<Map<String, dynamic>>.from(
+      (box.get('stocks', defaultValue: <Map<String, dynamic>>[]) as List).map(
+        (item) => Map<String, dynamic>.from(item as Map),
+      ),
+    );
+    final cachedDicSeq = Map<String, String>.from(
+      (box.get('dicSeq', defaultValue: <String, String>{}) as Map).map(
+        (key, value) => MapEntry(key.toString(), value.toString()),
+      ),
+    );
+
+    final dicMtlQtyRaw =
+        (box.get('dicMtlQty', defaultValue: <String, dynamic>{}) as Map).map(
+          (key, value) => MapEntry(key.toString(), value),
+        );
+    final dicMtlQty = dicMtlQtyRaw.map((key, value) {
+      final list = (value as List?) ?? const [];
+      return MapEntry(
+        key,
+        list.whereType<num>().map((e) => e.toDouble()).toList(growable: false),
+      );
+    });
+
+    final detailList = cachedDetailList
+        .map((item) => InTaskItem.fromJson(item))
+        .toList(growable: false);
+
+    final stocks = cachedStocks
+        .map((item) => UpCollectionStock.fromJson(item))
+        .toList(growable: false);
+
+    return GoodsUpCachedState(
+      detailList: detailList,
+      stocks: stocks,
+      dicSeq: cachedDicSeq,
+      dicMtlQty: dicMtlQty,
+    );
+  }
+
+  Future<void> clear() async {
+    final box = await _openBox();
+    await box.put('detailList', <Map<String, dynamic>>[]);
+    await box.put('stocks', <Map<String, dynamic>>[]);
+    await box.put('dicSeq', <String, String>{});
+    await box.put('dicMtlQty', <String, List<double>>{});
+    await box.put('updateFlag', '0');
+  }
+}


### PR DESCRIPTION
## Summary
- add freezed + hive-backed models for inbound goods up task details, barcode data, and collection stock
- add request payload model aligned with `intaskitemList` query parameter names
- implement a Hive-based cache manager to persist goods up detail and stock state
- register the new Hive adapters during application startup

## Testing
- flutter pub run build_runner build --delete-conflicting-outputs

------
https://chatgpt.com/codex/tasks/task_e_68ecbd233e008330815e69cf61b327d4