### PR TITLE
feat(goods_up): build inbound collection workflow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:wms_app/services/user_manager.dart';
 import 'package:wms_app/modules/home/home_page.dart';
 import 'package:wms_app/modules/outbound/collection_task/models/collection_models.dart';
+import 'modules/goods_up/collection_task/models/inbound_collection_models.dart';
 import 'modules/home/login/login_page.dart';
 import 'app_module.dart';
 
@@ -16,6 +17,9 @@ void main() async {
   Hive.registerAdapter(OutTaskItemAdapter());
   Hive.registerAdapter(BarcodeContentAdapter());
   Hive.registerAdapter(CollectionStockAdapter());
+  Hive.registerAdapter(InboundCollectTaskItemAdapter());
+  Hive.registerAdapter(InboundBarcodeContentAdapter());
+  Hive.registerAdapter(InboundCollectionStockAdapter());
   runApp(ModularApp(module: AppModule(), child: const MyApp()));
 }
 

--- a/lib/modules/goods_up/collection_task/bloc/inbound_collection_bloc.dart
+++ b/lib/modules/goods_up/collection_task/bloc/inbound_collection_bloc.dart
@@ -1,0 +1,816 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hive/hive.dart';
+import 'package:uuid/uuid.dart';
+import 'package:wms_app/models/page_status.dart';
+import 'package:wms_app/modules/goods_up/collection_task/bloc/inbound_collection_event.dart';
+import 'package:wms_app/modules/goods_up/collection_task/bloc/inbound_collection_state.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_collection_request.dart';
+import 'package:wms_app/modules/goods_up/services/goods_up_task_service.dart';
+import 'package:wms_app/modules/goods_up/task_list/models/goods_up_task.dart';
+import 'package:wms_app/utils/error_handler.dart';
+
+class InboundCollectionBloc
+    extends Bloc<InboundCollectionEvent, InboundCollectionState> {
+  InboundCollectionBloc({required GoodsUpTaskService service})
+      : _service = service,
+        super(const InboundCollectionState()) {
+    on<InitializeInboundCollectionEvent>(_onInitialize);
+    on<PerformInboundScanEvent>(_onPerformScan);
+    on<ChangeInboundTabEvent>(_onChangeTab);
+    on<CommitInboundCollectionEvent>(_onCommit);
+    on<ResetInboundStatusEvent>(_onResetStatus);
+    on<SetInboundFocusEvent>(_onSetFocus);
+    on<DeleteInboundStocksEvent>(_onDeleteStocks);
+    on<UpdateInboundResultEvent>(_onUpdateFromResult);
+    on<UpdateInboundProductionDateEvent>(_onUpdateProductionDate);
+    on<UpdateInboundExpireDaysEvent>(_onUpdateExpireDays);
+  }
+
+  final GoodsUpTaskService _service;
+  final Uuid _uuid = const Uuid();
+  Box? _cacheBox;
+  GoodsUpTask? _task;
+
+  Future<void> _onInitialize(
+    InitializeInboundCollectionEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    _task = event.task;
+    emit(
+      state.copyWith(
+        status: CollectionStatus.loading(),
+        task: event.task,
+        userId: event.userId,
+        storeRoom: event.task.storeRoomNo ?? '',
+        placeholder: '请扫描库位',
+        scanStep: InboundScanStep.site,
+        storeSite: '',
+      ),
+    );
+
+    try {
+      await _openCacheBox();
+      await _clearCacheIfNeeded();
+      await _loadTaskItems(event, emit);
+      await _restoreCache(emit);
+      emit(state.copyWith(status: CollectionStatus.success()));
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+        ),
+      );
+    }
+  }
+
+  Future<void> _openCacheBox() async {
+    if (_task == null) return;
+    final boxName = 'inbound_collection_cache_${_task!.inTaskId}';
+    _cacheBox ??= await Hive.openBox(boxName);
+  }
+
+  Future<void> _clearCacheIfNeeded() async {
+    if (_cacheBox == null) return;
+    await _cacheBox!.put('updateFlag', '0');
+    await _cacheBox!.put('detailList', const []);
+    await _cacheBox!.put('stocks', const []);
+    await _cacheBox!.put('dicSeq', <String, String>{});
+    await _cacheBox!.put('dicMtlQty', <String, Map<String, dynamic>>{});
+    await _cacheBox!.put('dicInvMtlQty', <String, double>{});
+  }
+
+  Future<void> _loadTaskItems(
+    InitializeInboundCollectionEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final task = event.task;
+    final query = GoodsUpCollectTaskItemQuery(
+      inTaskNo: task.inTaskNo,
+      inTaskId: task.inTaskId,
+      storeRoomNo: task.storeRoomNo ?? '',
+      forceSite: '',
+      forceBatch: '',
+      taskComment: task.taskComment ?? '',
+      taskFinishFlag: '0',
+      roomTag: '0',
+      workStation: task.workStation,
+      sortType: '',
+      sortColumn: '',
+      searchKey: '',
+      userId: event.userId.toString(),
+    );
+
+    final items = await _service.getInboundCollectItems(query: query);
+    final qtyMap = <String, InboundCollectionQty>{};
+    for (final item in items) {
+      final key = item.inTaskItemId.toString();
+      qtyMap[key] = InboundCollectionQty(
+        originalQty: item.collectedQty,
+        currentQty: 0,
+        materialCode: item.materialCode ?? '',
+      );
+    }
+
+    emit(
+      state.copyWith(
+        detailList: items,
+        dicMtlQty: qtyMap,
+      ),
+    );
+  }
+
+  Future<void> _restoreCache(Emitter<InboundCollectionState> emit) async {
+    if (_cacheBox == null) return;
+    final updateFlag = _cacheBox!.get('updateFlag', defaultValue: '0');
+    if (updateFlag != '1') {
+      return;
+    }
+
+    final cachedDetail = _cacheBox!.get('detailList', defaultValue: const []);
+    final cachedStocks = _cacheBox!.get('stocks', defaultValue: const []);
+    final cachedDicSeq = Map<String, String>.from(
+      _cacheBox!.get('dicSeq', defaultValue: <String, String>{}),
+    );
+    final rawDicMtlQty = Map<String, dynamic>.from(
+      _cacheBox!.get('dicMtlQty', defaultValue: <String, dynamic>{}),
+    );
+    final cachedDicMtlQty = rawDicMtlQty.map(
+      (key, value) => MapEntry(
+        key,
+        InboundCollectionQty.fromJson(
+          Map<String, dynamic>.from(value as Map),
+        ),
+      ),
+    );
+    final cachedDicInvMtlQty = Map<String, double>.from(
+      _cacheBox!.get('dicInvMtlQty', defaultValue: <String, double>{}),
+    );
+
+    final detailList = (cachedDetail as List)
+        .map(
+          (e) => InboundCollectTaskItem.fromJson(
+            Map<String, dynamic>.from(e as Map),
+          ),
+        )
+        .toList();
+    final stocks = (cachedStocks as List)
+        .map(
+          (e) => InboundCollectionStock.fromJson(
+            Map<String, dynamic>.from(e as Map),
+          ),
+        )
+        .toList();
+
+    emit(
+      state.copyWith(
+        detailList: detailList.isEmpty ? state.detailList : detailList,
+        stocks: stocks,
+        dicSeq: cachedDicSeq,
+        dicMtlQty: cachedDicMtlQty.isEmpty ? state.dicMtlQty : cachedDicMtlQty,
+        dicInvMtlQty: cachedDicInvMtlQty,
+      ),
+    );
+  }
+
+  Future<void> _onPerformScan(
+    PerformInboundScanEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final barcode = event.barcode.trim();
+    if (barcode.isEmpty) {
+      emit(state.copyWith(status: CollectionStatus.error('采集内容为空,请重新采集')));
+      return;
+    }
+
+    try {
+      switch (state.scanStep) {
+        case InboundScanStep.site:
+          await _handleSite(barcode, emit);
+          break;
+        case InboundScanStep.material:
+          await _handleMaterial(barcode, emit);
+          break;
+        case InboundScanStep.quantity:
+          await _handleQuantity(barcode, emit);
+          break;
+        case InboundScanStep.dangerousSupplement:
+          await _handleDangerousSupplement(barcode, emit);
+          break;
+      }
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _handleSite(
+    String barcode,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final site = barcode.replaceAll('\\$KW\\$', '').trim();
+    if (site.isEmpty) {
+      throw Exception('库位信息不能为空');
+    }
+
+    final room = state.storeRoom;
+    final siteList = await _service.getStoreSiteByRoom(
+      storeRoomNo: room,
+      storeSiteNo: site,
+    );
+    if (siteList.isEmpty) {
+      throw Exception('库房【$room】下无库位号【$site】');
+    }
+
+    final collection = state.detailList
+        .where((item) => (item.storeSiteNo ?? '').trim() == site)
+        .toList();
+
+    emit(
+      state.copyWith(
+        status: CollectionStatus.success(),
+        storeSite: site,
+        scanStep: InboundScanStep.material,
+        placeholder: '请扫描物料二维码',
+        collectionList: collection,
+        focus: true,
+        requireDangerousSupplement: false,
+        currentBarcode: null,
+        repQty: 0,
+        collectQty: 0,
+      ),
+    );
+  }
+
+  Future<void> _handleMaterial(
+    String barcode,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final content = await _service.getInboundBarcodeInfo(barcode);
+    if (content.isEmpty) {
+      throw Exception('物料条码识别出现问题');
+    }
+
+    final materialCode = content.materialKey;
+    final matched = state.detailList
+        .where((item) => (item.materialCode ?? '').trim() == materialCode)
+        .toList();
+    if (matched.isEmpty) {
+      throw Exception('任务明细中物料【$materialCode】不存在');
+    }
+
+    final requireSupplement = _needsDangerousSupplement(content);
+
+    final repQty = await _queryInventory(
+      storeSite: state.storeSite,
+      materialCode: materialCode,
+    );
+
+    emit(
+      state.copyWith(
+        status: CollectionStatus.success(),
+        currentBarcode: content,
+        scanStep: requireSupplement
+            ? InboundScanStep.dangerousSupplement
+            : InboundScanStep.quantity,
+        placeholder: requireSupplement
+            ? '请扫描供应商二维码，采集生产日期、有效期'
+            : '请输入数量',
+        collectQty: requireSupplement ? 0 : (content.quantity ?? 0),
+        requireDangerousSupplement: requireSupplement,
+        repQty: repQty,
+        focus: !requireSupplement,
+      ),
+    );
+  }
+
+  Future<void> _handleDangerousSupplement(
+    String barcode,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final supplement = await _service.getInboundBarcodeInfo(barcode);
+    if (supplement.isEmpty) {
+      throw Exception('供应商二维码识别失败');
+    }
+
+    final current = state.currentBarcode;
+    if (current == null || current.materialKey != supplement.materialKey) {
+      throw Exception('供应商二维码与物料不匹配');
+    }
+
+    final merged = current.copyWith(
+      productionDate: supplement.productionDate ?? current.productionDate,
+      expireDays: supplement.expireDays ?? current.expireDays,
+      quantity: current.quantity ?? supplement.quantity,
+    );
+
+    final requireSupplement = _needsDangerousSupplement(merged);
+
+    emit(
+      state.copyWith(
+        status: CollectionStatus.success(),
+        currentBarcode: merged,
+        scanStep: requireSupplement
+            ? InboundScanStep.dangerousSupplement
+            : InboundScanStep.quantity,
+        placeholder: requireSupplement
+            ? '请扫描供应商二维码，采集生产日期、有效期'
+            : '请输入数量',
+        requireDangerousSupplement: requireSupplement,
+        focus: !requireSupplement,
+      ),
+    );
+  }
+
+  bool _needsDangerousSupplement(InboundBarcodeContent content) {
+    if ((content.dgFlag ?? '').toUpperCase() != 'Y') {
+      return false;
+    }
+    final productionDate = content.productionDate?.trim() ?? '';
+    final expireDays = content.expireDays ?? 0;
+    return productionDate.isEmpty || expireDays <= 0;
+  }
+
+  void _onUpdateProductionDate(
+    UpdateInboundProductionDateEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) {
+    final barcode = state.currentBarcode;
+    if (barcode == null) {
+      return;
+    }
+
+    final trimmed = event.productionDate.trim();
+    final updated = barcode.copyWith(
+      productionDate: trimmed.isEmpty ? null : trimmed,
+      resetProductionDate: trimmed.isEmpty,
+    );
+    final requireSupplement = _needsDangerousSupplement(updated);
+
+    emit(
+      state.copyWith(
+        currentBarcode: updated,
+        requireDangerousSupplement: requireSupplement,
+        scanStep: requireSupplement
+            ? InboundScanStep.dangerousSupplement
+            : InboundScanStep.quantity,
+        placeholder: requireSupplement
+            ? '请扫描供应商二维码，采集生产日期、有效期'
+            : '请输入数量',
+        focus: !requireSupplement,
+      ),
+    );
+  }
+
+  void _onUpdateExpireDays(
+    UpdateInboundExpireDaysEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) {
+    final barcode = state.currentBarcode;
+    if (barcode == null) {
+      return;
+    }
+
+    final trimmed = event.expireDays.trim();
+    final parsed = trimmed.isEmpty ? null : int.tryParse(trimmed);
+    final updated = barcode.copyWith(
+      expireDays: parsed ?? 0,
+      resetExpireDays: trimmed.isEmpty,
+    );
+    final requireSupplement = _needsDangerousSupplement(updated);
+
+    emit(
+      state.copyWith(
+        currentBarcode: updated,
+        requireDangerousSupplement: requireSupplement,
+        scanStep: requireSupplement
+            ? InboundScanStep.dangerousSupplement
+            : InboundScanStep.quantity,
+        placeholder: requireSupplement
+            ? '请扫描供应商二维码，采集生产日期、有效期'
+            : '请输入数量',
+        focus: !requireSupplement,
+      ),
+    );
+  }
+
+  Future<void> _handleQuantity(
+    String barcode,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    final qty = double.tryParse(barcode);
+    if (qty == null || qty <= 0) {
+      throw Exception('采集数量必须大于0');
+    }
+
+    final barcodeContent = state.currentBarcode;
+    if (barcodeContent == null || barcodeContent.isEmpty) {
+      throw Exception('请先扫描物料二维码');
+    }
+
+    final materialCode = barcodeContent.materialKey;
+    final batchNo = (barcodeContent.batchNo ?? '').trim();
+    final serial = (barcodeContent.serialNumber ?? '').trim();
+    final seqCtrl = (barcodeContent.seqCtrl ?? '').trim();
+
+    final matchedItems = state.detailList.where((item) {
+      if ((item.materialCode ?? '').trim() != materialCode) {
+        return false;
+      }
+      if (seqCtrl == '0') {
+        final itemSn = (item.serialNumber ?? '').trim();
+        return itemSn.isEmpty || itemSn == serial;
+      }
+      if (seqCtrl == '1' || seqCtrl == '2') {
+        final itemBatch = (item.batchNo ?? '').trim();
+        if (itemBatch.isEmpty) {
+          return true;
+        }
+        return itemBatch == batchNo;
+      }
+      return true;
+    }).toList();
+
+    if (matchedItems.isEmpty) {
+      throw Exception('采集物料批号序列号信息匹配任务明细失败');
+    }
+
+    double totalPlan = 0;
+    double totalCollected = 0;
+    for (final item in matchedItems) {
+      totalPlan += item.planQty;
+      totalCollected += item.collectedQty;
+    }
+
+    if (totalCollected + qty > totalPlan) {
+      final remain = (totalPlan - totalCollected).toStringAsFixed(2);
+      throw Exception('本次采集数量【$qty】大于剩余可采集数量【$remain】');
+    }
+
+    final updatedItems = List<InboundCollectTaskItem>.from(state.detailList);
+    final dicMtlQty = Map<String, InboundCollectionQty>.from(state.dicMtlQty);
+    final stocks = List<InboundCollectionStock>.from(state.stocks);
+    final dicSeq = Map<String, String>.from(state.dicSeq);
+
+    double remain = qty;
+    for (var i = 0; i < updatedItems.length && remain > 0; i++) {
+      final item = updatedItems[i];
+      if ((item.materialCode ?? '').trim() != materialCode) {
+        continue;
+      }
+      if (seqCtrl == '0') {
+        final itemSn = (item.serialNumber ?? '').trim();
+        if (itemSn.isNotEmpty && itemSn != serial) {
+          continue;
+        }
+        if (serial.isNotEmpty) {
+          final key = '$materialCode@$serial';
+          if (dicSeq.containsKey(key)) {
+            throw Exception('物料$materialCode 序列号【$serial】不允许重复采集，请确认');
+          }
+          dicSeq[key] = key;
+        }
+      }
+      if ((seqCtrl == '1' || seqCtrl == '2') && batchNo.isNotEmpty) {
+        final itemBatch = (item.batchNo ?? '').trim();
+        if (itemBatch.isNotEmpty && itemBatch != batchNo) {
+          continue;
+        }
+      }
+
+      final available = item.planQty - item.collectedQty;
+      if (available <= 0) {
+        continue;
+      }
+
+      final take = remain <= available ? remain : available;
+      remain -= take;
+
+      updatedItems[i] = item.copyWith(collectedQty: item.collectedQty + take);
+
+      final key = item.inTaskItemId.toString();
+      final currentEntry = dicMtlQty[key] ??
+          InboundCollectionQty(
+            originalQty: item.collectedQty,
+            currentQty: 0,
+            materialCode: item.materialCode ?? '',
+          );
+      dicMtlQty[key] = currentEntry.copyWith(
+        currentQty: currentEntry.currentQty + take,
+        materialCode: currentEntry.materialCode.isNotEmpty
+            ? currentEntry.materialCode
+            : (item.materialCode ?? ''),
+      );
+
+      final stock = InboundCollectionStock(
+        stockId: _uuid.v4(),
+        materialCode: materialCode,
+        batchNo: batchNo,
+        serialNumber: serial,
+        planQty: item.planQty,
+        collectQty: take,
+        inTaskItemId: item.inTaskItemId.toString(),
+        taskId: item.inTaskId.toString(),
+        storeRoom: state.storeRoom,
+        storeSite: state.storeSite,
+        productionDate: (barcodeContent.productionDate ?? '').trim().isEmpty
+            ? null
+            : barcodeContent.productionDate,
+        expireDays: barcodeContent.expireDays != null &&
+                barcodeContent.expireDays! > 0
+            ? barcodeContent.expireDays
+            : null,
+        taskNo: _task?.inTaskNo,
+      );
+      stocks.add(stock);
+    }
+
+    if (remain > 0) {
+      throw Exception('采集物料批号序列号信息匹配任务明细失败');
+    }
+
+    final collectionList = updatedItems
+        .where((item) => (item.storeSiteNo ?? '').trim() == state.storeSite)
+        .toList();
+
+    await _localSave(
+      detailList: updatedItems,
+      stocks: stocks,
+      dicSeq: dicSeq,
+      dicMtlQty: dicMtlQty,
+      dicInvMtlQty: state.dicInvMtlQty,
+    );
+
+    emit(
+      state.copyWith(
+        detailList: updatedItems,
+        stocks: stocks,
+        dicSeq: dicSeq,
+        dicMtlQty: dicMtlQty,
+        collectionList: collectionList,
+        status: CollectionStatus.success('采集成功'),
+        scanStep: InboundScanStep.site,
+        placeholder: '请扫描库位',
+        currentTab: stocks.isEmpty ? 0 : 1,
+        focus: true,
+        requireDangerousSupplement: false,
+        currentBarcode: null,
+        collectQty: qty,
+      ),
+    );
+  }
+
+  Future<double> _queryInventory({
+    required String storeSite,
+    required String materialCode,
+  }) async {
+    if (storeSite.isEmpty || materialCode.isEmpty) {
+      return 0;
+    }
+    final rows = await _service.getMtlRepertoryByStoreSite(
+      storeSite: storeSite,
+      materialCode: materialCode,
+    );
+    if (rows.isEmpty) {
+      return 0;
+    }
+    double sum = 0;
+    for (final row in rows) {
+      final qty = row['repqty'];
+      if (qty is num) {
+        sum += qty.toDouble();
+      } else if (qty is String) {
+        sum += double.tryParse(qty) ?? 0;
+      }
+    }
+    return sum;
+  }
+
+  Future<void> _localSave({
+    required List<InboundCollectTaskItem> detailList,
+    required List<InboundCollectionStock> stocks,
+    required Map<String, String> dicSeq,
+    required Map<String, InboundCollectionQty> dicMtlQty,
+    required Map<String, double> dicInvMtlQty,
+  }) async {
+    if (_cacheBox == null) return;
+
+    await _cacheBox!.put('updateFlag', '1');
+    await _cacheBox!.put(
+      'detailList',
+      detailList.map((e) => e.toJson()).toList(),
+    );
+    await _cacheBox!.put(
+      'stocks',
+      stocks.map((e) => e.toJson()).toList(),
+    );
+    await _cacheBox!.put('dicSeq', dicSeq);
+    await _cacheBox!.put(
+      'dicMtlQty',
+      dicMtlQty.map((key, value) => MapEntry(key, value.toJson())),
+    );
+    await _cacheBox!.put('dicInvMtlQty', dicInvMtlQty);
+  }
+
+  Future<void> _onChangeTab(
+    ChangeInboundTabEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    emit(state.copyWith(currentTab: event.index));
+  }
+
+  Future<void> _onCommit(
+    CommitInboundCollectionEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    if (state.stocks.isEmpty) {
+      emit(state.copyWith(status: CollectionStatus.error('本次无采集明细，请确认！')));
+      return;
+    }
+
+    emit(state.copyWith(status: CollectionStatus.loading()));
+
+    try {
+      final upInfos = state.stocks.map((stock) {
+        return {
+          'taskNo': stock.taskNo,
+          'matCode': stock.materialCode,
+          'batchNo': stock.batchNo,
+          'sn': stock.serialNumber,
+          'taskQty': stock.planQty,
+          'collectQty': stock.collectQty,
+          'storeRoomNo': stock.storeRoom,
+          'storeSiteNo': stock.storeSite,
+          'taskid': stock.taskId,
+          'inTaskItemid': stock.inTaskItemId,
+          'data1': stock.productionDate,
+          'data2': stock.expireDays,
+        };
+      }).toList();
+
+      final itemInfos = state.dicMtlQty.entries.map((entry) {
+        final value = entry.value;
+        return {
+          'mtlQty': [value.originalQty, value.currentQty],
+          'inTaskItemid': entry.key,
+          'mtlCode': value.materialCode,
+        };
+      }).toList();
+
+      final filter = state.dicSeq.values.map((e) => '\\"$e\\"').join(',');
+
+      final response = await _service.commitUpShelves(
+        upShelvesInfos: upInfos,
+        itemListInfos: itemInfos,
+        filter: filter,
+      );
+
+      final code = response['code'] as int? ?? 200;
+      if (code != 200) {
+        throw Exception(response['msg']?.toString() ?? '提交失败');
+      }
+
+      await _clearCacheIfNeeded();
+      emit(
+        state.copyWith(
+          status: CollectionStatus.success('提交成功'),
+          stocks: const [],
+          dicSeq: const {},
+          dicMtlQty: const {},
+          collectionList: const [],
+          currentTab: 0,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+        ),
+      );
+    }
+  }
+
+  void _onResetStatus(
+    ResetInboundStatusEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) {
+    emit(state.copyWith(status: CollectionStatus.normal()));
+  }
+
+  void _onSetFocus(
+    SetInboundFocusEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) {
+    emit(state.copyWith(focus: event.focus));
+  }
+
+  Future<void> _onDeleteStocks(
+    DeleteInboundStocksEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    if (event.stockIds.isEmpty) {
+      emit(state.copyWith(status: CollectionStatus.error('请至少选择一条记录')));
+      return;
+    }
+
+    final targets = state.stocks
+        .where((stock) => event.stockIds.contains(stock.stockId))
+        .toList();
+    if (targets.isEmpty) {
+      emit(state.copyWith(status: CollectionStatus.error('未找到可删除的采集记录')));
+      return;
+    }
+
+    await _applyStockDeletion(targets, emit, message: '删除成功');
+  }
+
+  Future<void> _onUpdateFromResult(
+    UpdateInboundResultEvent event,
+    Emitter<InboundCollectionState> emit,
+  ) async {
+    if (event.deletedStocks.isEmpty) {
+      return;
+    }
+
+    await _applyStockDeletion(event.deletedStocks, emit);
+  }
+
+  Future<void> _applyStockDeletion(
+    List<InboundCollectionStock> targets,
+    Emitter<InboundCollectionState> emit, {
+    String? message,
+  }) async {
+    if (targets.isEmpty) {
+      return;
+    }
+
+    final updatedStocks = List<InboundCollectionStock>.from(state.stocks);
+    final updatedDetail = List<InboundCollectTaskItem>.from(state.detailList);
+    final dicSeq = Map<String, String>.from(state.dicSeq);
+    final dicMtlQty = Map<String, InboundCollectionQty>.from(state.dicMtlQty);
+
+    for (final stock in targets) {
+      final idx = updatedStocks.indexWhere((s) => s.stockId == stock.stockId);
+      if (idx < 0) {
+        continue;
+      }
+
+      final removed = updatedStocks.removeAt(idx);
+
+      final detailIdx = updatedDetail.indexWhere(
+        (item) => item.inTaskItemId.toString() == removed.inTaskItemId,
+      );
+      if (detailIdx >= 0) {
+        final detail = updatedDetail[detailIdx];
+        final newCollected = detail.collectedQty - removed.collectQty;
+        updatedDetail[detailIdx] = detail.copyWith(
+          collectedQty: newCollected < 0 ? 0 : newCollected,
+        );
+      }
+
+      final serial = (removed.serialNumber ?? '').trim();
+      if (serial.isNotEmpty) {
+        dicSeq.remove('${removed.materialCode}@$serial');
+      }
+
+      final qtyEntry = dicMtlQty[removed.inTaskItemId];
+      if (qtyEntry != null) {
+        final newCurrent = qtyEntry.currentQty - removed.collectQty;
+        dicMtlQty[removed.inTaskItemId] = qtyEntry.copyWith(
+          currentQty: newCurrent < 0 ? 0 : newCurrent,
+        );
+      }
+    }
+
+    final collectionList = updatedDetail
+        .where((item) => (item.storeSiteNo ?? '').trim() == state.storeSite)
+        .toList();
+
+    await _localSave(
+      detailList: updatedDetail,
+      stocks: updatedStocks,
+      dicSeq: dicSeq,
+      dicMtlQty: dicMtlQty,
+      dicInvMtlQty: state.dicInvMtlQty,
+    );
+
+    emit(
+      state.copyWith(
+        stocks: updatedStocks,
+        detailList: updatedDetail,
+        dicSeq: dicSeq,
+        dicMtlQty: dicMtlQty,
+        collectionList: collectionList,
+        status: message == null
+            ? CollectionStatus.success()
+            : CollectionStatus.success(message),
+        currentTab: updatedStocks.isEmpty ? 0 : state.currentTab,
+      ),
+    );
+  }
+}

--- a/lib/modules/goods_up/collection_task/bloc/inbound_collection_event.dart
+++ b/lib/modules/goods_up/collection_task/bloc/inbound_collection_event.dart
@@ -1,0 +1,91 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/modules/goods_up/task_list/models/goods_up_task.dart';
+
+abstract class InboundCollectionEvent extends Equatable {
+  const InboundCollectionEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class InitializeInboundCollectionEvent extends InboundCollectionEvent {
+  const InitializeInboundCollectionEvent({required this.task, required this.userId});
+
+  final GoodsUpTask task;
+  final int userId;
+
+  @override
+  List<Object?> get props => [task, userId];
+}
+
+class PerformInboundScanEvent extends InboundCollectionEvent {
+  const PerformInboundScanEvent(this.barcode);
+
+  final String barcode;
+
+  @override
+  List<Object?> get props => [barcode];
+}
+
+class ChangeInboundTabEvent extends InboundCollectionEvent {
+  const ChangeInboundTabEvent(this.index);
+
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}
+
+class CommitInboundCollectionEvent extends InboundCollectionEvent {
+  const CommitInboundCollectionEvent();
+}
+
+class ResetInboundStatusEvent extends InboundCollectionEvent {
+  const ResetInboundStatusEvent();
+}
+
+class SetInboundFocusEvent extends InboundCollectionEvent {
+  const SetInboundFocusEvent(this.focus);
+
+  final bool focus;
+
+  @override
+  List<Object?> get props => [focus];
+}
+
+class DeleteInboundStocksEvent extends InboundCollectionEvent {
+  const DeleteInboundStocksEvent(this.stockIds);
+
+  final List<String> stockIds;
+
+  @override
+  List<Object?> get props => [stockIds];
+}
+
+class UpdateInboundResultEvent extends InboundCollectionEvent {
+  const UpdateInboundResultEvent(this.deletedStocks);
+
+  final List<InboundCollectionStock> deletedStocks;
+
+  @override
+  List<Object?> get props => [deletedStocks];
+}
+
+class UpdateInboundProductionDateEvent extends InboundCollectionEvent {
+  const UpdateInboundProductionDateEvent(this.productionDate);
+
+  final String productionDate;
+
+  @override
+  List<Object?> get props => [productionDate];
+}
+
+class UpdateInboundExpireDaysEvent extends InboundCollectionEvent {
+  const UpdateInboundExpireDaysEvent(this.expireDays);
+
+  final String expireDays;
+
+  @override
+  List<Object?> get props => [expireDays];
+}

--- a/lib/modules/goods_up/collection_task/bloc/inbound_collection_state.dart
+++ b/lib/modules/goods_up/collection_task/bloc/inbound_collection_state.dart
@@ -1,0 +1,98 @@
+import 'package:wms_app/models/page_status.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/modules/goods_up/task_list/models/goods_up_task.dart';
+
+class InboundCollectionState {
+  const InboundCollectionState({
+    this.status = const CollectionStatus(CollectionStatusType.normal),
+    this.task,
+    this.detailList = const [],
+    this.collectionList = const [],
+    this.stocks = const [],
+    this.currentBarcode,
+    this.storeSite = '',
+    this.storeRoom = '',
+    this.repQty = 0,
+    this.collectQty = 0,
+    this.placeholder = '请扫描库位',
+    this.currentTab = 0,
+    this.checkedIds = const [],
+    this.dicMtlQty = const {},
+    this.dicSeq = const {},
+    this.dicInvMtlQty = const {},
+    this.scanStep = InboundScanStep.site,
+    this.focus = false,
+    this.requireDangerousSupplement = false,
+    this.userId = 0,
+  });
+
+  final CollectionStatus status;
+  final GoodsUpTask? task;
+  final List<InboundCollectTaskItem> detailList;
+  final List<InboundCollectTaskItem> collectionList;
+  final List<InboundCollectionStock> stocks;
+  final InboundBarcodeContent? currentBarcode;
+  final String storeSite;
+  final String storeRoom;
+  final double repQty;
+  final double collectQty;
+  final String placeholder;
+  final int currentTab;
+  final List<String> checkedIds;
+  final Map<String, InboundCollectionQty> dicMtlQty;
+  final Map<String, String> dicSeq;
+  final Map<String, double> dicInvMtlQty;
+  final InboundScanStep scanStep;
+  final bool focus;
+  final bool requireDangerousSupplement;
+  final int userId;
+
+  InboundCollectionState copyWith({
+    CollectionStatus? status,
+    GoodsUpTask? task,
+    List<InboundCollectTaskItem>? detailList,
+    List<InboundCollectTaskItem>? collectionList,
+    List<InboundCollectionStock>? stocks,
+    InboundBarcodeContent? currentBarcode,
+    String? storeSite,
+    String? storeRoom,
+    double? repQty,
+    double? collectQty,
+    String? placeholder,
+    int? currentTab,
+    List<String>? checkedIds,
+    Map<String, InboundCollectionQty>? dicMtlQty,
+    Map<String, String>? dicSeq,
+    Map<String, double>? dicInvMtlQty,
+    InboundScanStep? scanStep,
+    bool? focus,
+    bool? requireDangerousSupplement,
+    int? userId,
+    bool resetBarcode = false,
+  }) {
+    return InboundCollectionState(
+      status: status ?? this.status,
+      task: task ?? this.task,
+      detailList: detailList ?? this.detailList,
+      collectionList: collectionList ?? this.collectionList,
+      stocks: stocks ?? this.stocks,
+      currentBarcode:
+          resetBarcode ? null : (currentBarcode ?? this.currentBarcode),
+      storeSite: storeSite ?? this.storeSite,
+      storeRoom: storeRoom ?? this.storeRoom,
+      repQty: repQty ?? this.repQty,
+      collectQty: collectQty ?? this.collectQty,
+      placeholder: placeholder ?? this.placeholder,
+      currentTab: currentTab ?? this.currentTab,
+      checkedIds: checkedIds ?? this.checkedIds,
+      dicMtlQty: dicMtlQty ?? this.dicMtlQty,
+      dicSeq: dicSeq ?? this.dicSeq,
+      dicInvMtlQty: dicInvMtlQty ?? this.dicInvMtlQty,
+      scanStep: scanStep ?? this.scanStep,
+      focus: focus ?? this.focus,
+      requireDangerousSupplement:
+          requireDangerousSupplement ?? this.requireDangerousSupplement,
+      userId: userId ?? this.userId,
+    );
+  }
+}

--- a/lib/modules/goods_up/collection_task/config/inbound_collection_grid_config.dart
+++ b/lib/modules/goods_up/collection_task/config/inbound_collection_grid_config.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_collection_models.dart';
+
+class InboundCollectionGridConfig {
+  static List<GridColumnConfig<InboundCollectTaskItem>> taskColumns() {
+    return [
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'matcode',
+        headerText: '物料编码',
+        valueGetter: (item) => item.materialCode ?? '',
+        width: 160,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'storesite',
+        headerText: '库位',
+        valueGetter: (item) => item.storeSiteNo ?? '',
+        width: 150,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'qty',
+        headerText: '任务数量',
+        valueGetter: (item) => item.planQty,
+        width: 110,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'collectedqty',
+        headerText: '采集数量',
+        valueGetter: (item) => item.collectedQty,
+        width: 110,
+        cellTextStyle: const TextStyle(color: Color(0xFF1976D2)),
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'batchno',
+        headerText: '批次',
+        valueGetter: (item) => item.batchNo ?? '',
+        width: 200,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'sn',
+        headerText: '序列',
+        valueGetter: (item) => item.serialNumber ?? '',
+        width: 200,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'subinventory',
+        headerText: '子库',
+        valueGetter: (item) => item.subInventoryCode ?? '',
+        width: 120,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'storeroom',
+        headerText: '库房',
+        valueGetter: (item) => item.storeRoomNo ?? '',
+        width: 120,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'matname',
+        headerText: '物料名称',
+        valueGetter: (item) => item.materialName ?? '',
+        width: 220,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'orderno',
+        headerText: '入库单号',
+        valueGetter: (item) => item.inboundOrderNo ?? '',
+        width: 220,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'innercode',
+        headerText: '物料旧编码',
+        valueGetter: (item) => item.oldMaterialCode ?? '',
+        width: 200,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'taskcomment',
+        headerText: '凭证号',
+        valueGetter: (item) => item.taskComment ?? '',
+        width: 220,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'intaskno',
+        headerText: '任务号',
+        valueGetter: (item) => item.inTaskNo ?? '',
+        width: 180,
+      ),
+      GridColumnConfig<InboundCollectTaskItem>(
+        name: 'intaskitemid',
+        headerText: '任务明细ID',
+        valueGetter: (item) => item.inTaskItemId,
+        width: 120,
+      ),
+    ];
+  }
+
+  static List<GridColumnConfig<InboundCollectionStock>> resultColumns() {
+    return [
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'storesite',
+        headerText: '库位',
+        valueGetter: (item) => item.storeSite,
+        width: 150,
+      ),
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'matcode',
+        headerText: '物料编码',
+        valueGetter: (item) => item.materialCode,
+        width: 160,
+      ),
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'taskqty',
+        headerText: '任务数量',
+        valueGetter: (item) => item.planQty,
+        width: 110,
+      ),
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'collectqty',
+        headerText: '采集数量',
+        valueGetter: (item) => item.collectQty,
+        width: 110,
+      ),
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'batchno',
+        headerText: '批次',
+        valueGetter: (item) => item.batchNo,
+        width: 200,
+      ),
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'sn',
+        headerText: '序列',
+        valueGetter: (item) => item.serialNumber,
+        width: 200,
+      ),
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'storeroom',
+        headerText: '库房',
+        valueGetter: (item) => item.storeRoom,
+        width: 120,
+      ),
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'taskno',
+        headerText: '任务号',
+        valueGetter: (item) => item.taskNo ?? '',
+        width: 160,
+      ),
+      GridColumnConfig<InboundCollectionStock>(
+        name: 'stockid',
+        headerText: '采集ID',
+        valueGetter: (item) => item.stockId,
+        width: 160,
+      ),
+    ];
+  }
+}

--- a/lib/modules/goods_up/collection_task/inbound_collection_page.dart
+++ b/lib/modules/goods_up/collection_task/inbound_collection_page.dart
@@ -1,0 +1,555 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+import 'package:wms_app/modules/goods_up/collection_task/bloc/inbound_collection_bloc.dart';
+import 'package:wms_app/modules/goods_up/collection_task/bloc/inbound_collection_event.dart';
+import 'package:wms_app/modules/goods_up/collection_task/bloc/inbound_collection_state.dart';
+import 'package:wms_app/modules/goods_up/collection_task/config/inbound_collection_grid_config.dart';
+import 'package:wms_app/modules/goods_up/collection_task/inbound_collection_result_page.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_deleted_payload.dart';
+import 'package:wms_app/modules/goods_up/task_list/models/goods_up_task.dart';
+import 'package:wms_app/services/user_manager.dart';
+import 'package:wms_app/utils/custom_extension.dart';
+
+class InboundCollectionPage extends StatefulWidget {
+  const InboundCollectionPage({super.key, required this.task});
+
+  final GoodsUpTask task;
+
+  @override
+  State<InboundCollectionPage> createState() => _InboundCollectionPageState();
+}
+
+class _InboundCollectionPageState extends State<InboundCollectionPage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  late final InboundCollectionBloc _bloc;
+  final ScannerController _scannerController = ScannerController();
+  final TextEditingController _productionController = TextEditingController();
+  final TextEditingController _expireController = TextEditingController();
+  bool _isUpdatingSupplementFields = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<InboundCollectionBloc>(context);
+    _tabController = TabController(length: 2, vsync: this);
+
+    final userInfo = Modular.get<UserManager>().userInfo;
+    if (userInfo != null) {
+      _bloc.add(
+        InitializeInboundCollectionEvent(task: widget.task, userId: userInfo.userId),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    _productionController.dispose();
+    _expireController.dispose();
+    super.dispose();
+  }
+
+  bool canPop() {
+    final state = _bloc.state;
+    return state.stocks.isEmpty;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: canPop(),
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        _handleBackPress(context);
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF6F6F6),
+        appBar: AppBar(
+          backgroundColor: const Color(0xFF1976D2),
+          centerTitle: true,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: () => _handleBackPress(context),
+          ),
+          title: const Text(
+            '平库上架采集',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        body: BlocConsumer<InboundCollectionBloc, InboundCollectionState>(
+          listener: (context, state) {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+
+            if (state.status.isError) {
+              _showErrorDialog(context, state.status.message ?? '采集异常');
+              _bloc.add(const ResetInboundStatusEvent());
+            } else if (state.status.isLoading) {
+              LoadingDialogManager.instance.showLoadingDialog(context);
+            } else if (state.status.isSuccess && state.status.message != null) {
+              LoadingDialogManager.instance.showSnackSuccessMsg(
+                context,
+                state.status.message!,
+                duration: const Duration(milliseconds: 800),
+              );
+              _bloc.add(const ResetInboundStatusEvent());
+            }
+
+            if (state.currentTab != _tabController.index) {
+              _tabController.index = state.currentTab;
+            }
+
+            if (state.focus) {
+              _scannerController.requestFocus();
+              _bloc.add(const SetInboundFocusEvent(false));
+            }
+
+            _isUpdatingSupplementFields = true;
+            final barcode = state.currentBarcode;
+            if (barcode != null) {
+              final production = barcode.productionDate ?? '';
+              if (_productionController.text != production) {
+                _productionController.value = TextEditingValue(
+                  text: production,
+                  selection: TextSelection.collapsed(offset: production.length),
+                );
+              }
+              final expire = barcode.expireDays == null
+                  ? ''
+                  : barcode.expireDays!.toString();
+              if (_expireController.text != expire) {
+                _expireController.value = TextEditingValue(
+                  text: expire,
+                  selection: TextSelection.collapsed(offset: expire.length),
+                );
+              }
+            } else {
+              if (_productionController.text.isNotEmpty) {
+                _productionController.clear();
+              }
+              if (_expireController.text.isNotEmpty) {
+                _expireController.clear();
+              }
+            }
+            _isUpdatingSupplementFields = false;
+
+            _scannerController.clear();
+          },
+          builder: (context, state) {
+            return Column(
+              children: [
+                _buildScanInput(state),
+                _buildInfoCard(state),
+                Container(
+                  decoration: const BoxDecoration(color: Colors.white),
+                  height: 44,
+                  child: TabBar(
+                    controller: _tabController,
+                    labelColor: const Color(0xFF1976D2),
+                    unselectedLabelColor: Colors.grey,
+                    indicatorColor: const Color(0xFF1976D2),
+                    indicatorWeight: 3,
+                    dividerHeight: 0,
+                    labelStyle: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    tabs: const [
+                      Tab(text: '任务列表'),
+                      Tab(text: '正在采集'),
+                    ],
+                    onTap: (index) {
+                      _bloc.add(ChangeInboundTabEvent(index));
+                    },
+                  ),
+                ),
+                Expanded(
+                  child: TabBarView(
+                    controller: _tabController,
+                    children: [
+                      CommonDataGrid<InboundCollectTaskItem>(
+                        columns: InboundCollectionGridConfig.taskColumns(),
+                        datas: state.detailList,
+                        allowPager: false,
+                        allowSelect: false,
+                        currentPage: 1,
+                        totalPages: 1,
+                        onLoadData: (_) async {},
+                        selectedRows: const [],
+                      ),
+                      CommonDataGrid<InboundCollectTaskItem>(
+                        columns: InboundCollectionGridConfig.taskColumns(),
+                        datas: state.collectionList,
+                        allowPager: false,
+                        allowSelect: false,
+                        currentPage: 1,
+                        totalPages: 1,
+                        onLoadData: (_) async {},
+                        selectedRows: const [],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+        bottomNavigationBar: _buildBottomButtons(context),
+      ),
+    );
+  }
+
+  Widget _buildScanInput(InboundCollectionState state) {
+    final keyboardType = state.scanStep == InboundScanStep.quantity
+        ? TextInputType.number
+        : TextInputType.text;
+
+    final config = ScannerConfig().copyWith(
+      placeholder: state.placeholder,
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      height: 48,
+      keyboardType: keyboardType,
+    );
+
+    return ScannerWidget(
+      config: config,
+      controller: _scannerController,
+      onScanResult: (code) {
+        _bloc.add(PerformInboundScanEvent(code));
+      },
+      onError: (message) {
+        _showErrorDialog(context, message);
+      },
+    );
+  }
+
+  Widget _buildInfoCard(InboundCollectionState state) {
+    final barcode = state.currentBarcode;
+    final matCode = barcode?.materialKey ?? '';
+    final batchNo = barcode?.batchNo ?? '';
+    final sn = barcode?.serialNumber ?? '';
+    final matName = barcode?.materialName ?? '';
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(bottom: Radius.circular(8)),
+      ),
+      child: Column(
+        children: [
+          _buildInfoRow(
+            '库位：',
+            state.storeSite,
+            '库存：',
+            state.repQty.toFormatString(),
+          ),
+          _buildDottedDivider(),
+          _buildInfoRow(
+            '物料：',
+            matCode,
+            '采集数量：',
+            state.collectQty == 0 ? '' : state.collectQty.toFormatString(),
+          ),
+          _buildDottedDivider(),
+          _buildInfoRow('名称：', matName, '', ''),
+          _buildDottedDivider(),
+          if (sn.isNotEmpty)
+            _buildInfoRow('序列：', sn, '', '')
+          else
+            _buildInfoRow('批次：', batchNo, '', ''),
+          _buildDottedDivider(),
+          _buildSupplementRow(state),
+          if (state.requireDangerousSupplement)
+            Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: Row(
+                children: [
+                  const Icon(Icons.info_outline,
+                      size: 16, color: Color(0xFFE55D52)),
+                  const SizedBox(width: 6),
+                  const Expanded(
+                    child: Text(
+                      '危化品物料需补录生产日期和有效期后方可继续采集数量',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Color(0xFFE55D52),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(
+    String label1,
+    String value1,
+    String label2,
+    String value2,
+  ) {
+    const labelStyle = TextStyle(fontSize: 14, color: Color(0xFF666666));
+    const valueStyle = TextStyle(
+      fontSize: 14,
+      color: Color(0xFF333333),
+      fontWeight: FontWeight.w500,
+    );
+
+    return SizedBox(
+      height: 30,
+      child: Row(
+        children: [
+          Expanded(
+            child: Row(
+              children: [
+                Text(label1, style: labelStyle),
+                Expanded(
+                  child: Text(
+                    value1,
+                    style: valueStyle,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (label2.isNotEmpty)
+            Expanded(
+              child: Row(
+                children: [
+                  Text(label2, style: labelStyle),
+                  Expanded(
+                    child: Text(
+                      value2,
+                      style: valueStyle,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDottedDivider() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final boxWidth = constraints.maxWidth;
+        const dashWidth = 5.0;
+        const dashSpace = 3.0;
+        final dashCount = (boxWidth / (dashWidth + dashSpace)).floor();
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: List.generate(dashCount, (_) {
+            return const SizedBox(
+              width: dashWidth,
+              height: 1,
+              child: DecoratedBox(
+                decoration: BoxDecoration(color: Color(0xFF0067FC)),
+              ),
+            );
+          }),
+        );
+      },
+    );
+  }
+
+  Widget _buildSupplementRow(InboundCollectionState state) {
+    final isEnabled = state.currentBarcode != null;
+
+    InputDecoration _buildDecoration(String label) {
+      return InputDecoration(
+        isDense: true,
+        labelText: label,
+        border: const OutlineInputBorder(),
+        enabledBorder: const OutlineInputBorder(
+          borderSide: BorderSide(color: Color(0xFFD9D9D9)),
+        ),
+        focusedBorder: const OutlineInputBorder(
+          borderSide: BorderSide(color: Color(0xFF1976D2), width: 1.2),
+        ),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+      );
+    }
+
+    return SizedBox(
+      height: 64,
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _productionController,
+              enabled: isEnabled,
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              decoration: _buildDecoration('生产日期'),
+              onChanged: (value) {
+                if (_isUpdatingSupplementFields) return;
+                _bloc.add(UpdateInboundProductionDateEvent(value));
+              },
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: TextField(
+              controller: _expireController,
+              enabled: isEnabled,
+              keyboardType: TextInputType.number,
+              inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+              decoration: _buildDecoration('有效期(天)'),
+              onChanged: (value) {
+                if (_isUpdatingSupplementFields) return;
+                _bloc.add(UpdateInboundExpireDaysEvent(value));
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBottomButtons(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+      decoration: const BoxDecoration(color: Colors.white),
+      height: 40,
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: () async {
+                final stocks = List<InboundCollectionStock>.from(_bloc.state.stocks);
+                final result = await Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) =>
+                        InboundCollectionResultPage(initialStocks: stocks),
+                  ),
+                );
+                if (!mounted) return;
+                if (result is InboundDeletedStocksPayload &&
+                    result.deletedStocks.isNotEmpty) {
+                  _bloc.add(UpdateInboundResultEvent(result.deletedStocks));
+                  LoadingDialogManager.instance.showSnackSuccessMsg(
+                    context,
+                    '删除成功',
+                    duration: const Duration(milliseconds: 800),
+                  );
+                }
+              },
+              style: OutlinedButton.styleFrom(
+                foregroundColor: const Color(0xFF1976D2),
+                backgroundColor: Colors.transparent,
+                side: const BorderSide(color: Color(0xFF1976D2)),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                padding: EdgeInsets.zero,
+              ),
+              child: const Text('采集结果'),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: ElevatedButton(
+              onPressed: () => _showCommitConfirmation(context),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF1976D2),
+                foregroundColor: Colors.white,
+                padding: EdgeInsets.zero,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+              ),
+              child: const Text('提交'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showCommitConfirmation(BuildContext context) {
+    final state = _bloc.state;
+    if (state.stocks.isEmpty) {
+      _showErrorDialog(context, '本次无采集明细，请确认！');
+      return;
+    }
+
+    String message = '请确认是否提交？';
+    final pending = state.detailList.where((item) => item.planQty > item.collectedQty);
+    if (pending.isNotEmpty) {
+      final item = pending.first;
+      final remain = (item.planQty - item.collectedQty).toFormatString();
+      message =
+          '库位【${item.storeSiteNo ?? ''}】物料【${item.materialCode ?? ''}】还剩【$remain】未采集，是否继续提交？';
+    }
+
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('提交确认'),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              _bloc.add(const CommitInboundCollectionEvent());
+            },
+            child: const Text('确认'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _handleBackPress(BuildContext context) {
+    if (_bloc.state.stocks.isNotEmpty) {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('提示'),
+          content: const Text('当前采集记录尚未提交，确定退出采集吗？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('取消'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                Modular.to.pop();
+              },
+              child: const Text('确认'),
+            ),
+          ],
+        ),
+      );
+    } else {
+      Modular.to.pop();
+    }
+  }
+
+  void _showErrorDialog(BuildContext context, String message) {
+    LoadingDialogManager.instance.showErrorDialog(context, message);
+  }
+}

--- a/lib/modules/goods_up/collection_task/inbound_collection_result_page.dart
+++ b/lib/modules/goods_up/collection_task/inbound_collection_result_page.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/goods_up/collection_task/config/inbound_collection_grid_config.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_collection_models.dart';
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_deleted_payload.dart';
+
+class InboundCollectionResultPage extends StatefulWidget {
+  const InboundCollectionResultPage({super.key, required this.initialStocks});
+
+  final List<InboundCollectionStock> initialStocks;
+
+  @override
+  State<InboundCollectionResultPage> createState() =>
+      _InboundCollectionResultPageState();
+}
+
+class _InboundCollectionResultPageState
+    extends State<InboundCollectionResultPage> {
+  late List<InboundCollectionStock> _stocks;
+  final List<InboundCollectionStock> _deletedBuffer = [];
+  List<int> _selectedIndices = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _stocks = List<InboundCollectionStock>.from(widget.initialStocks);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        _finishWithPayload();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: const Color(0xFF1976D2),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: _finishWithPayload,
+          ),
+          centerTitle: true,
+          title: const Text(
+            '平库上架采集结果',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        backgroundColor: const Color(0xFFF6F6F6),
+        body: Column(
+          children: [
+            Expanded(
+              child: CommonDataGrid<InboundCollectionStock>(
+                columns: InboundCollectionGridConfig.resultColumns(),
+                datas: _stocks,
+                allowPager: false,
+                allowSelect: true,
+                currentPage: 1,
+                totalPages: 1,
+                onLoadData: (_) async {},
+                selectedRows: _selectedIndices,
+                onSelectionChanged: (indices) {
+                  setState(() {
+                    _selectedIndices = indices;
+                  });
+                },
+              ),
+            ),
+            _buildBottomBar(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBottomBar() {
+    if (_stocks.isEmpty) {
+      return const SizedBox(height: 0);
+    }
+
+    final selected = _selectedIndices.length;
+    final total = _stocks.length;
+
+    return Container(
+      height: 52,
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black12,
+            blurRadius: 4,
+            offset: Offset(0, -1),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Text('已选 $selected / $total', style: const TextStyle(fontSize: 14)),
+          const Spacer(),
+          ElevatedButton.icon(
+            onPressed: selected == 0 ? null : () => _confirmDelete(context),
+            icon: const Icon(Icons.delete_outline),
+            label: const Text('删除'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF1976D2),
+              foregroundColor: Colors.white,
+              minimumSize: const Size(96, 36),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmDelete(BuildContext context) {
+    if (_selectedIndices.isEmpty) {
+      LoadingDialogManager.instance
+          .showErrorDialog(context, '请至少选择一条采集记录');
+      return;
+    }
+
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('确认删除'),
+        content: Text('确定删除选中的 ${_selectedIndices.length} 条采集记录吗？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              _performDelete();
+            },
+            child: const Text('确定'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _performDelete() {
+    final toDelete = _selectedIndices
+        .where((i) => i >= 0 && i < _stocks.length)
+        .map((i) => _stocks[i])
+        .toList();
+
+    if (toDelete.isEmpty) {
+      LoadingDialogManager.instance.showErrorDialog(context, '请选择有效记录');
+      return;
+    }
+
+    setState(() {
+      _stocks = _stocks
+          .asMap()
+          .entries
+          .where((entry) => !_selectedIndices.contains(entry.key))
+          .map((entry) => entry.value)
+          .toList();
+      _selectedIndices = const [];
+    });
+
+    _deletedBuffer.addAll(toDelete);
+
+    LoadingDialogManager.instance.showSnackSuccessMsg(
+      context,
+      '删除成功',
+      duration: const Duration(milliseconds: 800),
+    );
+  }
+
+  void _finishWithPayload() {
+    Navigator.of(context).pop(
+      InboundDeletedStocksPayload(List<InboundCollectionStock>.from(_deletedBuffer)),
+    );
+  }
+}

--- a/lib/modules/goods_up/collection_task/models/inbound_collection_models.dart
+++ b/lib/modules/goods_up/collection_task/models/inbound_collection_models.dart
@@ -1,0 +1,402 @@
+import 'package:equatable/equatable.dart';
+import 'package:hive/hive.dart';
+
+part 'inbound_collection_models.g.dart';
+
+@HiveType(typeId: 3)
+class InboundCollectTaskItem extends HiveObject with EquatableMixin {
+  InboundCollectTaskItem({
+    required this.inTaskItemId,
+    required this.inTaskId,
+    this.inTaskNo,
+    this.materialCode,
+    this.materialName,
+    this.oldMaterialCode,
+    this.planQty = 0,
+    this.collectedQty = 0,
+    this.batchNo,
+    this.serialNumber,
+    this.subInventoryCode,
+    this.storeRoomNo,
+    this.storeSiteNo,
+    this.inboundOrderNo,
+    this.taskComment,
+    this.repertoryQty = 0,
+  });
+
+  @HiveField(0)
+  final int inTaskItemId;
+  @HiveField(1)
+  final int inTaskId;
+  @HiveField(2)
+  final String? inTaskNo;
+  @HiveField(3)
+  final String? materialCode;
+  @HiveField(4)
+  final String? materialName;
+  @HiveField(5)
+  final String? oldMaterialCode;
+  @HiveField(6)
+  final double planQty;
+  @HiveField(7)
+  final double collectedQty;
+  @HiveField(8)
+  final String? batchNo;
+  @HiveField(9)
+  final String? serialNumber;
+  @HiveField(10)
+  final String? subInventoryCode;
+  @HiveField(11)
+  final String? storeRoomNo;
+  @HiveField(12)
+  final String? storeSiteNo;
+  @HiveField(13)
+  final String? inboundOrderNo;
+  @HiveField(14)
+  final String? taskComment;
+  @HiveField(15)
+  final double repertoryQty;
+
+  double get remainingQty => planQty - collectedQty;
+
+  InboundCollectTaskItem copyWith({
+    double? planQty,
+    double? collectedQty,
+  }) {
+    return InboundCollectTaskItem(
+      inTaskItemId: inTaskItemId,
+      inTaskId: inTaskId,
+      inTaskNo: inTaskNo,
+      materialCode: materialCode,
+      materialName: materialName,
+      oldMaterialCode: oldMaterialCode,
+      planQty: planQty ?? this.planQty,
+      collectedQty: collectedQty ?? this.collectedQty,
+      batchNo: batchNo,
+      serialNumber: serialNumber,
+      subInventoryCode: subInventoryCode,
+      storeRoomNo: storeRoomNo,
+      storeSiteNo: storeSiteNo,
+      inboundOrderNo: inboundOrderNo,
+      taskComment: taskComment,
+      repertoryQty: repertoryQty,
+    );
+  }
+
+  factory InboundCollectTaskItem.fromJson(Map<String, dynamic> json) {
+    return InboundCollectTaskItem(
+      inTaskItemId: _parseInt(json['intaskitemid']),
+      inTaskId: _parseInt(json['intaskid']),
+      inTaskNo: json['intaskno']?.toString(),
+      materialCode: json['matcode']?.toString(),
+      materialName: json['matname']?.toString(),
+      oldMaterialCode: json['matinnercode']?.toString(),
+      planQty: _parseDouble(json['qty']),
+      collectedQty: _parseDouble(json['collectedqty']),
+      batchNo: json['batchno']?.toString(),
+      serialNumber: json['sn']?.toString(),
+      subInventoryCode: json['subinventoryCode']?.toString(),
+      storeRoomNo: json['storeroomno']?.toString(),
+      storeSiteNo: json['storesiteno']?.toString(),
+      inboundOrderNo: json['orderno']?.toString(),
+      taskComment: json['taskcomment']?.toString(),
+      repertoryQty: _parseDouble(json['repqty']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'intaskitemid': inTaskItemId,
+      'intaskid': inTaskId,
+      'intaskno': inTaskNo,
+      'matcode': materialCode,
+      'matname': materialName,
+      'matinnercode': oldMaterialCode,
+      'qty': planQty,
+      'collectedqty': collectedQty,
+      'batchno': batchNo,
+      'sn': serialNumber,
+      'subinventoryCode': subInventoryCode,
+      'storeroomno': storeRoomNo,
+      'storesiteno': storeSiteNo,
+      'orderno': inboundOrderNo,
+      'taskcomment': taskComment,
+      'repqty': repertoryQty,
+    };
+  }
+
+  static int _parseInt(dynamic value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) {
+      return int.tryParse(value) ?? 0;
+    }
+    return 0;
+  }
+
+  static double _parseDouble(dynamic value) {
+    if (value is double) return value;
+    if (value is int) return value.toDouble();
+    if (value is String) {
+      return double.tryParse(value) ?? 0;
+    }
+    if (value is num) return value.toDouble();
+    return 0;
+  }
+
+  @override
+  List<Object?> get props => [
+        inTaskItemId,
+        inTaskId,
+        inTaskNo,
+        materialCode,
+        planQty,
+        collectedQty,
+        batchNo,
+        serialNumber,
+        storeSiteNo,
+      ];
+}
+
+@HiveType(typeId: 4)
+class InboundBarcodeContent extends HiveObject with EquatableMixin {
+  InboundBarcodeContent({
+    this.materialCode,
+    this.materialName,
+    this.batchNo,
+    this.serialNumber,
+    this.quantity,
+    this.seqCtrl,
+    this.idOld,
+    this.productionDate,
+    this.expireDays,
+    this.dgFlag,
+  });
+
+  @HiveField(0)
+  final String? materialCode;
+  @HiveField(1)
+  final String? materialName;
+  @HiveField(2)
+  final String? batchNo;
+  @HiveField(3)
+  final String? serialNumber;
+  @HiveField(4)
+  final double? quantity;
+  @HiveField(5)
+  final String? seqCtrl;
+  @HiveField(6)
+  final String? idOld;
+  @HiveField(7)
+  final String? productionDate;
+  @HiveField(8)
+  final int? expireDays;
+  @HiveField(9)
+  final String? dgFlag;
+
+  String get materialKey => (materialCode ?? '').trim();
+  bool get isEmpty => materialKey.isEmpty;
+  bool get isNotEmpty => !isEmpty;
+
+  InboundBarcodeContent copyWith({
+    String? productionDate,
+    int? expireDays,
+    double? quantity,
+    bool resetProductionDate = false,
+    bool resetExpireDays = false,
+  }) {
+    return InboundBarcodeContent(
+      materialCode: materialCode,
+      materialName: materialName,
+      batchNo: batchNo,
+      serialNumber: serialNumber,
+      quantity: quantity ?? this.quantity,
+      seqCtrl: seqCtrl,
+      idOld: idOld,
+      productionDate:
+          resetProductionDate ? null : (productionDate ?? this.productionDate),
+      expireDays: resetExpireDays ? null : (expireDays ?? this.expireDays),
+      dgFlag: dgFlag,
+    );
+  }
+
+  factory InboundBarcodeContent.fromJson(Map<String, dynamic> json) {
+    return InboundBarcodeContent(
+      materialCode: json['matcode']?.toString(),
+      materialName: json['matname']?.toString(),
+      batchNo: json['batchno']?.toString(),
+      serialNumber: json['sn']?.toString(),
+      quantity: InboundCollectTaskItem._parseDouble(json['qty']),
+      seqCtrl: json['seqctrl']?.toString(),
+      idOld: json['id_old']?.toString(),
+      productionDate: json['pdate']?.toString(),
+      expireDays: json['vdays'] == null
+          ? null
+          : InboundCollectTaskItem._parseInt(json['vdays']),
+      dgFlag: json['dgFlg']?.toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'matcode': materialCode,
+      'matname': materialName,
+      'batchno': batchNo,
+      'sn': serialNumber,
+      'qty': quantity,
+      'seqctrl': seqCtrl,
+      'id_old': idOld,
+      'pdate': productionDate,
+      'vdays': expireDays,
+      'dgFlg': dgFlag,
+    };
+  }
+
+  @override
+  List<Object?> get props => [
+        materialCode,
+        batchNo,
+        serialNumber,
+        quantity,
+        productionDate,
+        expireDays,
+        dgFlag,
+      ];
+}
+
+@HiveType(typeId: 5)
+class InboundCollectionStock extends HiveObject with EquatableMixin {
+  InboundCollectionStock({
+    required this.stockId,
+    required this.materialCode,
+    required this.batchNo,
+    required this.serialNumber,
+    required this.planQty,
+    required this.collectQty,
+    required this.inTaskItemId,
+    required this.taskId,
+    required this.storeRoom,
+    required this.storeSite,
+    this.productionDate,
+    this.expireDays,
+    this.taskNo,
+  });
+
+  @HiveField(0)
+  final String stockId;
+  @HiveField(1)
+  final String materialCode;
+  @HiveField(2)
+  final String batchNo;
+  @HiveField(3)
+  final String serialNumber;
+  @HiveField(4)
+  final double planQty;
+  @HiveField(5)
+  final double collectQty;
+  @HiveField(6)
+  final String inTaskItemId;
+  @HiveField(7)
+  final String taskId;
+  @HiveField(8)
+  final String storeRoom;
+  @HiveField(9)
+  final String storeSite;
+  @HiveField(10)
+  final String? productionDate;
+  @HiveField(11)
+  final int? expireDays;
+  @HiveField(12)
+  final String? taskNo;
+
+  factory InboundCollectionStock.fromJson(Map<String, dynamic> json) {
+    return InboundCollectionStock(
+      stockId: json['stockid']?.toString() ?? '',
+      materialCode: json['matcode']?.toString() ?? '',
+      batchNo: json['batchno']?.toString() ?? '',
+      serialNumber: json['sn']?.toString() ?? '',
+      planQty: InboundCollectTaskItem._parseDouble(json['taskQty']),
+      collectQty: InboundCollectTaskItem._parseDouble(json['collectQty']),
+      inTaskItemId: json['inTaskItemid']?.toString() ?? '',
+      taskId: json['taskid']?.toString() ?? '',
+      storeRoom: json['storeRoom']?.toString() ?? '',
+      storeSite: json['storeSite']?.toString() ?? '',
+      productionDate: json['data1']?.toString(),
+      expireDays: json['data2'] == null
+          ? null
+          : InboundCollectTaskItem._parseInt(json['data2']),
+      taskNo: json['taskNo']?.toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'stockid': stockId,
+      'matcode': materialCode,
+      'batchno': batchNo,
+      'sn': serialNumber,
+      'taskQty': planQty,
+      'collectQty': collectQty,
+      'inTaskItemid': inTaskItemId,
+      'taskid': taskId,
+      'storeRoom': storeRoom,
+      'storeSite': storeSite,
+      'data1': productionDate,
+      'data2': expireDays,
+      'taskNo': taskNo,
+    };
+  }
+
+  @override
+  List<Object?> get props => [stockId, materialCode, batchNo, serialNumber];
+}
+
+enum InboundScanStep {
+  site,
+  material,
+  quantity,
+  dangerousSupplement,
+}
+
+class InboundCollectionQty extends Equatable {
+  const InboundCollectionQty({
+    required this.originalQty,
+    required this.currentQty,
+    required this.materialCode,
+  });
+
+  final double originalQty;
+  final double currentQty;
+  final String materialCode;
+
+  InboundCollectionQty copyWith({
+    double? originalQty,
+    double? currentQty,
+    String? materialCode,
+  }) {
+    return InboundCollectionQty(
+      originalQty: originalQty ?? this.originalQty,
+      currentQty: currentQty ?? this.currentQty,
+      materialCode: materialCode ?? this.materialCode,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'originalQty': originalQty,
+      'currentQty': currentQty,
+      'materialCode': materialCode,
+    };
+  }
+
+  factory InboundCollectionQty.fromJson(Map<String, dynamic> json) {
+    return InboundCollectionQty(
+      originalQty: InboundCollectTaskItem._parseDouble(json['originalQty']),
+      currentQty: InboundCollectTaskItem._parseDouble(json['currentQty']),
+      materialCode: json['materialCode']?.toString() ?? '',
+    );
+  }
+
+  @override
+  List<Object?> get props => [originalQty, currentQty, materialCode];
+}

--- a/lib/modules/goods_up/collection_task/models/inbound_collection_models.g.dart
+++ b/lib/modules/goods_up/collection_task/models/inbound_collection_models.g.dart
@@ -1,0 +1,189 @@
+// GENERATED CODE - MANUAL IMPLEMENTATION
+
+part of 'inbound_collection_models.dart';
+
+class InboundCollectTaskItemAdapter
+    extends TypeAdapter<InboundCollectTaskItem> {
+  @override
+  final int typeId = 3;
+
+  @override
+  InboundCollectTaskItem read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{};
+    for (var i = 0; i < numOfFields; i++) {
+      fields[reader.readByte()] = reader.read();
+    }
+    return InboundCollectTaskItem(
+      inTaskItemId: fields[0] as int,
+      inTaskId: fields[1] as int,
+      inTaskNo: fields[2] as String?,
+      materialCode: fields[3] as String?,
+      materialName: fields[4] as String?,
+      oldMaterialCode: fields[5] as String?,
+      planQty: (fields[6] as num?)?.toDouble() ?? 0,
+      collectedQty: (fields[7] as num?)?.toDouble() ?? 0,
+      batchNo: fields[8] as String?,
+      serialNumber: fields[9] as String?,
+      subInventoryCode: fields[10] as String?,
+      storeRoomNo: fields[11] as String?,
+      storeSiteNo: fields[12] as String?,
+      inboundOrderNo: fields[13] as String?,
+      taskComment: fields[14] as String?,
+      repertoryQty: (fields[15] as num?)?.toDouble() ?? 0,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, InboundCollectTaskItem obj) {
+    writer
+      ..writeByte(16)
+      ..writeByte(0)
+      ..write(obj.inTaskItemId)
+      ..writeByte(1)
+      ..write(obj.inTaskId)
+      ..writeByte(2)
+      ..write(obj.inTaskNo)
+      ..writeByte(3)
+      ..write(obj.materialCode)
+      ..writeByte(4)
+      ..write(obj.materialName)
+      ..writeByte(5)
+      ..write(obj.oldMaterialCode)
+      ..writeByte(6)
+      ..write(obj.planQty)
+      ..writeByte(7)
+      ..write(obj.collectedQty)
+      ..writeByte(8)
+      ..write(obj.batchNo)
+      ..writeByte(9)
+      ..write(obj.serialNumber)
+      ..writeByte(10)
+      ..write(obj.subInventoryCode)
+      ..writeByte(11)
+      ..write(obj.storeRoomNo)
+      ..writeByte(12)
+      ..write(obj.storeSiteNo)
+      ..writeByte(13)
+      ..write(obj.inboundOrderNo)
+      ..writeByte(14)
+      ..write(obj.taskComment)
+      ..writeByte(15)
+      ..write(obj.repertoryQty);
+  }
+}
+
+class InboundBarcodeContentAdapter
+    extends TypeAdapter<InboundBarcodeContent> {
+  @override
+  final int typeId = 4;
+
+  @override
+  InboundBarcodeContent read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{};
+    for (var i = 0; i < numOfFields; i++) {
+      fields[reader.readByte()] = reader.read();
+    }
+    return InboundBarcodeContent(
+      materialCode: fields[0] as String?,
+      materialName: fields[1] as String?,
+      batchNo: fields[2] as String?,
+      serialNumber: fields[3] as String?,
+      quantity: (fields[4] as num?)?.toDouble(),
+      seqCtrl: fields[5] as String?,
+      idOld: fields[6] as String?,
+      productionDate: fields[7] as String?,
+      expireDays: fields[8] as int?,
+      dgFlag: fields[9] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, InboundBarcodeContent obj) {
+    writer
+      ..writeByte(10)
+      ..writeByte(0)
+      ..write(obj.materialCode)
+      ..writeByte(1)
+      ..write(obj.materialName)
+      ..writeByte(2)
+      ..write(obj.batchNo)
+      ..writeByte(3)
+      ..write(obj.serialNumber)
+      ..writeByte(4)
+      ..write(obj.quantity)
+      ..writeByte(5)
+      ..write(obj.seqCtrl)
+      ..writeByte(6)
+      ..write(obj.idOld)
+      ..writeByte(7)
+      ..write(obj.productionDate)
+      ..writeByte(8)
+      ..write(obj.expireDays)
+      ..writeByte(9)
+      ..write(obj.dgFlag);
+  }
+}
+
+class InboundCollectionStockAdapter
+    extends TypeAdapter<InboundCollectionStock> {
+  @override
+  final int typeId = 5;
+
+  @override
+  InboundCollectionStock read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{};
+    for (var i = 0; i < numOfFields; i++) {
+      fields[reader.readByte()] = reader.read();
+    }
+    return InboundCollectionStock(
+      stockId: fields[0] as String,
+      materialCode: fields[1] as String,
+      batchNo: fields[2] as String,
+      serialNumber: fields[3] as String,
+      planQty: (fields[4] as num).toDouble(),
+      collectQty: (fields[5] as num).toDouble(),
+      inTaskItemId: fields[6] as String,
+      taskId: fields[7] as String,
+      storeRoom: fields[8] as String,
+      storeSite: fields[9] as String,
+      productionDate: fields[10] as String?,
+      expireDays: fields[11] as int?,
+      taskNo: fields[12] as String?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, InboundCollectionStock obj) {
+    writer
+      ..writeByte(13)
+      ..writeByte(0)
+      ..write(obj.stockId)
+      ..writeByte(1)
+      ..write(obj.materialCode)
+      ..writeByte(2)
+      ..write(obj.batchNo)
+      ..writeByte(3)
+      ..write(obj.serialNumber)
+      ..writeByte(4)
+      ..write(obj.planQty)
+      ..writeByte(5)
+      ..write(obj.collectQty)
+      ..writeByte(6)
+      ..write(obj.inTaskItemId)
+      ..writeByte(7)
+      ..write(obj.taskId)
+      ..writeByte(8)
+      ..write(obj.storeRoom)
+      ..writeByte(9)
+      ..write(obj.storeSite)
+      ..writeByte(10)
+      ..write(obj.productionDate)
+      ..writeByte(11)
+      ..write(obj.expireDays)
+      ..writeByte(12)
+      ..write(obj.taskNo);
+  }
+}

--- a/lib/modules/goods_up/collection_task/models/inbound_collection_request.dart
+++ b/lib/modules/goods_up/collection_task/models/inbound_collection_request.dart
@@ -1,0 +1,69 @@
+class GoodsUpCollectTaskItemQuery {
+  GoodsUpCollectTaskItemQuery({
+    required this.inTaskNo,
+    required this.inTaskId,
+    required this.storeRoomNo,
+    this.forceSite = '',
+    this.forceBatch = '',
+    this.taskComment = '',
+    this.taskFinishFlag = '0',
+    this.roomTag = '0',
+    this.workStation,
+    this.sortType = '',
+    this.sortColumn = '',
+    this.searchKey = '',
+    required this.userId,
+  });
+
+  final String inTaskNo;
+  final int inTaskId;
+  final String storeRoomNo;
+  final String forceSite;
+  final String forceBatch;
+  final String taskComment;
+  final String taskFinishFlag;
+  final String roomTag;
+  final String? workStation;
+  final String sortType;
+  final String sortColumn;
+  final String searchKey;
+  final String userId;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'intaskno': inTaskNo,
+      'intaskid': inTaskId,
+      'storeroomno': storeRoomNo,
+      'forcesite': forceSite,
+      'forcebatch': forceBatch,
+      'taskcomment': taskComment,
+      'taskFinishFlag': taskFinishFlag,
+      'roomtag': roomTag,
+      if (workStation != null) 'workstation': workStation,
+      'sortType': sortType,
+      'sortColumn': sortColumn,
+      'searchKey': searchKey,
+      'userId': userId,
+    };
+  }
+}
+
+class InboundCommitRequest {
+  InboundCommitRequest({
+    required this.upShelvesInfos,
+    required this.itemListInfos,
+    this.filter = '',
+  });
+
+  final List<Map<String, dynamic>> upShelvesInfos;
+  final List<Map<String, dynamic>> itemListInfos;
+  final String filter;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'upShelvesInfos': upShelvesInfos,
+      'itemListInfos': itemListInfos,
+      'filter': filter,
+    };
+  }
+}

--- a/lib/modules/goods_up/collection_task/models/inbound_deleted_payload.dart
+++ b/lib/modules/goods_up/collection_task/models/inbound_deleted_payload.dart
@@ -1,0 +1,7 @@
+import 'package:wms_app/modules/goods_up/collection_task/models/inbound_collection_models.dart';
+
+class InboundDeletedStocksPayload {
+  const InboundDeletedStocksPayload(this.deletedStocks);
+
+  final List<InboundCollectionStock> deletedStocks;
+}

--- a/lib/modules/goods_up/goods_up_module.dart
+++ b/lib/modules/goods_up/goods_up_module.dart
@@ -5,6 +5,8 @@ import 'package:flutter_modular/flutter_modular.dart';
 import '../../app_module.dart';
 import '../../services/dio_client.dart';
 import '../../services/user_manager.dart';
+import 'collection_task/bloc/inbound_collection_bloc.dart';
+import 'collection_task/inbound_collection_page.dart';
 import 'services/goods_up_task_service.dart';
 import 'task_details/bloc/goods_up_task_detail_bloc.dart';
 import 'task_details/goods_up_task_detail_page.dart';
@@ -52,6 +54,10 @@ class GoodsUpModule extends Module {
         i.get<GoodsUpTaskService>(),
         i.get<UserManager>(),
       ),
+    );
+
+    i.add<InboundCollectionBloc>(
+      () => InboundCollectionBloc(service: i.get<GoodsUpTaskService>()),
     );
   }
 
@@ -108,6 +114,20 @@ class GoodsUpModule extends Module {
         return BlocProvider(
           create: (_) => Modular.get<InboundReceiveTaskDetailBloc>(),
           child: GoodsUpReceiveDetailPage(task: task),
+        );
+      },
+    );
+
+    r.child(
+      '/collection',
+      child: (_) {
+        final task = Modular.args.data as GoodsUpTask?;
+        if (task == null) {
+          return const _TodoPlaceholder(title: '缺少任务信息，无法进入采集页面');
+        }
+        return BlocProvider(
+          create: (_) => Modular.get<InboundCollectionBloc>(),
+          child: InboundCollectionPage(task: task),
         );
       },
     );


### PR DESCRIPTION
## Summary
- implement inbound collection page with scanner-driven workflow, info cards, and commit confirmation
- add reusable grid configs, result list page, and deletion payload model for inbound collection records
- upgrade inbound collection bloc to track session quantities, restore caches, synchronize deletions, with module route bindings
- allow manual supplement entry of production date and validity days for dangerous goods, keeping bloc placeholders, focus, and commit payloads in sync

## Testing
- dart format lib/modules/goods_up/collection_task/bloc/inbound_collection_bloc.dart lib/modules/goods_up/collection_task/bloc/inbound_collection_event.dart lib/modules/goods_up/collection_task/inbound_collection_page.dart lib/modules/goods_up/collection_task/models/inbound_collection_models.dart *(fails: dart command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68eccece0c308330aa819c13d5703cae