### PR TITLE
feat: add goods up inbound service

### DIFF
--- a/lib/modules/inbound/goods_up_task/bloc/goods_up_collection_bloc.dart
+++ b/lib/modules/inbound/goods_up_task/bloc/goods_up_collection_bloc.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 
 import '../models/goods_up_collection_task.dart';
 import '../services/goods_up_collection_service.dart';
+import '../services/goods_up_service.dart';
 import '../../../../services/user_manager.dart';
 
 @immutable
@@ -33,12 +34,16 @@ class GoodsUpCollectionLoadFailure extends GoodsUpCollectionState {
 class GoodsUpCollectionBloc extends Cubit<GoodsUpCollectionState> {
   GoodsUpCollectionBloc({
     required GoodsUpCollectionService service,
+    required GoodsUpService goodsUpService,
     required UserManager userManager,
   })  : _service = service,
+        _goodsUpService = goodsUpService,
         _userManager = userManager,
         super(const GoodsUpCollectionInitial());
 
   final GoodsUpCollectionService _service;
+  // ignore: unused_field
+  final GoodsUpService _goodsUpService;
   final UserManager _userManager;
 
   Future<void> loadTasks() async {

--- a/lib/modules/inbound/goods_up_task/goods_up_task_module.dart
+++ b/lib/modules/inbound/goods_up_task/goods_up_task_module.dart
@@ -7,6 +7,7 @@ import '../../../../services/user_manager.dart';
 import 'bloc/goods_up_collection_bloc.dart';
 import 'goods_up_collection_page.dart';
 import 'services/goods_up_collection_service.dart';
+import 'services/goods_up_service.dart';
 
 class GoodsUpTaskModule extends Module {
   @override
@@ -14,13 +15,18 @@ class GoodsUpTaskModule extends Module {
 
   @override
   void binds(Injector i) {
-    i.addSingleton<GoodsUpCollectionService>(
-      () => GoodsUpCollectionService(i.get<DioClient>().dio),
-    );
+    i
+      ..addSingleton<GoodsUpCollectionService>(
+        () => GoodsUpCollectionService(i.get<DioClient>().dio),
+      )
+      ..addSingleton<GoodsUpService>(
+        () => GoodsUpService(i.get<DioClient>().dio),
+      );
 
     i.add<GoodsUpCollectionBloc>(
       () => GoodsUpCollectionBloc(
         service: i.get<GoodsUpCollectionService>(),
+        goodsUpService: i.get<GoodsUpService>(),
         userManager: i.get<UserManager>(),
       ),
     );

--- a/lib/modules/inbound/goods_up_task/models/goods_up_request.dart
+++ b/lib/modules/inbound/goods_up_task/models/goods_up_request.dart
@@ -53,3 +53,6 @@ class GoodsUpTaskItemQueryRequest with _$GoodsUpTaskItemQueryRequest {
   factory GoodsUpTaskItemQueryRequest.fromJson(Map<String, dynamic> json) =>
       _$GoodsUpTaskItemQueryRequestFromJson(json);
 }
+
+/// `GoodsUpTaskItemQuery` 的别名，方便在 service 中引用
+typedef GoodsUpTaskItemQuery = GoodsUpTaskItemQueryRequest;

--- a/lib/modules/inbound/goods_up_task/services/goods_up_service.dart
+++ b/lib/modules/inbound/goods_up_task/services/goods_up_service.dart
@@ -1,0 +1,191 @@
+import 'package:dio/dio.dart';
+import 'package:wms_app/modules/inbound/goods_up_task/models/goods_up_models.dart';
+import 'package:wms_app/modules/inbound/goods_up_task/models/goods_up_request.dart';
+import 'package:wms_app/services/api_response_handler.dart';
+
+/// 入库上架业务接口服务
+class GoodsUpService {
+  GoodsUpService(this._dio);
+
+  final Dio _dio;
+
+  Future<List<InTaskItem>> getInTaskItemList(
+    GoodsUpTaskItemQuery params,
+  ) async {
+    try {
+      final response = await _dio.get(
+        '/system/terminal/intaskitemList',
+        queryParameters: params.toJson(),
+      );
+
+      return ApiResponseHandler.handleResponse(
+        response: response,
+        dataExtractor: (data) {
+          if (data is List) {
+            return data
+                .whereType<Map>()
+                .map((item) => Map<String, dynamic>.from(item as Map))
+                .map(InTaskItem.fromJson)
+                .toList(growable: false);
+          }
+
+          if (data is Map) {
+            final rows = data['rows'];
+            if (rows is List) {
+              return rows
+                  .whereType<Map>()
+                  .map((item) => Map<String, dynamic>.from(item as Map))
+                  .map(InTaskItem.fromJson)
+                  .toList(growable: false);
+            }
+          }
+
+          throw Exception('入库任务明细返回格式不正确');
+        },
+      );
+    } on DioException catch (e) {
+      throw Exception(ApiResponseHandler.handleDioException(e));
+    }
+  }
+
+  Future<Map<String, dynamic>> getStoreSite(
+    String storeRoomNo,
+    String storeSiteNo,
+  ) async {
+    try {
+      final response = await _dio.get(
+        '/system/terminal/getStoreSite',
+        queryParameters: {
+          'storeRoomNo': storeRoomNo,
+          'storeSiteNo': storeSiteNo,
+        },
+      );
+
+      return ApiResponseHandler.handleResponse(
+        response: response,
+        dataExtractor: _normalizeMapData,
+      );
+    } on DioException catch (e) {
+      throw Exception(ApiResponseHandler.handleDioException(e));
+    }
+  }
+
+  Future<Map<String, dynamic>> getMtlRepertory(
+    String storeSite,
+    String matCode,
+  ) async {
+    try {
+      final response = await _dio.get(
+        '/system/terminal/getMtlRepertory',
+        queryParameters: {
+          'storeSite': storeSite,
+          'matCode': matCode,
+        },
+      );
+
+      return ApiResponseHandler.handleResponse(
+        response: response,
+        dataExtractor: _normalizeMapData,
+      );
+    } on DioException catch (e) {
+      throw Exception(ApiResponseHandler.handleDioException(e));
+    }
+  }
+
+  Future<Map<String, dynamic>> commitUpShelves(
+    List<Map<String, dynamic>> infos,
+    List<Map<String, dynamic>> items,
+    String filter,
+  ) async {
+    try {
+      final response = await _dio.post(
+        '/system/terminal/commitUp',
+        data: {
+          'infos': infos,
+          'items': items,
+          'filter': filter,
+        },
+        options: Options(
+          headers: {'content-type': 'application/json;charset=UTF-8'},
+        ),
+      );
+
+      return ApiResponseHandler.handleResponse(
+        response: response,
+        dataExtractor: _normalizeMapData,
+      );
+    } on DioException catch (e) {
+      throw Exception(ApiResponseHandler.handleDioException(e));
+    }
+  }
+
+  Future<UpBarcodeContent> getMaterialInfo(String qrString) async {
+    try {
+      final response = await _dio.get(
+        '/system/terminal/materialInfo',
+        queryParameters: {'QRstring': qrString},
+      );
+
+      return ApiResponseHandler.handleResponse(
+        response: response,
+        dataExtractor: (data) {
+          if (data is Map<String, dynamic>) {
+            return UpBarcodeContent.fromJson(data);
+          }
+
+          if (data is Map) {
+            return UpBarcodeContent.fromJson(
+              Map<String, dynamic>.from(data as Map),
+            );
+          }
+
+          throw Exception('二维码解析数据格式不正确');
+        },
+      );
+    } on DioException catch (e) {
+      throw Exception(ApiResponseHandler.handleDioException(e));
+    }
+  }
+
+  Map<String, dynamic> _normalizeMapData(dynamic data) {
+    if (data is Map<String, dynamic>) {
+      return _normalizeRows(data);
+    }
+
+    if (data is Map) {
+      return _normalizeRows(Map<String, dynamic>.from(data as Map));
+    }
+
+    if (data is List) {
+      return {
+        'rows': data
+            .whereType<Map>()
+            .map((item) => Map<String, dynamic>.from(item as Map))
+            .toList(growable: false),
+      };
+    }
+
+    throw Exception('接口返回数据格式不正确');
+  }
+
+  Map<String, dynamic> _normalizeRows(Map<String, dynamic> source) {
+    final map = Map<String, dynamic>.from(source);
+    final dataField = map['data'];
+    if (dataField is List) {
+      map['data'] = dataField
+          .whereType<Map>()
+          .map((item) => Map<String, dynamic>.from(item as Map))
+          .toList(growable: false);
+    }
+
+    final rows = map['rows'];
+    if (rows is List) {
+      map['rows'] = rows
+          .whereType<Map>()
+          .map((item) => Map<String, dynamic>.from(item as Map))
+          .toList(growable: false);
+    }
+
+    return map;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated GoodsUpService to wrap inbound goods-up API calls with shared response handling
- register the new service in the module and expose it to the GoodsUpCollectionBloc
- add a GoodsUpTaskItemQuery typedef to simplify request usage

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ecc0c5c77c8330a42d1512e6cd0c59