### PR TITLE
Refactor collection workflow into shared base bloc

### DIFF
--- a/lib/modules/common/collection/base_collection_bloc.dart
+++ b/lib/modules/common/collection/base_collection_bloc.dart
@@ -1,0 +1,938 @@
+import 'dart:developer';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hive/hive.dart';
+import 'package:uuid/uuid.dart';
+import 'package:wms_app/models/page_status.dart';
+import 'package:wms_app/modules/outbound/collection_task/bloc/collection_event.dart';
+import 'package:wms_app/modules/outbound/collection_task/bloc/collection_state.dart';
+import 'package:wms_app/modules/outbound/collection_task/models/collection_models.dart';
+import 'package:wms_app/utils/custom_extension.dart';
+import 'package:wms_app/utils/error_handler.dart';
+
+/// Base bloc that encapsulates the common collection workflow shared by
+/// outbound and inbound modules.
+abstract class BaseCollectionBloc<TTask>
+    extends Bloc<CollectionEvent, CollectionState> {
+  BaseCollectionBloc() : super(CollectionState()) {
+    on<PerformBarcodeEvent>(_onPerformBarcode);
+    on<ChangeTabEvent>(_onChangeTab);
+    on<ChangedSelectionEvent>(_onChangedSelection);
+    on<DeleteCollectedStocksEvent>(_onDeleteCollectedStocks);
+    on<UpdateFromResultEvent>(_onUpdateFromResult);
+    on<ResetStatusEvent>(_onResetStatus);
+    on<SetFocusEvent>(_onSetFocus);
+  }
+
+  late Box _cacheBox;
+  late int userId;
+  late String taskId;
+  late String taskNo;
+  late String storeRoomNo;
+
+  String siteFlag = 'Y';
+  String batchFlag = 'Y';
+
+  /// Hook for subclasses to set the task context.
+  @protected
+  void configureTask({
+    required int userId,
+    required String taskId,
+    required String taskNo,
+    required String storeRoomNo,
+  }) {
+    this.userId = userId;
+    this.taskId = taskId;
+    this.taskNo = taskNo;
+    this.storeRoomNo = storeRoomNo;
+    siteFlag = 'Y';
+    batchFlag = 'Y';
+  }
+
+  /// Opens hive cache according to the provided key.
+  @protected
+  Future<void> openCache(String cacheKey) async {
+    _cacheBox = await Hive.openBox(cacheKey);
+  }
+
+  /// Clears cached collection data.
+  @protected
+  Future<void> clearCache() async {
+    await _cacheBox.put('stocks', <Map>[]);
+    await _cacheBox.put('updateFlag', '0');
+    await _cacheBox.put('detailList', <Map>[]);
+    await _cacheBox.put('dicMtlQty', <String, List<double>>{});
+    await _cacheBox.put('dicInvMtlQty', <String, double>{});
+    await _cacheBox.clear();
+  }
+
+  Future<void> restoreFromCache(Emitter<CollectionState> emit) async {
+    try {
+      final updateFlag = _cacheBox.get('updateFlag', defaultValue: '0');
+      if (updateFlag != '1') {
+        return;
+      }
+
+      final cachedStocks = _cacheBox.get('stocks', defaultValue: <Map>[]);
+      final cachedDicSeq = Map<String, String>.from(
+        _cacheBox.get('dicSeq', defaultValue: <String, String>{}),
+      );
+      final cachedDicMtlQty = Map<String, List<double>>.from(
+        _cacheBox.get('dicMtlQty', defaultValue: <String, List<double>>{}),
+      );
+      final cachedDicInvMtlQty = Map<String, double>.from(
+        _cacheBox.get('dicInvMtlQty', defaultValue: <String, double>{}),
+      );
+
+      final stocks = cachedStocks
+          .map<CollectionStock>(
+            (item) => CollectionStock.fromJson(
+              Map<String, dynamic>.from(item),
+            ),
+          )
+          .toList();
+
+      emit(
+        state.copyWith(
+          stocks: stocks,
+          dicSeq: cachedDicSeq,
+          dicMtlQty: cachedDicMtlQty,
+          dicInvMtlQty: cachedDicInvMtlQty,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('恢复缓存数据失败：${e.toString()}'),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onSetFocus(
+    SetFocusEvent event,
+    Emitter<CollectionState> emit,
+  ) async {
+    emit(state.copyWith(focus: event.focus));
+  }
+
+  void _onResetStatus(ResetStatusEvent event, Emitter<CollectionState> emit) {
+    emit(state.copyWith(status: CollectionStatus.normal()));
+  }
+
+  Future<void> _onChangeTab(
+    ChangeTabEvent event,
+    Emitter<CollectionState> emit,
+  ) async {
+    emit(state.copyWith(currentTab: event.index));
+  }
+
+  Future<void> _onChangedSelection(
+    ChangedSelectionEvent event,
+    Emitter<CollectionState> emit,
+  ) async {
+    debugPrint('------------- Selected indexes: ${event.ids}');
+    emit(state.copyWith(checkedIds: event.ids));
+  }
+
+  Future<void> _onPerformBarcode(
+    PerformBarcodeEvent event,
+    Emitter<CollectionState> emit,
+  ) async {
+    final barcode = event.barcode;
+    if (barcode.isEmpty) {
+      emit(state.copyWith(status: CollectionStatus.error('采集内容为空,请重新采集')));
+      return;
+    }
+
+    try {
+      if (barcode.contains('MC')) {
+        await handleQRCode(barcode, emit);
+      } else if (barcode.contains('\\$KW\\$')) {
+        await handleSite(barcode, emit);
+      } else if (_isNumeric(barcode)) {
+        await handleQuantity(double.parse(barcode), emit);
+      } else {
+        emit(state.copyWith(status: CollectionStatus.error('采集内容不合法！')));
+        return;
+      }
+
+      var placeholder = await getPlaceMessage();
+      if (placeholder.isEmpty) {
+        await dealQuantity(state.collectQty, state.matControlFlag, emit);
+      }
+
+      placeholder = placeholder.isEmpty
+          ? (state.storeSite.isEmpty ? '请扫描库位' : '请扫描二维码')
+          : placeholder;
+
+      final focus = placeholder == '请输入数量';
+
+      emit(state.copyWith(placeholder: placeholder, focus: focus));
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(e)),
+        ),
+      );
+    }
+  }
+
+  Future<void> handleQRCode(
+    String barcode,
+    Emitter<CollectionState> emit,
+  ) async {
+    emit(state.copyWith(status: CollectionStatus.loading()));
+
+    final barcodeContent = await fetchBarcode(barcode);
+    final newmarttask = barcodeContent.id_old ?? '';
+    final matControl = barcodeContent.seqctrl ?? '';
+
+    String matSendControl = '0';
+    final mtlInfo = await fetchMatControl(barcodeContent.matcode!);
+    if (mtlInfo.length > 4 && mtlInfo[4].isNotEmpty) {
+      matSendControl = mtlInfo[4];
+    }
+
+    final erpRoom = await validateMaterialControl(
+      barcodeContent,
+      newmarttask,
+      matControl,
+      matSendControl,
+    );
+
+    var newstate = state.copyWith(
+      currentBarcode: barcodeContent,
+      matControlFlag: matControl,
+      matSendControl: matSendControl,
+      collectQty: matControl == '0' ? 1 : state.collectQty,
+      erpRoom: erpRoom ?? '',
+      status: CollectionStatus.success(),
+    );
+
+    newstate = await checkInventory(
+      newstate,
+      newstate.collectQty,
+      newstate.storeSite,
+      emit,
+    );
+    final collectionList = updateCollectionList(newstate.storeSite);
+
+    final newTab = collectionList.isEmpty ? 0 : 1;
+
+    emit(newstate.copyWith(collectionList: collectionList, currentTab: newTab));
+  }
+
+  Future<String?> validateMaterialControl(
+    BarcodeContent barcodeContent,
+    String newmarttask,
+    String matControl,
+    String matSendControl,
+  ) async {
+    String erpRoom = '';
+    if (matControl == '0') {
+      if ((barcodeContent.sn ?? '').isEmpty) {
+        throw Exception('物料【${barcodeContent.matcode!}】序列号不能为空');
+      }
+
+      final seqKey = '${barcodeContent.matcode!}@${barcodeContent.sn}';
+      if (state.dicSeq.containsKey(seqKey)) {
+        throw Exception(
+          '物料【${barcodeContent.matcode!}】序列号【${barcodeContent.sn}】不允许重复采集，请确认',
+        );
+      }
+    } else if (matControl == '1' || matControl == '2') {
+      String? batchNo = newmarttask == '0'
+          ? barcodeContent.sn
+          : barcodeContent.batchno;
+
+      if ((matSendControl == '0' && state.roomMatControl == '0') ||
+          state.roomMatControl == '1') {
+        final erpRoom1 = await checkMaterial(
+          barcodeContent.matcode!,
+          batchNo!,
+          state.storeSite,
+        );
+        if (erpRoom1.isNotEmpty) {
+          erpRoom = erpRoom1;
+        }
+      }
+      final erpRoom2 = await checkMaterialSite(
+        barcodeContent.matcode!,
+        batchNo!,
+        state.storeSite,
+      );
+      if (erpRoom2.isNotEmpty) {
+        erpRoom = erpRoom2;
+      }
+      return erpRoom;
+    } else {
+      throw Exception('物料${barcodeContent.matcode!}编码控制维护值维护不合法');
+    }
+    return null;
+  }
+
+  Future<String> checkMaterial(
+    String matcode,
+    String batchno,
+    String storeSite,
+  ) async {
+    bool batchFound = false;
+    String erpRoom = '';
+
+    for (final item in state.detailList) {
+      if (item.matcode == matcode &&
+          item.storesiteno == storeSite &&
+          item.hintbatchno == batchno) {
+        erpRoom = item.subinventoryCode ?? '';
+        batchFound = true;
+        break;
+      }
+    }
+
+    if (!batchFound) {
+      for (final item in state.detailList) {
+        if (item.matcode == matcode && item.storesiteno == storeSite) {
+          erpRoom = item.subinventoryCode ?? '';
+          batchFound = true;
+          break;
+        }
+      }
+    }
+
+    if (!batchFound) {
+      throw Exception('任务明细中物料【$matcode】不存在');
+    }
+    return erpRoom;
+  }
+
+  Future<String> checkMaterialSite(
+    String matcode,
+    String batchno,
+    String storeSite,
+  ) async {
+    if (isSnTask) return '';
+
+    bool matFind = false;
+    String erpRoom = '';
+
+    for (final item in state.detailList) {
+      bool matches = false;
+
+      switch (state.mtlCheckMode) {
+        case MtlCheckMode.mtlSiteBatch:
+          matches =
+              item.matcode == matcode &&
+              item.hintbatchno == batchno &&
+              item.storesiteno == storeSite;
+          break;
+        case MtlCheckMode.mtlSite:
+          matches = item.matcode == matcode && item.storesiteno == storeSite;
+          break;
+        case MtlCheckMode.mtlBatch:
+          matches = item.matcode == matcode && item.hintbatchno == batchno;
+          break;
+        case MtlCheckMode.mtl:
+          matches = item.matcode == matcode;
+          break;
+      }
+
+      if (matches) {
+        erpRoom = item.subinventoryCode ?? '';
+        matFind = true;
+        break;
+      }
+    }
+
+    if (!matFind) {
+      if (batchFlag == 'Y') {
+        throw Exception('采集物料【$matcode】批次【$batchno】库位【$storeSite】不在任务明细中，请核实');
+      } else {
+        throw Exception('采集物料【$matcode】库位【$storeSite】不在任务明细中，请核实');
+      }
+    }
+
+    return erpRoom;
+  }
+
+  Future<void> handleSite(
+    String barcode,
+    Emitter<CollectionState> emit,
+  ) async {
+    final parts = barcode.split('\\$');
+    if (parts.length < 3) {
+      throw Exception('库位格式不正确');
+    }
+
+    final siteCode = parts[2];
+
+    emit(state.copyWith(status: CollectionStatus.loading()));
+
+    final response = await fetchStoreSite(storeRoomNo, siteCode);
+    if (response['code'] != 200) {
+      throw Exception(response['msg'] ?? '库位验证失败');
+    }
+
+    final siteList = response['data'] as List;
+    if (siteList.isEmpty) {
+      throw Exception('库房【$storeRoomNo}}】下无库位号【$siteCode】');
+    }
+
+    if (siteList[0]['isfrozen'] != '0') {
+      throw Exception('库位【$siteCode】被锁定或者冻结');
+    }
+
+    if (state.currentBarcode != null && state.currentBarcode!.isNotEmpty) {
+      if ((state.matSendControl == '0' && state.roomMatControl == '0') ||
+          state.roomMatControl == '1') {
+        await checkMaterialSite(
+          state.currentBarcode!.matcode ?? '',
+          state.currentBarcode!.batchno ?? '',
+          siteCode,
+        );
+      }
+    }
+
+    var newstate = state.copyWith(storeSite: siteCode);
+
+    newstate = await checkInventory(
+      newstate,
+      newstate.collectQty,
+      newstate.storeSite,
+      emit,
+    );
+
+    final collectionList = updateCollectionList(newstate.storeSite);
+
+    final newTab = collectionList.isEmpty ? 0 : 1;
+
+    emit(
+      newstate.copyWith(
+        collectionList: collectionList,
+        currentTab: newTab,
+        status: CollectionStatus.success(),
+      ),
+    );
+  }
+
+  Future<void> handleQuantity(
+    double quantity,
+    Emitter<CollectionState> emit,
+  ) async {
+    if (isSnTask) {
+      throw Exception('已采集序列号无需采集数量，请扫描二维码');
+    }
+
+    emit(state.copyWith(collectQty: quantity));
+  }
+
+  bool get isSnTask => state.matControlFlag == '0';
+
+  Future<CollectionState> checkInventory(
+    CollectionState state,
+    double collectQty,
+    String storeSite,
+    Emitter<CollectionState> emit,
+  ) async {
+    if (state.currentBarcode?.matcode == null || storeSite.isEmpty) {
+      return state;
+    }
+
+    final result = await fetchInventory(
+      storeSite: storeSite,
+      barcode: state.currentBarcode!,
+      matControlFlag: state.matControlFlag,
+      erpRoom: state.erpRoom,
+    );
+
+    final repQty = (result['repQty'] ?? 0).toDouble();
+    final erpStoreInv = result['erpStoreInv']?.toString() ?? state.erpStoreInv;
+
+    return state.copyWith(repQty: repQty, erpStoreInv: erpStoreInv);
+  }
+
+  Future<String> getPlaceMessage() async {
+    if (state.storeSite.isEmpty) {
+      return '请扫描库位';
+    }
+    if (state.currentBarcode?.isEmpty ?? true) {
+      return '请扫描二维码';
+    }
+    if (!isSnTask && state.collectQty == 0) {
+      return '请输入数量';
+    }
+    return '';
+  }
+
+  List<OutTaskItem> updateCollectionList(String storeSite) {
+    if (storeSite.isEmpty) return [];
+
+    final collectionList = state.detailList
+        .where((item) => item.storesiteno == storeSite)
+        .toList();
+
+    return collectionList;
+  }
+
+  bool _shouldInclude(OutTaskItem item) {
+    bool include = true;
+    switch (state.mtlCheckMode) {
+      case MtlCheckMode.mtlBatch:
+        include = item.hintbatchno == state.currentBarcode?.batchno;
+        break;
+      case MtlCheckMode.mtlSiteBatch:
+        include =
+            item.hintbatchno == state.currentBarcode?.batchno &&
+            item.storesiteno == state.storeSite;
+        break;
+      case MtlCheckMode.mtlSite:
+        include = item.storesiteno == state.storeSite;
+        break;
+      case MtlCheckMode.mtl:
+        include = true;
+        break;
+    }
+    return include;
+  }
+
+  Future<void> dealQuantity(
+    double count,
+    String matFlag,
+    Emitter<CollectionState> emit,
+  ) async {
+    if (matFlag.isEmpty) {
+      throw Exception('获取物料编码属性失败');
+    }
+
+    final matFlagInt = int.tryParse(matFlag) ?? 0;
+    String sn = '';
+    if (matFlagInt == 0) {
+      sn = state.currentBarcode?.sn ?? '';
+    }
+
+    if (count <= 0) {
+      throw Exception('采集数量必须大于0');
+    }
+
+    final strKey =
+        '${state.storeSite}${state.currentBarcode?.matcode!}${matFlagInt == 0 ? state.currentBarcode?.sn : state.currentBarcode?.batchno}';
+    final decRepqty = state.dicInvMtlQty[strKey] ?? 0;
+    if (state.repQty - decRepqty < count) {
+      throw Exception(
+        '库位【${state.storeSite}】物料【${state.currentBarcode?.matcode}】的库存【${state.repQty - decRepqty}】小于本次移出库存【$count】，请确认',
+      );
+    }
+
+    final newDicSeq = Map<String, String>.from(state.dicSeq);
+
+    final newDicInvMtlQty = Map<String, double>.from(state.dicInvMtlQty);
+    final currentInvQty = newDicInvMtlQty[strKey] ?? 0;
+    newDicInvMtlQty[strKey] = currentInvQty + count;
+
+    final updatedDetailList = List<OutTaskItem>.from(state.detailList);
+    final dicMtlOperation = <String, List<double>>{};
+    final newDicMtlQty = Map<String, List<double>>.from(state.dicMtlQty);
+
+    double totalTaskQty = 0;
+    double totalTmpQty = 0;
+    double totalInventory = state.repQty;
+
+    final indexes = updatedDetailList
+        .asMap()
+        .entries
+        .where(
+          (e) =>
+              e.value.matcode == state.currentBarcode?.matcode &&
+              _shouldInclude(e.value),
+        )
+        .map((e) => e.key)
+        .toList();
+
+    if (matFlagInt != 0 && indexes.isEmpty) {
+      throw Exception('采集物料批号序列号信息匹配任务明细失败');
+    }
+
+    for (var index in indexes) {
+      final item = updatedDetailList[index];
+      totalTaskQty += item.hintqty;
+      totalTmpQty += item.collectedqty;
+    }
+
+    totalInventory -= totalTmpQty + count;
+
+    if (totalTmpQty + count > totalTaskQty) {
+      throw Exception('本次采集数量【$count】大于剩余可采集数量【${totalTaskQty - totalTmpQty}】');
+    }
+
+    if (matFlagInt == 0) {
+      var idx = indexes
+          .where((index) => updatedDetailList[index].sn == sn)
+          .firstOrNull;
+      if (idx != null) {
+        var item = updatedDetailList[idx];
+        item = item.copyWith(collectedqty: 1);
+        updatedDetailList[idx] = item;
+
+        dicMtlOperation[item.outtaskitemid.toString()] = [1, 1];
+
+        newDicMtlQty[item.outtaskitemid.toString()] = [0, 1];
+
+        newDicSeq['${state.currentBarcode?.matcode}@$sn'] =
+            '${state.currentBarcode?.matcode}@$sn';
+
+        await addCollectData(
+          state.currentBarcode?.matcode ?? '',
+          state.currentBarcode?.batchno ?? '',
+          sn,
+          count,
+          storeRoomNo,
+          state.storeSite,
+          dicMtlOperation,
+          state.erpStoreInv,
+          '',
+          emit,
+        );
+      }
+    } else {
+      double currentCount = count;
+      for (var index in indexes) {
+        var item = updatedDetailList[index];
+        final taskCount = item.hintqty;
+        final collectedCount = item.collectedqty;
+
+        item = item.copyWith(repqty: totalInventory);
+        updatedDetailList[index] = item;
+
+        if (taskCount == collectedCount || currentCount == 0) continue;
+
+        final tempCount = (taskCount - collectedCount) > currentCount
+            ? currentCount
+            : (taskCount - collectedCount);
+
+        currentCount -= tempCount;
+
+        item = item.copyWith(collectedqty: collectedCount + tempCount);
+        updatedDetailList[index] = item;
+
+        if (!newDicMtlQty.containsKey(item.outtaskitemid.toString())) {
+          newDicMtlQty[item.outtaskitemid.toString()] = [collectedCount, 0];
+        }
+
+        dicMtlOperation[item.outtaskitemid.toString()] = [taskCount, tempCount];
+
+        final begin = newDicMtlQty[item.outtaskitemid.toString()]![0];
+        newDicMtlQty[item.outtaskitemid.toString()] = [
+          begin,
+          collectedCount + tempCount,
+        ];
+      }
+
+      await addCollectData(
+        state.currentBarcode?.matcode ?? '',
+        state.currentBarcode?.batchno ?? '',
+        sn,
+        count,
+        storeRoomNo,
+        state.storeSite,
+        dicMtlOperation,
+        state.erpStoreInv,
+        '',
+        emit,
+      );
+    }
+
+    final collectionList = updatedDetailList
+        .where((item) => item.storesiteno == state.storeSite)
+        .toList();
+
+    emit(
+      initializeCollect().copyWith(
+        detailList: updatedDetailList,
+        collectionList: collectionList,
+        dicSeq: newDicSeq,
+        dicMtlQty: newDicMtlQty,
+        dicInvMtlQty: newDicInvMtlQty,
+        status: CollectionStatus.success('采集成功'),
+      ),
+    );
+
+    await localSave();
+  }
+
+  Future<void> addCollectData(
+    String matCode,
+    String batchNo,
+    String sn,
+    double collectQty,
+    String storeRoom,
+    String storeSite,
+    Map<String, List<double>> dicMtlOperation,
+    String erpRoom,
+    String trayNo,
+    Emitter<CollectionState> emit,
+  ) async {
+    final newStocks = List<CollectionStock>.from(state.stocks);
+
+    for (final entry in dicMtlOperation.entries) {
+      final stock = mapStock(
+        stockId: const Uuid().v4(),
+        matCode: matCode,
+        batchNo: batchNo,
+        sn: sn,
+        taskQty: entry.value[0],
+        collectQty: entry.value[1],
+        outTaskItemId: entry.key,
+        taskId: taskId,
+        storeRoom: storeRoom,
+        storeSite: storeSite,
+        erpStore: erpRoom,
+        trayNo: trayNo,
+      );
+      newStocks.add(stock);
+    }
+
+    emit(state.copyWith(stocks: newStocks));
+  }
+
+  Future<void> localSave() async {
+    await _cacheBox.put(
+      'detailList',
+      state.detailList.map((e) => e.toJson()).toList(),
+    );
+
+    await _cacheBox.put('stocks', state.stocks.map((e) => e.toJson()).toList());
+    await _cacheBox.put('dicSeq', state.dicSeq);
+    await _cacheBox.put('dicMtlQty', state.dicMtlQty);
+    await _cacheBox.put('dicInvMtlQty', state.dicInvMtlQty);
+    await _cacheBox.put('updateFlag', '1');
+  }
+
+  CollectionState initializeCollect() {
+    return state.copyWith(
+      status: CollectionStatus.normal(),
+      collectQty: 0,
+      repQty: 0,
+      currentBarcode: BarcodeContent.fromJson({}),
+      focus: false,
+      matControlFlag: '',
+      erpRoom: '',
+      erpStoreInv: '',
+      placeholder: '请扫描库位',
+    );
+  }
+
+  bool _isNumeric(String str) {
+    return RegExp(r'^[0-9]+(\\.[0-9]+)?').hasMatch(str);
+  }
+
+  Future<void> _onDeleteCollectedStocks(
+    DeleteCollectedStocksEvent event,
+    Emitter<CollectionState> emit,
+  ) async {
+    try {
+      if (event.stockIds.isEmpty) {
+        emit(state.copyWith(status: CollectionStatus.error('请至少选择一行记录')));
+        return;
+      }
+
+      final updatedStocks = List<CollectionStock>.from(state.stocks);
+      final updatedDetailList = List<OutTaskItem>.from(state.detailList);
+      final newDicSeq = Map<String, String>.from(state.dicSeq);
+      final newDicMtlQty = Map<String, List<double>>.from(state.dicMtlQty);
+      final newDicInvMtlQty = Map<String, double>.from(state.dicInvMtlQty);
+
+      for (final stockId in event.stockIds) {
+        final idx = updatedStocks.indexWhere((s) => s.stockid == stockId);
+        if (idx < 0) continue;
+
+        final s = updatedStocks[idx];
+
+        final dIdx = updatedDetailList.indexWhere(
+          (d) => d.outtaskitemid.toString() == s.outtaskitemid,
+        );
+        if (dIdx >= 0) {
+          final d = updatedDetailList[dIdx];
+          final newCollected = (d.collectedqty - s.collectQty);
+          updatedDetailList[dIdx] = d.copyWith(
+            collectedqty: newCollected < 0 ? 0 : newCollected,
+          );
+        }
+
+        if (s.sn.isNotEmpty) {
+          final seqKey = '${s.matcode}@${s.sn}';
+          if (newDicSeq.containsKey(seqKey)) {
+            newDicSeq.remove(seqKey);
+          }
+        }
+
+        final mtlKey = s.outtaskitemid;
+        if (newDicMtlQty.containsKey(mtlKey)) {
+          final ls2 = List<double>.from(newDicMtlQty[mtlKey]!);
+          final newSecond = (ls2.length > 1 ? ls2[1] : 0) - s.collectQty;
+          if (ls2.length > 1) {
+            ls2[1] = newSecond < 0 ? 0 : newSecond;
+          } else {
+            ls2.add(newSecond < 0 ? 0 : newSecond);
+          }
+          newDicMtlQty[mtlKey] = ls2;
+        }
+
+        String invKey = '';
+        if (s.sn.isNotEmpty) {
+          invKey = '${s.storeSite}${s.matcode}${s.sn}';
+        } else {
+          invKey = '${s.storeSite}${s.matcode}${s.batchno}';
+        }
+        if (newDicInvMtlQty.containsKey(invKey)) {
+          final val = (newDicInvMtlQty[invKey] ?? 0) - s.collectQty;
+          newDicInvMtlQty[invKey] = val < 0 ? 0 : val;
+        }
+
+        updatedStocks.removeAt(idx);
+      }
+      final updateCollectionList = updatedDetailList
+          .where((item) => item.storesiteno == state.storeSite)
+          .toList();
+
+      emit(
+        state.copyWith(
+          stocks: updatedStocks,
+          detailList: updatedDetailList,
+          collectionList: updateCollectionList,
+          dicSeq: newDicSeq,
+          dicMtlQty: newDicMtlQty,
+          dicInvMtlQty: newDicInvMtlQty,
+        ),
+      );
+      await localSave();
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(
+            '删除采集记录失败：${ErrorHandler.handleError(e)}',
+          ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onUpdateFromResult(
+    UpdateFromResultEvent event,
+    Emitter<CollectionState> emit,
+  ) async {
+    try {
+      if (event.deletedStocks.isEmpty) return;
+
+      final deleted = event.deletedStocks;
+      if (deleted.isEmpty) return;
+
+      final updatedStocks = List<CollectionStock>.from(state.stocks);
+      final updatedDetailList = List<OutTaskItem>.from(state.detailList);
+      final newDicSeq = Map<String, String>.from(state.dicSeq);
+      final newDicMtlQty = Map<String, List<double>>.from(state.dicMtlQty);
+      final newDicInvMtlQty = Map<String, double>.from(state.dicInvMtlQty);
+
+      for (final s in deleted) {
+        final idx = updatedStocks.indexWhere((x) => x.stockid == s.stockid);
+        if (idx < 0) continue;
+
+        final dIdx = updatedDetailList.indexWhere(
+          (d) => d.outtaskitemid.toString() == s.outtaskitemid,
+        );
+        if (dIdx >= 0) {
+          final d = updatedDetailList[dIdx];
+          final newCollected = d.collectedqty - s.collectQty;
+          updatedDetailList[dIdx] = d.copyWith(
+            collectedqty: newCollected < 0 ? 0 : newCollected,
+          );
+        }
+
+        if (s.sn.isNotEmpty) {
+          final seqKey = '${s.matcode}@${s.sn}';
+          newDicSeq.remove(seqKey);
+        }
+
+        final mtlKey = s.outtaskitemid;
+        if (newDicMtlQty.containsKey(mtlKey)) {
+          final values = List<double>.from(newDicMtlQty[mtlKey]!);
+          if (values.length > 1) {
+            final newValue = values[1] - s.collectQty;
+            values[1] = newValue < 0 ? 0 : newValue;
+          }
+          newDicMtlQty[mtlKey] = values;
+        }
+
+        String invKey = '';
+        if (s.sn.isNotEmpty) {
+          invKey = '${s.storeSite}${s.matcode}${s.sn}';
+        } else {
+          invKey = '${s.storeSite}${s.matcode}${s.batchno}';
+        }
+        if (newDicInvMtlQty.containsKey(invKey)) {
+          final value = (newDicInvMtlQty[invKey] ?? 0) - s.collectQty;
+          newDicInvMtlQty[invKey] = value < 0 ? 0 : value;
+        }
+
+        updatedStocks.removeAt(idx);
+      }
+
+      final updateCollectionList = updatedDetailList
+          .where((item) => item.storesiteno == state.storeSite)
+          .toList();
+
+      emit(
+        state.copyWith(
+          stocks: updatedStocks,
+          detailList: updatedDetailList,
+          collectionList: updateCollectionList,
+          dicSeq: newDicSeq,
+          dicMtlQty: newDicMtlQty,
+          dicInvMtlQty: newDicInvMtlQty,
+        ),
+      );
+      await localSave();
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(
+            '从结果页更新采集数据失败：${ErrorHandler.handleError(e)}',
+          ),
+        ),
+      );
+    }
+  }
+
+  /// Fetches barcode content.
+  Future<BarcodeContent> fetchBarcode(String code);
+
+  /// Fetches material control information for the given material code.
+  Future<List<String>> fetchMatControl(String matCode);
+
+  /// Validates store site and returns response map.
+  Future<Map<String, dynamic>> fetchStoreSite(String storeRoomNo, String siteNo);
+
+  /// Fetches inventory information required by [checkInventory].
+  Future<Map<String, dynamic>> fetchInventory({
+    required String storeSite,
+    required BarcodeContent barcode,
+    required String matControlFlag,
+    required String erpRoom,
+  });
+
+  /// Maps collected data to [CollectionStock].
+  CollectionStock mapStock({
+    required String stockId,
+    required String matCode,
+    required String batchNo,
+    required String sn,
+    required double taskQty,
+    required double collectQty,
+    required String outTaskItemId,
+    required String taskId,
+    required String storeRoom,
+    required String storeSite,
+    required String erpStore,
+    required String trayNo,
+  });
+}

--- a/lib/modules/outbound/collection_task/bloc/collection_bloc.dart
+++ b/lib/modules/outbound/collection_task/bloc/collection_bloc.dart
@@ -1,64 +1,44 @@
 import 'dart:developer';
 
-import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:hive/hive.dart';
-import 'package:uuid/uuid.dart';
 import 'package:wms_app/models/page_status.dart';
+import 'package:wms_app/modules/common/collection/base_collection_bloc.dart';
 import 'package:wms_app/modules/outbound/collection_task/bloc/collection_state.dart';
+import 'package:wms_app/modules/outbound/collection_task/models/collection_models.dart';
+import 'package:wms_app/modules/outbound/collection_task/models/collection_request.dart';
+import 'package:wms_app/modules/outbound/collection_task/services/collection_service.dart';
 import 'package:wms_app/modules/outbound/task_list/models/outbound_task.dart';
 import 'package:wms_app/utils/custom_extension.dart';
 import 'package:wms_app/utils/error_handler.dart';
-import '../models/collection_models.dart';
-import '../services/collection_service.dart';
-import 'package:wms_app/modules/outbound/collection_task/models/collection_request.dart';
+
 import 'collection_event.dart';
 
-class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
+class CollectionBloc extends BaseCollectionBloc<OutboundTask> {
   final CollectionService _service;
-  late Box _cacheBox;
-
   late OutboundTask _task;
 
-  String _siteFlag = 'Y';
-  String _batchFlag = 'Y';
-  late int _userId;
-
-  CollectionBloc(this._service) : super(CollectionState()) {
+  CollectionBloc(this._service) : super() {
     on<InitializeTaskEvent>(_onInitializeTask);
-    on<PerformBarcodeEvent>(_onPerformBarcode);
-    on<ChangeTabEvent>(_onChangeTab);
     on<CommitCollectionEvent>(_onCommitCollection);
     on<ReportShortageEvent>(_onReportShortage);
-    on<SetFocusEvent>(_onSetFocus);
-    on<ChangedSelectionEvent>(_onChangedSelection);
-    on<DeleteCollectedStocksEvent>(_onDeleteCollectedStocks);
-    on<UpdateFromResultEvent>(_onUpdateFromResult);
-    on<ResetStatusEvent>(_onResetStatus);
-  }
-
-  void _onResetStatus(ResetStatusEvent event, Emitter<CollectionState> emit) {
-    emit(state.copyWith(status: CollectionStatus.normal()));
-  }
-
-  Future<void> _initHive() async {
-    _cacheBox = await Hive.openBox('collection_cache_${_task.outTaskId}');
   }
 
   Future<void> _onInitializeTask(
     InitializeTaskEvent event,
     Emitter<CollectionState> emit,
   ) async {
-    _userId = event.userId;
     _task = event.task;
+    configureTask(
+      userId: event.userId,
+      taskId: _task.outTaskId.toString(),
+      taskNo: _task.outTaskNo,
+      storeRoomNo: _task.storeRoomNo,
+    );
 
-    _siteFlag = 'Y';
-    _batchFlag = 'Y';
-
-    await _initHive();
-    _clearCache();
+    await openCache('collection_cache_${_task.outTaskId}');
+    await clearCache();
     await loadTaskList(emit);
-    await _restoreFromCache(emit);
+    await restoreFromCache(emit);
   }
 
   Future<void> loadTaskList(Emitter<CollectionState> emit) async {
@@ -80,7 +60,7 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
           sortColumn: '',
           searchKey: '',
           beatFlag: 'N',
-          collecter: _userId,
+          collecter: userId,
         ),
       );
 
@@ -89,7 +69,6 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
         return;
       }
 
-      // 获取物料控制信息
       String roomMatControl = '0';
       final controlResponse = await _service.getRoomMatControl(
         _task.outTaskId.toString(),
@@ -99,13 +78,12 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
         roomMatControl = roomMtlInfo[4];
       }
 
-      // 确定检查模式
       MtlCheckMode mtlCheckMode;
-      if (_siteFlag == 'Y' && _batchFlag == 'Y') {
+      if (siteFlag == 'Y' && batchFlag == 'Y') {
         mtlCheckMode = MtlCheckMode.mtlSiteBatch;
-      } else if (_siteFlag == 'Y' && _batchFlag != 'Y') {
+      } else if (siteFlag == 'Y' && batchFlag != 'Y') {
         mtlCheckMode = MtlCheckMode.mtlSite;
-      } else if (_siteFlag != 'Y' && _batchFlag == 'Y') {
+      } else if (siteFlag != 'Y' && batchFlag == 'Y') {
         mtlCheckMode = MtlCheckMode.mtlBatch;
       } else {
         mtlCheckMode = MtlCheckMode.mtl;
@@ -128,841 +106,6 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
     }
   }
 
-  Future<void> _restoreFromCache(Emitter<CollectionState> emit) async {
-    try {
-      final updateFlag = _cacheBox.get('updateFlag', defaultValue: '0');
-      if (updateFlag == '1') {
-        // 从缓存恢复数据
-        final cachedDetailList = _cacheBox.get(
-          'detailList',
-          defaultValue: <Map>[],
-        );
-        final cachedStocks = _cacheBox.get('stocks', defaultValue: <Map>[]);
-        final cachedDicSeq = Map<String, String>.from(
-          _cacheBox.get('dicSeq', defaultValue: <String, String>{}),
-        );
-        final cachedDicMtlQty = Map<String, List<double>>.from(
-          _cacheBox.get('dicMtlQty', defaultValue: <String, List<double>>{}),
-        );
-        final cachedDicInvMtlQty = Map<String, double>.from(
-          _cacheBox.get('dicInvMtlQty', defaultValue: <String, double>{}),
-        );
-
-        final detailList = cachedDetailList
-            .map<OutTaskItem>(
-              (item) => OutTaskItem.fromJson(Map<String, dynamic>.from(item)),
-            )
-            .toList();
-        final stocks = cachedStocks
-            .map<CollectionStock>(
-              (item) =>
-                  CollectionStock.fromJson(Map<String, dynamic>.from(item)),
-            )
-            .toList();
-
-        emit(
-          state.copyWith(
-            // detailList: detailList,
-            stocks: stocks,
-            dicSeq: cachedDicSeq,
-            dicMtlQty: cachedDicMtlQty,
-            dicInvMtlQty: cachedDicInvMtlQty,
-          ),
-        );
-
-        // await _cacheBox.put('updateFlag', '0');
-      }
-    } catch (e) {
-      emit(
-        state.copyWith(
-          status: CollectionStatus.error('恢复缓存数据失败：${e.toString()}'),
-        ),
-      );
-    }
-  }
-
-  List<OutTaskItem> updateCollectionList(
-    String storeSite,
-    Emitter<CollectionState> emit,
-  ) {
-    if (storeSite.isEmpty) return [];
-
-    final collectionList = state.detailList
-        .where((item) => item.storesiteno == storeSite)
-        .toList();
-
-    return collectionList;
-  }
-
-  Future<void> _onChangeTab(
-    ChangeTabEvent event,
-    Emitter<CollectionState> emit,
-  ) async {
-    emit(state.copyWith(currentTab: event.index));
-  }
-
-  Future<void> _onChangedSelection(
-    ChangedSelectionEvent event,
-    Emitter<CollectionState> emit,
-  ) async {
-    debugPrint('------------- Selected indexes: ${event.ids}');
-    emit(state.copyWith(checkedIds: event.ids));
-  }
-
-  Future<void> _onPerformBarcode(
-    PerformBarcodeEvent event,
-    Emitter<CollectionState> emit,
-  ) async {
-    final barcode = event.barcode;
-    if (barcode.isEmpty) {
-      emit(state.copyWith(status: CollectionStatus.error('采集内容为空,请重新采集')));
-      return;
-    }
-
-    try {
-      // 判断扫码内容类型
-      ScanStep currentStep;
-      if (barcode.contains('MC')) {
-        currentStep = ScanStep.qrcode;
-        await _handleQRCode(barcode, emit);
-      } else if (barcode.contains('\$KW\$')) {
-        currentStep = ScanStep.site;
-        await _handleSite(barcode, emit);
-      } else if (_isNumeric(barcode)) {
-        currentStep = ScanStep.quantity;
-        await _handleQuantity(double.parse(barcode), emit);
-      } else {
-        emit(state.copyWith(status: CollectionStatus.error('采集内容不合法！')));
-        return;
-      }
-
-      var placeholder = await _getPlaceMessage();
-      if (placeholder.isEmpty) {
-        // 所有扫码步骤完成，处理数量
-        await _dealQuantity(state.collectQty, state.matControlFlag, emit);
-      }
-
-      placeholder = placeholder.isEmpty
-          ? (state.storeSite.isEmpty ? '请扫描库位' : '请扫描二维码')
-          : placeholder;
-
-      final focus = placeholder == '请输入数量';
-
-      emit(state.copyWith(placeholder: placeholder, focus: focus));
-    } catch (e) {
-      emit(
-        state.copyWith(
-          status: CollectionStatus.error(ErrorHandler.handleError(e)),
-        ),
-      );
-    }
-  }
-
-  Future<void> _handleQRCode(
-    String barcode,
-    Emitter<CollectionState> emit,
-  ) async {
-    emit(state.copyWith(status: CollectionStatus.loading()));
-
-    // 解析二维码
-    final barcodeContent = await _service.getMaterialInfoByQR(barcode);
-    final newmarttask = barcodeContent.id_old ?? '';
-    final matControl = barcodeContent.seqctrl ?? '';
-
-    // 获取物料控制信息
-    String matSendControl = '0';
-    final mtlInfo = await _service.getMatControl(barcodeContent.matcode!);
-    if (mtlInfo.length > 4 && mtlInfo[4].isNotEmpty) {
-      matSendControl = mtlInfo[4];
-    }
-
-    // 验证序列号和批次
-    final erpRoom = await _validateMaterialControl(
-      barcodeContent,
-      newmarttask,
-      matControl,
-      matSendControl,
-    );
-
-    var newstate = state.copyWith(
-      currentBarcode: barcodeContent,
-      matControlFlag: matControl,
-      matSendControl: matSendControl,
-      collectQty: matControl == '0' ? 1 : state.collectQty,
-      erpRoom: erpRoom,
-      status: CollectionStatus.success(),
-    );
-
-    // 检查库存
-    newstate = await _checkInventory(
-      newstate,
-      newstate.collectQty,
-      newstate.storeSite,
-      emit,
-    );
-    final collectionList = updateCollectionList(newstate.storeSite, emit);
-
-    final newTab = collectionList.isEmpty ? 0 : 1;
-
-    emit(newstate.copyWith(collectionList: collectionList, currentTab: newTab));
-  }
-
-  Future<String?> _validateMaterialControl(
-    BarcodeContent barcodeContent,
-    String newmarttask,
-    String matControl,
-    String matSendControl,
-  ) async {
-    String erpRoom = '';
-    if (matControl == '0') {
-      if ((barcodeContent.sn ?? '').isEmpty) {
-        throw Exception('物料【${barcodeContent.matcode!}】序列号不能为空');
-      }
-
-      final seqKey = '${barcodeContent.matcode!}@${barcodeContent.sn}';
-      if (state.dicSeq.containsKey(seqKey)) {
-        throw Exception(
-          '物料【${barcodeContent.matcode!}】序列号【${barcodeContent.sn}】不允许重复采集，请确认',
-        );
-      }
-    } else if (matControl == '1' || matControl == '2') {
-      // 新格式与老格式的批次号
-      String? batchNo = newmarttask == '0'
-          ? barcodeContent.sn
-          : barcodeContent.batchno;
-
-      if ((matSendControl == '0' && state.roomMatControl == '0') ||
-          state.roomMatControl == '1') {
-        final erpRoom1 = await _checkMaterial(
-          barcodeContent.matcode!,
-          batchNo!,
-          state.storeSite,
-        );
-        if (erpRoom1.isNotEmpty) {
-          erpRoom = erpRoom1;
-        }
-      }
-      final erpRoom2 = await _checkMaterialSite(
-        barcodeContent.matcode!,
-        batchNo!,
-        state.storeSite,
-      );
-      if (erpRoom2.isNotEmpty) {
-        erpRoom = erpRoom2;
-      }
-      return erpRoom;
-    } else {
-      throw Exception('物料${barcodeContent.matcode!}编码控制维护值维护不合法');
-    }
-    return null;
-  }
-
-  Future<String> _checkMaterial(
-    String matcode,
-    String batchno,
-    String storeSite,
-  ) async {
-    bool batchFound = false;
-    String erpRoom = '';
-
-    // 在任务明细中查找物料
-    for (final item in state.detailList) {
-      if (item.matcode == matcode &&
-          item.storesiteno == storeSite &&
-          item.hintbatchno == batchno) {
-        erpRoom = item.subinventoryCode ?? '';
-        batchFound = true;
-        break;
-      }
-    }
-
-    if (!batchFound) {
-      for (final item in state.detailList) {
-        if (item.matcode == matcode && item.storesiteno == storeSite) {
-          erpRoom = item.subinventoryCode ?? '';
-          batchFound = true;
-          break;
-        }
-      }
-    }
-
-    if (!batchFound) {
-      throw Exception('任务明细中物料【$matcode】不存在');
-    }
-    return erpRoom;
-  }
-
-  Future<String> _checkMaterialSite(
-    String matcode,
-    String batchno,
-    String storeSite,
-  ) async {
-    if (isSnTask) return '';
-
-    bool matFind = false;
-    String erpRoom = '';
-
-    // 根据控制模式检查物料
-    for (final item in state.detailList) {
-      bool matches = false;
-
-      switch (state.mtlCheckMode) {
-        case MtlCheckMode.mtlSiteBatch:
-          matches =
-              item.matcode == matcode &&
-              item.hintbatchno == batchno &&
-              item.storesiteno == storeSite;
-          break;
-        case MtlCheckMode.mtlSite:
-          matches = item.matcode == matcode && item.storesiteno == storeSite;
-          break;
-        case MtlCheckMode.mtlBatch:
-          matches = item.matcode == matcode && item.hintbatchno == batchno;
-          break;
-        case MtlCheckMode.mtl:
-          matches = item.matcode == matcode;
-          break;
-      }
-
-      if (matches) {
-        erpRoom = item.subinventoryCode ?? '';
-        matFind = true;
-        break;
-      }
-    }
-
-    if (!matFind) {
-      if (_batchFlag == 'Y') {
-        throw Exception('采集物料【$matcode】批次【$batchno】库位【$storeSite】不在任务明细中，请核实');
-      } else {
-        throw Exception('采集物料【$matcode】库位【$storeSite】不在任务明细中，请核实');
-      }
-    }
-
-    return erpRoom;
-  }
-
-  Future<void> _handleSite(
-    String barcode,
-    Emitter<CollectionState> emit,
-  ) async {
-    final parts = barcode.split('\$');
-    if (parts.length < 3) {
-      throw Exception('库位格式不正确');
-    }
-
-    final siteCode = parts[2];
-
-    emit(state.copyWith(status: CollectionStatus.loading()));
-
-    // 验证库位
-    final response = await _service.getStoreSite(_task.storeRoomNo, siteCode);
-    if (response['code'] != 200) {
-      throw Exception(response['msg'] ?? '库位验证失败');
-    }
-
-    final siteList = response['data'] as List;
-    if (siteList.isEmpty) {
-      throw Exception('库房【${_task.storeRoomNo}}】下无库位号【$siteCode】');
-    }
-
-    if (siteList[0]['isfrozen'] != '0') {
-      throw Exception('库位【$siteCode】被锁定或者冻结');
-    }
-
-    // 检查物料和库位匹配
-    if (state.currentBarcode != null && state.currentBarcode!.isNotEmpty) {
-      if ((state.matSendControl == '0' && state.roomMatControl == '0') ||
-          state.roomMatControl == '1') {
-        await _checkMaterialSite(
-          state.currentBarcode!.matcode ?? '',
-          state.currentBarcode!.batchno ?? '',
-          siteCode,
-        );
-      }
-    }
-
-    var newstate = state.copyWith(storeSite: siteCode);
-
-    // 检查库存
-    newstate = await _checkInventory(
-      newstate,
-      newstate.collectQty,
-      newstate.storeSite,
-      emit,
-    );
-
-    final collectionList = updateCollectionList(newstate.storeSite, emit);
-
-    final newTab = collectionList.isEmpty ? 0 : 1;
-
-    emit(
-      newstate.copyWith(
-        collectionList: collectionList,
-        currentTab: newTab,
-        status: CollectionStatus.success(),
-      ),
-    );
-  }
-
-  /// 是否是序列号任务
-  bool get isSnTask => state.matControlFlag == '0';
-
-  Future<void> _handleQuantity(
-    double quantity,
-    Emitter<CollectionState> emit,
-  ) async {
-    if (isSnTask) {
-      throw Exception('已采集序列号无需采集数量，请扫描二维码');
-    }
-
-    emit(state.copyWith(collectQty: quantity));
-  }
-
-  Future<CollectionState> _checkInventory(
-    CollectionState state,
-    double collectQty,
-    String storeSite,
-    Emitter<CollectionState> emit,
-  ) async {
-    if (state.currentBarcode?.matcode == null || storeSite.isEmpty) {
-      return state;
-    }
-
-    final batchno = state.currentBarcode!.batchno ?? '';
-
-    CollectionState newstate = state;
-
-    List<dynamic> repertoryList = [];
-    double repQty = 0;
-
-    if (state.matControlFlag == '1' || state.matControlFlag == '2') {
-      // 批次管理的库存查询
-      final response = await _service.getRepertoryByStoreSiteNo(
-        storeSite,
-        state.currentBarcode!.matcode ?? '',
-      );
-
-      if (response['code'] == 200) {
-        repertoryList = response['data'];
-
-        // 计算总库存
-        double repqtySum = 0;
-        for (final item in repertoryList) {
-          repqtySum += double.parse(item['repqty']?.toString() ?? '0');
-        }
-        repQty = repqtySum;
-
-        // 检查符合条件的库存
-        final List<dynamic> drcheck = [];
-        if (state.erpRoom.isNotEmpty) {
-          for (final item in repertoryList) {
-            if (item['erpStoreroom'] == state.erpRoom &&
-                item['batchno'] == batchno) {
-              drcheck.add(item);
-              repQty = double.parse(item['repqty']?.toString() ?? '0');
-            }
-          }
-        } else {
-          for (final item in repertoryList) {
-            if (item['batchno'] == batchno) {
-              drcheck.add(item);
-              repQty += double.parse(item['repqty']?.toString() ?? '0');
-            }
-          }
-        }
-
-        if (drcheck.isEmpty || repertoryList.isEmpty) {
-          throw Exception(
-            '物料【${state.currentBarcode!.matcode}】批次【$batchno】在库位【$storeSite】不存在，请确认',
-          );
-        }
-
-        // 检查子库一致性
-        if (state.erpRoom.isNotEmpty && repertoryList.isNotEmpty) {
-          final erpStoreInv = repertoryList[0]['erpStoreroom'];
-          if (erpStoreInv != state.erpRoom) {
-            throw Exception(
-              '当前物料明细指定子库【${state.erpRoom}】与当前库位的物料批次子库【$erpStoreInv】存在不一致，请确认',
-            );
-          }
-          newstate = newstate.copyWith(erpStoreInv: erpStoreInv);
-        }
-      }
-    } else {
-      // 序列号管理的库存查询
-      double repqtySum31 = 0;
-      double repqtySum41 = 0;
-
-      final responseSn = await _service.getRepertoryByStoreSiteNoSn(
-        storeSite,
-        state.currentBarcode!.matcode ?? '',
-        null,
-        null,
-        null,
-      );
-
-      if (responseSn['code'] == 200) {
-        repertoryList = responseSn['data'];
-        if (repertoryList.isNotEmpty) {
-          repQty = double.parse(repertoryList[0]['repqty']?.toString() ?? '0');
-        }
-
-        if (repQty <= 0) {
-          throw Exception(
-            '物料【${state.currentBarcode!.matcode}】批次【$batchno】序列【${state.currentBarcode!.sn}】 在库位【$storeSite】不存在，请确认',
-          );
-        }
-
-        // 根据ERP子库查询
-        if (state.erpRoom.isNotEmpty) {
-          final responseErp = await _service.getRepertoryByStoreSiteNoSn(
-            storeSite,
-            state.currentBarcode!.matcode ?? '',
-            state.erpRoom,
-            state.currentBarcode!.batchno ?? '',
-            state.currentBarcode!.sn ?? '',
-          );
-          if (responseErp['code'] == 200) {
-            final erpList = responseErp['data'] as List;
-            if (erpList.isNotEmpty) {
-              repqtySum31 = double.parse(
-                erpList[0]['repqty']?.toString() ?? '0',
-              );
-            }
-          }
-          repQty = repqtySum31;
-        } else {
-          final responseBatch = await _service.getRepertoryByStoreSiteNoSn(
-            storeSite,
-            state.currentBarcode?.matcode ?? '',
-            null,
-            state.currentBarcode?.batchno ?? '',
-            state.currentBarcode?.sn ?? '',
-          );
-          if (responseBatch['code'] == 200) {
-            final batchList = responseBatch['data'] as List;
-            if (batchList.isNotEmpty) {
-              repqtySum41 = double.parse(
-                batchList[0]['repqty']?.toString() ?? '0',
-              );
-            }
-          }
-          repQty = repqtySum41;
-        }
-
-        if (repQty <= 0) {
-          throw Exception(
-            '物料【${state.currentBarcode!.matcode}】批次【$batchno】序列【${state.currentBarcode!.sn}】在库位【$storeSite】不存在，请确认',
-          );
-        }
-
-        // 获取ERP子库信息
-        final erpResponse = await _service.getRepertoryByStoreSiteNoErp(
-          storeSite,
-          state.currentBarcode!.matcode ?? '',
-        );
-        if (erpResponse['code'] == 200) {
-          final erpList = erpResponse['data'] as List;
-          if (erpList.isNotEmpty) {
-            final erpStoreInv = erpList[0]['erpStoreroom'];
-            if (state.erpRoom.isNotEmpty && erpStoreInv != state.erpRoom) {
-              throw Exception(
-                '当前物料明细指定子库【${state.erpRoom}】与当前库位的物料批次子库【$erpStoreInv】存在不一致，请确认',
-              );
-            }
-            newstate = newstate.copyWith(erpStoreInv: erpStoreInv);
-          }
-        }
-      }
-    }
-
-    return newstate.copyWith(repQty: repQty);
-  }
-
-  Future<String> _getPlaceMessage() async {
-    if (state.storeSite.isEmpty) {
-      return '请扫描库位';
-    }
-    if (state.currentBarcode?.isEmpty ?? true) {
-      return '请扫描二维码';
-    }
-    if (!isSnTask && state.collectQty == 0) {
-      return '请输入数量';
-    }
-    return '';
-  }
-
-  bool _shouldInclude(OutTaskItem item) {
-    bool include = true;
-    switch (state.mtlCheckMode) {
-      case MtlCheckMode.mtlBatch:
-        include = item.hintbatchno == state.currentBarcode?.batchno;
-        break;
-      case MtlCheckMode.mtlSiteBatch:
-        include =
-            item.hintbatchno == state.currentBarcode?.batchno &&
-            item.storesiteno == state.storeSite;
-        break;
-      case MtlCheckMode.mtlSite:
-        include = item.storesiteno == state.storeSite;
-        break;
-      case MtlCheckMode.mtl:
-        include = true;
-        break;
-    }
-    return include;
-  }
-
-  Future<void> _dealQuantity(
-    double count,
-    String matFlag,
-    Emitter<CollectionState> emit,
-  ) async {
-    if (matFlag.isEmpty) {
-      throw Exception('获取物料编码属性失败');
-    }
-
-    final matFlagInt = int.tryParse(matFlag) ?? 0;
-    String sn = '';
-    if (matFlagInt == 0) {
-      sn = state.currentBarcode?.sn ?? '';
-    }
-
-    if (count <= 0) {
-      throw Exception('采集数量必须大于0');
-    }
-
-    // 检查库存是否足够
-    final strKey =
-        '${state.storeSite}${state.currentBarcode?.matcode!}${matFlagInt == 0 ? state.currentBarcode?.sn : state.currentBarcode?.batchno}';
-    final decRepqty = state.dicInvMtlQty[strKey] ?? 0;
-    if (state.repQty - decRepqty < count) {
-      throw Exception(
-        '库位【${state.storeSite}】物料【${state.currentBarcode?.matcode}】的库存【${state.repQty - decRepqty}】小于本次移出库存【$count】，请确认',
-      );
-    }
-
-    // 更新序列号记录
-    final newDicSeq = Map<String, String>.from(state.dicSeq);
-
-    // 更新库存消耗记录
-    final newDicInvMtlQty = Map<String, double>.from(state.dicInvMtlQty);
-    final currentInvQty = newDicInvMtlQty[strKey] ?? 0;
-    newDicInvMtlQty[strKey] = currentInvQty + count;
-
-    final updatedDetailList = List<OutTaskItem>.from(state.detailList);
-    final dicMtlOperation = <String, List<double>>{};
-    final newDicMtlQty = Map<String, List<double>>.from(state.dicMtlQty);
-
-    // 统计当前物料总计划数和总扫描数 - 第一次遍历
-    double totalTaskQty = 0;
-    double totalTmpQty = 0;
-    double totalInventory = state.repQty;
-
-    // 当前操作物料的所有任务项的index
-    final indexes = updatedDetailList
-        .asMap()
-        .entries
-        .where(
-          (e) =>
-              e.value.matcode == state.currentBarcode?.matcode &&
-              _shouldInclude(e.value),
-        )
-        .map((e) => e.key)
-        .toList();
-
-    if (matFlagInt != 0 && indexes.isEmpty) {
-      // 验证是否成功分配
-      throw Exception('采集物料批号序列号信息匹配任务明细失败');
-    }
-
-    for (var index in indexes) {
-      final item = updatedDetailList[index];
-      totalTaskQty += item.hintqty;
-      totalTmpQty += item.collectedqty;
-    }
-
-    totalInventory -= totalTmpQty + count; // 剩余总库存
-
-    // 校验数量是否足够
-    if (totalTmpQty + count > totalTaskQty) {
-      throw Exception('本次采集数量【$count】大于剩余可采集数量【${totalTaskQty - totalTmpQty}】');
-    }
-
-    if (matFlagInt == 0) {
-      // 处理序列号
-      var idx = indexes
-          .where((index) => updatedDetailList[index].sn == sn)
-          .firstOrNull;
-      if (idx != null) {
-        var item = updatedDetailList[idx];
-        item = item.copyWith(collectedqty: 1);
-        updatedDetailList[idx] = item;
-
-        // 记录分配操作（任务的总采集数，本次采集的数量）
-        dicMtlOperation[item.outtaskitemid.toString()] = [1, 1];
-
-        // 更新dicMtlQty (已采集的数量，累计采集的数量)
-        newDicMtlQty[item.outtaskitemid.toString()] = [0, 1];
-
-        newDicSeq['${state.currentBarcode?.matcode}@$sn'] =
-            '${state.currentBarcode?.matcode}@$sn';
-
-        // 添加采集记录
-        await _addCollectData(
-          state.currentBarcode?.matcode ?? '',
-          state.currentBarcode?.batchno ?? '',
-          sn,
-          count,
-          _task.storeRoomNo,
-          state.storeSite,
-          dicMtlOperation,
-          state.erpStoreInv,
-          '',
-          emit,
-        );
-      }
-    } else {
-      // 分配数量到具体任务项
-      double currentCount = count;
-      for (var index in indexes) {
-        var item = updatedDetailList[index];
-        final taskCount = item.hintqty;
-        final collectedCount = item.collectedqty;
-
-        item = item.copyWith(repqty: totalInventory);
-        updatedDetailList[index] = item;
-
-        // 已经完成的跳过
-        if (taskCount == collectedCount || currentCount == 0) continue;
-
-        // 采集数量
-        final tempCount = (taskCount - collectedCount) > currentCount
-            ? currentCount
-            : (taskCount - collectedCount);
-
-        // 剩余采集数量
-        currentCount -= tempCount;
-
-        item = item.copyWith(collectedqty: collectedCount + tempCount);
-        updatedDetailList[index] = item;
-
-        // 初始化 dicMtlQty
-        if (!newDicMtlQty.containsKey(item.outtaskitemid.toString())) {
-          newDicMtlQty[item.outtaskitemid.toString()] = [collectedCount, 0];
-        }
-
-        // 记录分配操作（任务的总采集数，本次采集的数量）
-        dicMtlOperation[item.outtaskitemid.toString()] = [taskCount, tempCount];
-
-        // 更新dicMtlQty (已采集的数量，累计采集的数量)
-        final begin = newDicMtlQty[item.outtaskitemid.toString()]![0];
-        newDicMtlQty[item.outtaskitemid.toString()] = [
-          begin,
-          collectedCount + tempCount,
-        ];
-      }
-
-      // 添加采集记录
-      await _addCollectData(
-        state.currentBarcode?.matcode ?? '',
-        state.currentBarcode?.batchno ?? '',
-        sn,
-        count,
-        _task.storeRoomNo,
-        state.storeSite,
-        dicMtlOperation,
-        state.erpStoreInv,
-        '',
-        emit,
-      );
-    }
-
-    final collectionList = updatedDetailList
-        .where((item) => item.storesiteno == state.storeSite)
-        .toList();
-
-    emit(
-      _initializeCollect().copyWith(
-        detailList: updatedDetailList,
-        collectionList: collectionList,
-        dicSeq: newDicSeq,
-        dicMtlQty: newDicMtlQty,
-        dicInvMtlQty: newDicInvMtlQty,
-        status: CollectionStatus.success('采集成功'),
-      ),
-    );
-
-    await _localSave();
-  }
-
-  Future<void> _addCollectData(
-    String matCode,
-    String batchNo,
-    String sn,
-    double collectQty,
-    String storeRoom,
-    String storeSite,
-    Map<String, List<double>> dicMtlOperation,
-    String erpRoom,
-    String trayNo,
-    Emitter<CollectionState> emit,
-  ) async {
-    final newStocks = List<CollectionStock>.from(state.stocks);
-
-    for (final entry in dicMtlOperation.entries) {
-      final stock = CollectionStock(
-        stockid: const Uuid().v4(),
-        matcode: matCode,
-        batchno: batchNo,
-        sn: sn,
-        taskQty: entry.value[0],
-        collectQty: entry.value[1],
-        outtaskitemid: entry.key,
-        taskid: _task.outTaskId.toString(),
-        storeRoom: storeRoom,
-        storeSite: storeSite,
-        erpStore: erpRoom,
-        trayNo: trayNo,
-      );
-      newStocks.add(stock);
-    }
-
-    emit(state.copyWith(stocks: newStocks));
-  }
-
-  Future<void> _localSave() async {
-    await _cacheBox.put(
-      'detailList',
-      state.detailList.map((e) => e.toJson()).toList(),
-    );
-
-    await _cacheBox.put('stocks', state.stocks.map((e) => e.toJson()).toList());
-    await _cacheBox.put('dicSeq', state.dicSeq);
-    await _cacheBox.put('dicMtlQty', state.dicMtlQty);
-    await _cacheBox.put('dicInvMtlQty', state.dicInvMtlQty);
-    await _cacheBox.put('updateFlag', '1');
-  }
-
-  CollectionState _initializeCollect() {
-    return state.copyWith(
-      status: CollectionStatus.normal(),
-      collectQty: 0,
-      repQty: 0,
-      currentBarcode: BarcodeContent.fromJson({}),
-      focus: false,
-      matControlFlag: '',
-      erpRoom: '',
-      erpStoreInv: '',
-      placeholder: '请扫描库位',
-    );
-  }
-
-  bool _isNumeric(String str) {
-    return RegExp(r'^[0-9]+(\.[0-9]+)?').hasMatch(str);
-  }
-
   Future<void> _onCommitCollection(
     CommitCollectionEvent event,
     Emitter<CollectionState> emit,
@@ -973,7 +116,6 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
         return;
       }
 
-      // 按照原文档逻辑检查未完成任务，生成详细的提示信息
       String msg = '';
       String tmpStore = '';
       String tmpMat = '';
@@ -998,7 +140,6 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
         msg = '请确认是否提交？';
       }
 
-      // 这里应该显示确认对话框，为简化直接处理
       await _performCommit(emit);
     } catch (e) {
       emit(
@@ -1015,13 +156,11 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
     try {
       emit(state.copyWith(status: CollectionStatus.loading()));
 
-      // 再次校验采集数据
       final collectStocks = state.stocks;
       if (collectStocks.isEmpty) {
         throw Exception('本次无采集明细，请确认！');
       }
 
-      // 生成下架信息列表
       final downShelvesInfosList = collectStocks
           .map(
             (stock) => {
@@ -1040,7 +179,6 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
           )
           .toList();
 
-      // 生成任务项列表
       final lsItems = <Map<String, dynamic>>[];
       for (final entry in state.dicMtlQty.entries) {
         final itemListInfo = <String, dynamic>{};
@@ -1048,7 +186,6 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
         itemListInfo['mtlQty'] = mtlQty;
         itemListInfo['outTaskItemid'] = entry.key;
 
-        // 查找物料编码
         final taskItem = state.detailList.firstWhere(
           (item) => item.outtaskitemid.toString() == entry.key,
           orElse: () => OutTaskItem(
@@ -1085,8 +222,7 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
       );
 
       if (response['code'] == 200) {
-        // 清理缓存
-        await _clearCache();
+        await clearCache();
         emit(
           state.copyWith(
             status: CollectionStatus.success(response['msg'] ?? '提交成功'),
@@ -1096,10 +232,6 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
             dicInvMtlQty: {},
           ),
         );
-
-        // 显示成功提示
-        // 在实际应用中应该显示成功对话框并导航回上一页
-        // Navigator.of(context).pop();
       } else {
         emit(
           state.copyWith(
@@ -1136,7 +268,6 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
       final response = await _service.commitFinishOutTaskItem(id);
 
       if (response['code'] == 200) {
-        // 重新加载任务列表
         await loadTaskList(emit);
       } else {
         emit(
@@ -1154,206 +285,208 @@ class CollectionBloc extends Bloc<CollectionEvent, CollectionState> {
     }
   }
 
-  Future<void> _clearCache() async {
-    await _cacheBox.put('stocks', <Map>[]);
-    await _cacheBox.put('updateFlag', '0');
-    await _cacheBox.put('detailList', <Map>[]);
-    await _cacheBox.put('dicMtlQty', <String, List<double>>{});
-    await _cacheBox.put('dicInvMtlQty', <String, double>{});
-    _cacheBox.clear();
+  @override
+  Future<BarcodeContent> fetchBarcode(String code) {
+    return _service.getMaterialInfoByQR(code);
   }
 
-  Future<void> _onUpdateFromResult(
-    UpdateFromResultEvent event,
-    Emitter<CollectionState> emit,
-  ) async {
-    try {
-      if (event.deletedStocks.isEmpty) return;
+  @override
+  Future<List<String>> fetchMatControl(String matCode) async {
+    final response = await _service.getMatControl(matCode);
+    return response.split('!');
+  }
 
-      // 类型安全：集合内应为 CollectionStock
-      final deleted = event.deletedStocks;
-      if (deleted.isEmpty) return;
+  @override
+  Future<Map<String, dynamic>> fetchStoreSite(String storeRoomNo, String siteNo) {
+    return _service.getStoreSite(storeRoomNo, siteNo);
+  }
 
-      final updatedStocks = List<CollectionStock>.from(state.stocks);
-      final updatedDetailList = List<OutTaskItem>.from(state.detailList);
-      final newDicSeq = Map<String, String>.from(state.dicSeq);
-      final newDicMtlQty = Map<String, List<double>>.from(state.dicMtlQty);
-      final newDicInvMtlQty = Map<String, double>.from(state.dicInvMtlQty);
+  @override
+  Future<Map<String, dynamic>> fetchInventory({
+    required String storeSite,
+    required BarcodeContent barcode,
+    required String matControlFlag,
+    required String erpRoom,
+  }) async {
+    final batchno = barcode.batchno ?? '';
+    final matCode = barcode.matcode ?? '';
+    double repQty = 0;
+    String? erpStoreInv;
 
-      for (final s in deleted) {
-        final idx = updatedStocks.indexWhere((x) => x.stockid == s.stockid);
-        if (idx < 0) continue;
+    if (matControlFlag == '1' || matControlFlag == '2') {
+      final response = await _service.getRepertoryByStoreSiteNo(
+        storeSite,
+        matCode,
+      );
 
-        // 1) 明细 collectedqty 扣减
-        final dIdx = updatedDetailList.indexWhere(
-          (d) => d.outtaskitemid.toString() == s.outtaskitemid,
-        );
-        if (dIdx >= 0) {
-          final d = updatedDetailList[dIdx];
-          final newCollected = d.collectedqty - s.collectQty;
-          updatedDetailList[dIdx] = d.copyWith(
-            collectedqty: newCollected < 0 ? 0 : newCollected,
-          );
+      if (response['code'] == 200) {
+        final repertoryList = (response['data'] as List?) ?? [];
+
+        double repqtySum = 0;
+        for (final item in repertoryList) {
+          repqtySum += double.parse(item['repqty']?.toString() ?? '0');
         }
+        repQty = repqtySum;
 
-        // 2) dicSeq 删除 matcode@sn
-        if (s.sn.isNotEmpty) {
-          final seqKey = '${s.matcode}@${s.sn}';
-          newDicSeq.remove(seqKey);
-        }
-
-        // 3) dicMtlQty 扣减第二位（累计采集量）
-        final mtlKey = s.outtaskitemid;
-        final ls2 = List<double>.from(newDicMtlQty[mtlKey] ?? <double>[0, 0]);
-        final newSecond = (ls2.length > 1 ? ls2[1] : 0) - s.collectQty;
-        if (ls2.length > 1) {
-          ls2[1] = newSecond < 0 ? 0 : newSecond;
+        final List<dynamic> drcheck = [];
+        if (erpRoom.isNotEmpty) {
+          for (final item in repertoryList) {
+            if (item['erpStoreroom'] == erpRoom &&
+                item['batchno'] == batchno) {
+              drcheck.add(item);
+              repQty = double.parse(item['repqty']?.toString() ?? '0');
+            }
+          }
         } else {
-          ls2.add(newSecond < 0 ? 0 : newSecond);
-        }
-        newDicMtlQty[mtlKey] = ls2;
-
-        // 4) dicInvMtlQty 扣减库存消耗
-        final invKey = s.sn.isNotEmpty
-            ? '${s.storeSite}${s.matcode}${s.sn}'
-            : '${s.storeSite}${s.matcode}${s.batchno}';
-        final invVal = (newDicInvMtlQty[invKey] ?? 0) - s.collectQty;
-        newDicInvMtlQty[invKey] = invVal < 0 ? 0 : invVal;
-
-        // 5) 从 stocks 移除
-        updatedStocks.removeAt(idx);
-      }
-
-      final updateCollectionList = updatedDetailList
-          .where((item) => item.storesiteno == state.storeSite)
-          .toList();
-
-      emit(
-        state.copyWith(
-          stocks: updatedStocks,
-          detailList: updatedDetailList,
-          collectionList: updateCollectionList,
-          dicSeq: newDicSeq,
-          dicMtlQty: newDicMtlQty,
-          dicInvMtlQty: newDicInvMtlQty,
-        ),
-      );
-      await _localSave();
-    } catch (e) {
-      emit(
-        state.copyWith(
-          status: CollectionStatus.error(
-            '从结果页更新采集数据失败：${ErrorHandler.handleError(e)}',
-          ),
-        ),
-      );
-    }
-  }
-
-  Future<void> _onDeleteCollectedStocks(
-    DeleteCollectedStocksEvent event,
-    Emitter<CollectionState> emit,
-  ) async {
-    try {
-      if (event.stockIds.isEmpty) {
-        emit(state.copyWith(status: CollectionStatus.error('请至少选择一行记录')));
-        return;
-      }
-
-      // 可变副本
-      final updatedStocks = List<CollectionStock>.from(state.stocks);
-      final updatedDetailList = List<OutTaskItem>.from(state.detailList);
-      final newDicSeq = Map<String, String>.from(state.dicSeq);
-      final newDicMtlQty = Map<String, List<double>>.from(state.dicMtlQty);
-      final newDicInvMtlQty = Map<String, double>.from(state.dicInvMtlQty);
-
-      // 逐条删除并扣减关联数据
-      for (final stockId in event.stockIds) {
-        final idx = updatedStocks.indexWhere((s) => s.stockid == stockId);
-        if (idx < 0) continue;
-
-        final s = updatedStocks[idx];
-
-        // 1) 明细 collectedqty 扣减
-        final dIdx = updatedDetailList.indexWhere(
-          (d) => d.outtaskitemid.toString() == s.outtaskitemid,
-        );
-        if (dIdx >= 0) {
-          final d = updatedDetailList[dIdx];
-          final newCollected = (d.collectedqty - s.collectQty);
-          updatedDetailList[dIdx] = d.copyWith(
-            collectedqty: newCollected < 0 ? 0 : newCollected,
-          );
-        }
-
-        // 2) dicSeq 删除 matcode@sn
-        if (s.sn.isNotEmpty) {
-          final seqKey = '${s.matcode}@${s.sn}';
-          if (newDicSeq.containsKey(seqKey)) {
-            newDicSeq.remove(seqKey);
+          for (final item in repertoryList) {
+            if (item['batchno'] == batchno) {
+              drcheck.add(item);
+            }
+          }
+          if (drcheck.isNotEmpty) {
+            repQty = drcheck.fold<double>(
+              0,
+              (previousValue, element) =>
+                  previousValue + double.parse(element['repqty']?.toString() ?? '0'),
+            );
           }
         }
 
-        // 3) dicMtlQty 扣减第二位（累计采集量）
-        final mtlKey = s.outtaskitemid;
-        if (newDicMtlQty.containsKey(mtlKey)) {
-          final ls2 = List<double>.from(newDicMtlQty[mtlKey]!);
-          // ls2 结构： [原tmpQty, 累计采集 qty]
-          final newSecond = (ls2.length > 1 ? ls2[1] : 0) - s.collectQty;
-          if (ls2.length > 1) {
-            ls2[1] = newSecond < 0 ? 0 : newSecond;
-          } else {
-            ls2.add(newSecond < 0 ? 0 : newSecond);
+        if (drcheck.isEmpty || repertoryList.isEmpty) {
+          throw Exception(
+            '物料【${barcode.matcode}】批次【$batchno】在库位【$storeSite】不存在，请确认',
+          );
+        }
+
+        if (erpRoom.isNotEmpty && repertoryList.isNotEmpty) {
+          final erpStoreInvValue = repertoryList[0]['erpStoreroom'];
+          if (erpStoreInvValue != erpRoom) {
+            throw Exception(
+              '当前物料明细指定子库【$erpRoom】与当前库位的物料批次子库【$erpStoreInvValue】存在不一致，请确认',
+            );
           }
-          newDicMtlQty[mtlKey] = ls2;
+          erpStoreInv = erpStoreInvValue?.toString();
         }
-
-        // 4) dicInvMtlQty 扣减库存消耗
-        String invKey = '';
-        if (s.sn.isNotEmpty) {
-          invKey = '${s.storeSite}${s.matcode}${s.sn}';
-        } else {
-          invKey = '${s.storeSite}${s.matcode}${s.batchno}';
-        }
-        if (newDicInvMtlQty.containsKey(invKey)) {
-          final val = (newDicInvMtlQty[invKey] ?? 0) - s.collectQty;
-          newDicInvMtlQty[invKey] = val < 0 ? 0 : val;
-        }
-
-        // 5) 从 stocks 移除
-        updatedStocks.removeAt(idx);
       }
-      final updateCollectionList = updatedDetailList
-          .where((item) => item.storesiteno == state.storeSite)
-          .toList();
+    } else {
+      double repqtySum31 = 0;
+      double repqtySum41 = 0;
 
-      // 写入并持久化
-      emit(
-        state.copyWith(
-          stocks: updatedStocks,
-          detailList: updatedDetailList,
-          collectionList: updateCollectionList,
-          dicSeq: newDicSeq,
-          dicMtlQty: newDicMtlQty,
-          dicInvMtlQty: newDicInvMtlQty,
-        ),
+      final responseSn = await _service.getRepertoryByStoreSiteNoSn(
+        storeSite,
+        matCode,
+        null,
+        null,
+        null,
       );
-      await _localSave();
-    } catch (e) {
-      emit(
-        state.copyWith(
-          status: CollectionStatus.error(
-            '删除采集记录失败：${ErrorHandler.handleError(e)}',
-          ),
-        ),
-      );
+
+      if (responseSn['code'] == 200) {
+        final repertoryList = (responseSn['data'] as List?) ?? [];
+        if (repertoryList.isNotEmpty) {
+          repQty = double.parse(repertoryList[0]['repqty']?.toString() ?? '0');
+        }
+
+        if (repQty <= 0) {
+          throw Exception(
+            '物料【${barcode.matcode}】批次【$batchno】序列【${barcode.sn}】 在库位【$storeSite】不存在，请确认',
+          );
+        }
+
+        if (erpRoom.isNotEmpty) {
+          final responseErp = await _service.getRepertoryByStoreSiteNoSn(
+            storeSite,
+            matCode,
+            erpRoom,
+            barcode.batchno ?? '',
+            barcode.sn ?? '',
+          );
+          if (responseErp['code'] == 200) {
+            final erpList = responseErp['data'] as List;
+            if (erpList.isNotEmpty) {
+              repqtySum31 = double.parse(
+                erpList[0]['repqty']?.toString() ?? '0',
+              );
+            }
+          }
+          repQty = repqtySum31;
+        } else {
+          final responseBatch = await _service.getRepertoryByStoreSiteNoSn(
+            storeSite,
+            matCode,
+            null,
+            barcode.batchno ?? '',
+            barcode.sn ?? '',
+          );
+          if (responseBatch['code'] == 200) {
+            final batchList = responseBatch['data'] as List;
+            if (batchList.isNotEmpty) {
+              repqtySum41 = double.parse(
+                batchList[0]['repqty']?.toString() ?? '0',
+              );
+            }
+          }
+          repQty = repqtySum41;
+        }
+
+        if (repQty <= 0) {
+          throw Exception(
+            '物料【${barcode.matcode}】批次【$batchno】序列【${barcode.sn}】在库位【$storeSite】不存在，请确认',
+          );
+        }
+
+        final erpResponse = await _service.getRepertoryByStoreSiteNoErp(
+          storeSite,
+          matCode,
+        );
+        if (erpResponse['code'] == 200) {
+          final erpList = erpResponse['data'] as List;
+          if (erpList.isNotEmpty) {
+            final erpStoreInvValue = erpList[0]['erpStoreroom'];
+            if (erpRoom.isNotEmpty && erpStoreInvValue != erpRoom) {
+              throw Exception(
+                '当前物料明细指定子库【$erpRoom】与当前库位的物料批次子库【$erpStoreInvValue】存在不一致，请确认',
+              );
+            }
+            erpStoreInv = erpStoreInvValue?.toString();
+          }
+        }
+      }
     }
+
+    return {
+      'repQty': repQty,
+      if (erpStoreInv != null) 'erpStoreInv': erpStoreInv,
+    };
   }
 
-  Future<void> _onSetFocus(
-    SetFocusEvent event,
-    Emitter<CollectionState> emit,
-  ) async {
-    emit(state.copyWith(focus: event.focus));
+  @override
+  CollectionStock mapStock({
+    required String stockId,
+    required String matCode,
+    required String batchNo,
+    required String sn,
+    required double taskQty,
+    required double collectQty,
+    required String outTaskItemId,
+    required String taskId,
+    required String storeRoom,
+    required String storeSite,
+    required String erpStore,
+    required String trayNo,
+  }) {
+    return CollectionStock(
+      stockid: stockId,
+      matcode: matCode,
+      batchno: batchNo,
+      sn: sn,
+      taskQty: taskQty,
+      collectQty: collectQty,
+      outtaskitemid: outTaskItemId,
+      taskid: taskId,
+      storeRoom: storeRoom,
+      storeSite: storeSite,
+      erpStore: erpStore,
+      trayNo: trayNo,
+    );
   }
 }

--- a/test/modules/outbound/collection_task/bloc/collection_bloc_test.dart
+++ b/test/modules/outbound/collection_task/bloc/collection_bloc_test.dart
@@ -1,0 +1,189 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wms_app/modules/outbound/collection_task/bloc/collection_bloc.dart';
+import 'package:wms_app/modules/outbound/collection_task/bloc/collection_state.dart';
+import 'package:wms_app/modules/outbound/collection_task/models/collection_models.dart';
+import 'package:wms_app/modules/outbound/collection_task/models/collection_request.dart';
+import 'package:wms_app/modules/outbound/collection_task/services/collection_service.dart';
+
+class FakeCollectionService extends CollectionService {
+  FakeCollectionService() : super(Dio());
+
+  List<OutTaskItem> detailList = const [];
+  String roomMatControl = '0';
+  BarcodeContent barcodeContent = BarcodeContent.fromJson({});
+  String matControlMessage = '';
+  Map<String, dynamic> storeSiteResponse = const {
+    'code': 200,
+    'data': [
+      {'isfrozen': '0'},
+    ],
+  };
+  Map<String, dynamic> repertoryResponse = const {'code': 200, 'data': []};
+  Map<String, dynamic> repertorySnResponse = const {'code': 200, 'data': []};
+  Map<String, dynamic> repertorySnErpResponse = const {'code': 200, 'data': []};
+  Map<String, dynamic> repertorySnBatchResponse = const {'code': 200, 'data': []};
+  Map<String, dynamic> repertoryErpResponse = const {'code': 200, 'data': []};
+
+  @override
+  Future<List<OutTaskItem>> getOutTaskCollitemList(
+    CollectionTaskItemQuery params,
+  ) async {
+    return detailList;
+  }
+
+  @override
+  Future<String> getRoomMatControl(String taskId) async {
+    return roomMatControl;
+  }
+
+  @override
+  Future<BarcodeContent> getMaterialInfoByQR(String barcode) async {
+    return barcodeContent;
+  }
+
+  @override
+  Future<String> getMatControl(String matcode) async {
+    return matControlMessage;
+  }
+
+  @override
+  Future<Map<String, dynamic>> getStoreSite(
+    String storeRoomNo,
+    String storeSiteNo,
+  ) async {
+    return storeSiteResponse;
+  }
+
+  @override
+  Future<Map<String, dynamic>> getRepertoryByStoreSiteNo(
+    String storesiteno,
+    String matcode,
+  ) async {
+    return repertoryResponse;
+  }
+
+  @override
+  Future<Map<String, dynamic>> getRepertoryByStoreSiteNoSn(
+    String storesiteno,
+    String matcode,
+    String? erpStoreroom,
+    String? batchno,
+    String? sn,
+  ) async {
+    if (erpStoreroom != null) {
+      return repertorySnErpResponse;
+    }
+    if (batchno != null || sn != null) {
+      return repertorySnBatchResponse;
+    }
+    return repertorySnResponse;
+  }
+
+  @override
+  Future<Map<String, dynamic>> getRepertoryByStoreSiteNoErp(
+    String storesiteno,
+    String matcode,
+  ) async {
+    return repertoryErpResponse;
+  }
+}
+
+class TestableCollectionBloc extends CollectionBloc {
+  TestableCollectionBloc(CollectionService service) : super(service);
+
+  void setStateForTest(CollectionState value) {
+    emit(value);
+  }
+}
+
+void main() {
+  group('CollectionBloc base integration', () {
+    late FakeCollectionService service;
+    late TestableCollectionBloc bloc;
+
+    setUp(() {
+      service = FakeCollectionService();
+      bloc = TestableCollectionBloc(service);
+    });
+
+    test('fetchInventory returns batch inventory summary', () async {
+      service.repertoryResponse = {
+        'code': 200,
+        'data': [
+          {'repqty': '2', 'erpStoreroom': 'ERP1', 'batchno': 'B1'},
+          {'repqty': '3', 'erpStoreroom': 'ERP1', 'batchno': 'B1'},
+        ],
+      };
+
+      final result = await bloc.fetchInventory(
+        storeSite: 'A1',
+        barcode: BarcodeContent(matcode: 'MAT1', batchno: 'B1'),
+        matControlFlag: '1',
+        erpRoom: 'ERP1',
+      );
+
+      expect(result['repQty'], 5);
+      expect(result['erpStoreInv'], 'ERP1');
+    });
+
+    test('fetchInventory returns serial inventory summary', () async {
+      service.repertorySnResponse = {
+        'code': 200,
+        'data': [
+          {'repqty': '1'},
+        ],
+      };
+      service.repertorySnErpResponse = {
+        'code': 200,
+        'data': [
+          {'repqty': '1'},
+        ],
+      };
+      service.repertoryErpResponse = {
+        'code': 200,
+        'data': [
+          {'erpStoreroom': 'ERP2'},
+        ],
+      };
+
+      final result = await bloc.fetchInventory(
+        storeSite: 'A1',
+        barcode: BarcodeContent(
+          matcode: 'MAT2',
+          batchno: 'B2',
+          sn: 'SN1',
+        ),
+        matControlFlag: '0',
+        erpRoom: 'ERP2',
+      );
+
+      expect(result['repQty'], 1);
+      expect(result['erpStoreInv'], 'ERP2');
+    });
+
+    test('mapStock builds CollectionStock with provided fields', () {
+      final stock = bloc.mapStock(
+        stockId: 'ID1',
+        matCode: 'MAT1',
+        batchNo: 'B1',
+        sn: 'SN1',
+        taskQty: 1,
+        collectQty: 1,
+        outTaskItemId: 'ITEM1',
+        taskId: 'TASK1',
+        storeRoom: 'ROOM',
+        storeSite: 'SITE',
+        erpStore: 'ERP',
+        trayNo: '',
+      );
+
+      expect(stock.stockid, 'ID1');
+      expect(stock.matcode, 'MAT1');
+      expect(stock.batchno, 'B1');
+      expect(stock.sn, 'SN1');
+      expect(stock.outtaskitemid, 'ITEM1');
+      expect(stock.taskid, 'TASK1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extract the common scanning workflow, cache utilities, and quantity allocation logic into a reusable `BaseCollectionBloc`
- refactor the outbound `CollectionBloc` to extend the base implementation while keeping outbound-specific API calls and state updates
- add unit coverage for the refactored inventory mapping and stock helpers

## Testing
- flutter test test/modules/outbound/collection_task/bloc/collection_bloc_test.dart *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ecc4b86d1c833083352777343a91a1