### PR TITLE
Add arrival sign collect workflow

### DIFF
--- a/docs/arrive_sign_refactor/detail_page_todo.md
+++ b/docs/arrive_sign_refactor/detail_page_todo.md
@@ -1,0 +1,42 @@
+# 到货任务明细页重构 TODO（原 `pages/arrive_sign/detail.nvue`）
+
+## 目标
+- 基于 Flutter 页面展示到货单明细，沿用 `CommonDataGrid` 表格体验。
+- 支持分页、扫码刷新、从列表页带参跳转、返回列表。
+
+## 待办清单
+### 路由与依赖
+- [x] 在 `arrival_sign_module.dart` 中注册 `/arrival-sign/detail` 路由，接收 `arrivalsBillId` 参数，保持与出库明细页路由风格一致。
+- [x] 提前在模块注入 `ArrivalSignService` 供 bloc 使用。
+
+### 数据模型（Freezed）
+- [x] 使用 `freezed` 定义 `ArrivalSignDetail` 模型，字段覆盖原始列（matcode、qty、goodqty、batchno、sn、subinventoryCode、posnr、matname、parname、matcodecontrol、orderno、arrivalsBillno、pdate、vdays 等）。
+- [x] 定义 `ArrivalSignDetailQuery`（含分页参数）与 `ArrivalSignDetailPage`（total/rows）。
+
+### 服务层
+- [x] 在 `ArrivalSignService` 内新增 `getArrivalSignDetails(ArrivalSignDetailQuery)` 调用 `/system/terminal/arriveSignDetailList`。
+- [x] 支持可选 `searchKey` 用于扫码过滤。
+
+### 状态管理
+- [x] 创建 `ArrivalSignDetailBloc`（或使用 `CommonDataGridBloc<ArrivalSignDetail>` 包装），事件包括：初始化加载、分页切换、刷新。
+- [x] 使用 `freezed` 定义事件与状态，状态需保存 `currentPage`、`totalPages`、`loading`、`errorMessage`、`details`。
+
+### UI 实现
+- [x] 构建 `ArrivalSignDetailPage`，包含：
+  - `CustomAppBar` 标题“到货任务明细”，返回按钮 `Navigator.pop`。
+  - `CommonDataGrid` 渲染列头，与 uni-app 顺序保持一致。
+  - 底部分页器（可使用 `CommonDataGrid` 自带分页功能或手动 `PaginationFooter`）。
+- [x] 如果需要扫码过滤，复用 `ScannerWidget`（可隐藏在 AppBar actions 或顶部输入框）。
+- [x] Loading/空态/错误使用 `LoadingDialogManager` 与 `CommonDataGrid` 状态统一处理。
+
+### 导航交互
+- [x] 确保从列表页传入的 `arrivalsBillId` 正确注入到 bloc query，首屏自动加载。
+- [x] 返回时无需额外确认；保留页面 pop 即可。
+
+### 校验
+- [x] 数据为空时提示“当前任务列表没有待处理任务！”（可用 `SnackBar` 或空态组件）。
+- [x] 捕获服务异常并弹出错误提示。
+
+### 测试
+- [ ] Bloc 单元测试：校验初始加载成功/失败、分页切换逻辑。
+- [ ] Widget 测试：验证表头渲染、空态展示。

--- a/docs/arrive_sign_refactor/index_list_todo.md
+++ b/docs/arrive_sign_refactor/index_list_todo.md
@@ -1,0 +1,51 @@
+# 到货签收列表页重构 TODO（原 `pages/arrive_sign/index.nvue`）
+
+## 目标
+- 复刻 uni-app 已签收待采集列表的业务逻辑，并对标 Flutter 已有的“平库出库任务列表”页面（`lib/modules/outbound/task_list/outbound_task_list_page.dart`）。
+- 支持扫码搜索、分页、到货单撤销、跳转到采集/明细/接收页面。
+- 采用模块化、BLoC、Freezed 数据模型等既有 Flutter 架构。
+
+## 待办清单
+### 模块与路由
+- [x] 在 `lib/modules` 下创建 `arrival_sign` 模块目录（参照 `lib/modules/outbound` 与 `lib/modules/goods_up` 结构），新增 `arrival_sign_module.dart` 注册列表页、详情页、采集页、采集结果页、接收页、接收明细页路由。
+- [x] 在 `AppModule` 中挂载新模块或在父模块中声明 `/arrival-sign/...` 路径，保持与现有路由风格一致。
+
+### 数据模型（Freezed）
+- [x] 使用 `freezed` + `json_serializable` 定义 `ArrivalSignTask`、`ArrivalSignTaskPage` 等实体，字段覆盖接口 `/system/terminal/arriveSignList` 返回的 `rows` 与分页元数据，参考 `lib/modules/outbound/task_list/models/outbound_task.dart`。
+- [x] 增加 `ArrivalSignSummaryAction`（或在 UI 层定义按钮配置）枚举/模型用于描述“采集/明细/撤销”操作按钮。
+
+### 服务层
+- [x] 在 `lib/modules/arrival_sign/services/arrival_sign_service.dart` 内封装接口：`getArrivalSignTasks`、`cancelArrivalSign`，请求参数对齐 `api.md` 4.1，复用 `ApiService`/`DioClient` 模板。
+- [x] 为扫码搜索补充查询参数（searchKey、sortType、PageIndex、PageSize 等），并在服务层设置默认分页大小 100。
+
+### 状态管理
+- [x] 创建 `ArrivalSignListBloc`，事件包括：初始化加载、扫码/输入搜索、分页跳转、撤销单据、刷新（参照 `OutboundTaskBloc`）。
+- [x] 使用 `freezed` 定义事件、状态（含 `GridStatus` 对应字段），并内嵌/组合 `CommonDataGridBloc<ArrivalSignTask>` 或复用现有 `CommonDataGridBloc` 逻辑。
+- [x] 确保撤销成功后派发刷新事件并处理 loading/error/empty 状态。
+
+### UI 实现
+- [x] 新建 `arrival_sign_list_page.dart`（命名可为 `arrival_sign_task_list_page.dart`）沿用 `CustomAppBar` 与 `ScannerWidget`，标题“到货接收”，右上角 `IconButton` 跳转到接收任务页 `/arrival-sign/receive`。
+- [x] 页面主体使用 `CommonDataGrid` 构建表格列（“操作/装箱单号/采购单号/到货日期/到货单号/工厂/供应商/到货单ID”），列配置参考原始表头与 `OutboundTaskGridConfig`。
+- [x] 在 `CommonDataGrid` 的操作列中渲染 3 个按钮（采集/明细/撤销），调用 bloc 发出 `NavigateToCollect`/`NavigateToDetail`/`CancelOrder` 等事件。
+- [x] 集成扫码输入：`ScannerWidget` 成功回调触发搜索事件，错误回调使用 `LoadingDialogManager` 弹窗。
+- [x] 为分页器实现事件：调用 `CommonDataGridBloc` 的 `LoadDataEvent` 或自定义分页事件。
+- [x] 撤销操作需通过 `showDialog`/`LoadingDialogManager` 弹出确认框，成功后提示 `SnackBar`/`Dialog`。
+
+### 交互 & 导航
+- [x] 完成导航逻辑：
+  - 采集按钮 -> `/arrival-sign/collect`，传递整行数据（使用 `jsonEncode` 或模型实例）。
+  - 明细按钮 -> `/arrival-sign/detail?arrivalsBillId=...`。
+  - 右上角 + 按钮 -> `/arrival-sign/receive`。
+- [x] 离开页面时释放扫码监听（在 `dispose` 中调 `ScannerController.dispose()`，无需手动事件总线）。
+
+### 校验 & 反馈
+- [x] 当返回数据为空时展示与出库模块一致的空态提示（`CommonDataGrid` 支持/或手动 `Center(Text('暂无数据'))`）。
+- [x] 捕获服务异常并通过 Bloc 状态传递错误信息，统一展示。
+
+### 代码生成
+- [x] 变更模型/Bloc 后更新 `build_runner` 指令（记入 README 或脚本）。
+
+### 验收要点
+- [x] 列表数据与 uni-app 版本字段一致，功能流程（搜索/分页/撤销/导航）完整。
+- [x] UI 风格与“平库出库任务列表”一致，包括背景色、Padding、表格主题。
+- [ ] 单元/集成测试：至少覆盖 Bloc 数据加载成功、失败、撤销成功路径（可以参考现有 `*_bloc_test.dart`）。

--- a/docs/arrive_sign_refactor/task_collect_main_todo.md
+++ b/docs/arrive_sign_refactor/task_collect_main_todo.md
@@ -1,0 +1,72 @@
+# 到货签收采集页重构 TODO（原 `pages/arrive_sign/task_collect/index.nvue`）
+
+## 目标
+- 实现到货签收的采集作业流程，包含扫码、批次/序列校验、数量录入、列表切换、采集记录提交。
+- 参考“平库出库采集”模块（`lib/modules/outbound/collection_task`）和“平库入库采集”模块的架构与交互。
+
+## 待办清单
+### 模块与基础设施
+- [x] 在 `arrival_sign_module.dart` 中注册 `/arrival-sign/collect` 路由，接收整行任务对象（`ArrivalSignTask`）。
+- [x] 新建 `lib/modules/arrival_sign/task_collect/` 子目录（`bloc`、`models`、`widgets`、`services`、`config`），保持与 `outbound/collection_task` 对齐。
+
+### 数据模型（Freezed）
+- [x] 定义以下模型：
+  - `ArrivalCollectTask`：承载当前任务行字段（matcode、qty、goodqty、batchno、sn、subinventoryCode、matname、matcodecontrol、orderno、arrivalsBillno、arrivalsBillid 等）。
+  - `ArrivalCollectProgress`：记录采集中的临时状态（matcode、batchno、sn、collectQty、pdate、vdays、collectFlg 等）。
+  - `ArrivalCollectSubmitRequest`：封装提交接口 `/system/terminal/commitSign` 所需 `upShelvesInfos`、`itemListInfos`、`filter` 结构。
+  - `ArrivalCollectScanStep` 枚举（materialQRCode、location、quantity）用于描述多步扫码流程。
+  - `ArrivalCollectSummary`：用于“正在采集”列表与提交预览。
+- [x] 若需要本地缓存，定义 `ArrivalCollectCache` 模型（用于 Hive）。
+
+- [x] `ArrivalSignService` 中补充：
+  - `getArrivalSignDetails`（复用 detail 页实现）。
+  - `getMaterialInfoByQr(String qr)` -> `/system/terminal/materialInfo`。
+  - `commitSignShelves(ArrivalCollectSubmitRequest request)` -> `/system/terminal/commitSign`（POST JSON，content-type 需指定）。
+- [x] 若存在草稿保存需求，规划使用 `LocalStorageService`/Hive box（可参考 `OutboundCollectionCacheService`）。
+
+- [x] 创建 `ArrivalCollectBloc`（或按功能拆分多个 bloc）：
+  - 事件：初始化任务、切换 Tab、扫码结果（二维码/数量/库位）、手动输入数量、选择采集记录、删除记录、提交、恢复缓存、刷新明细列表。
+  - 状态：包含当前扫描步骤、当前输入内容、`taskItems` 列表、`collectingItems` 列表、`selectedCollects`、错误提示、加载状态、提交状态。
+- [x] 使用 `freezed` 生成事件/状态类，参考 `OutboundCollectBloc` 的组织方式。
+- [x] 整合 `CommonDataGridBloc` 或自定义数据源以呈现“任务列表/正在采集”两个表格。
+
+- [x] 集成 `ScannerWidget`（或 `ScannerTextField`）作为顶部输入，placeholder “请扫描物料二维码”。
+- [x] 还原 uni-app 逻辑：
+  - 第一阶段识别物料二维码（包含 `MC`） -> 匹配 `detailListView` 中的物料。
+  - 校验物料控制属性（序列/批次）、供应商、批号是否匹配。
+  - 序列号控制物料需校验序列唯一；批次控制物料需校验批次非空。
+  - 第二阶段读取数量（纯数字），支持浮点；数量需 >0，且不得超过任务剩余量。
+  - 若有库位扫描需求（Step.Site），对接 `storeRoom` 验证逻辑（确认在 uni-app 中是否启用）。
+- [x] 将错误通过 Bloc 状态上报并由 UI 弹窗提示（`LoadingDialogManager.showErrorDialog`）。
+
+- [x] 构建页面布局：
+  - 顶部信息卡片展示当前物料/数量/批次/序列/生产日期/有效期。
+  - `FUITabs` 对应 Flutter 端使用 `ToggleButtons`/`TabBar`，切换“任务列表”“正在采集”。
+  - “任务列表”使用 `CommonDataGrid` 显示 `taskItems`，点击行触发 `SelectTask` 事件并更新顶部信息。
+  - “正在采集”使用 `CommonDataGrid` 显示 `collectingItems`，支持复选（删除、提交时使用）。
+  - 底部 `BottomNavbar` 对应 Flutter `BottomAppBar` + `PrimaryButton` 实现“采集结果/提交”功能。
+  - 弹出菜单（bubble box）可用 `PopupMenuButton` 或自定义 overlay，包含“采集结果”“提交”入口。
+- [x] 点击“采集结果”跳转 `/arrival-sign/collect/result`，并将缓存同步。
+- [ ] `taskcollAdd` 行为：切换到“正在采集”Tab，并过滤出同物料记录。
+
+- [x] 用 Hive 或本地服务代替 `uni.setStorageSync`：
+  - 进入页面时清空 `stocks`、`updateflag`，并在采集有变更时写入缓存。
+  - 从结果页返回时根据 `updateflag` 恢复最新列表。
+- [x] 提供 `ArrivalCollectCacheRepository` 统一读写缓存，避免直接操作 Hive。
+
+- [x] 在“正在采集”表格中支持多选删除，删除后需要回写 `taskItems` 中对应行的 `goodqty`（类似 uni-app `deleteColl` 逻辑）。
+- [x] Bloc 中实现数量计算方法：统计每个物料已采集总量、校验是否超计划、更新 `dicMtlQty`、`dicSeq` 等映射。
+
+- [x] Bloc 处理提交事件：
+  - 根据 `collectingItems` 组装 `ArrivalCollectSubmitRequest`（upShelvesInfos/itemListInfos/filter），字段命名与 uni-app 保持一致。
+  - 调用 `commitSignShelves`，成功后清空缓存、刷新列表，弹出成功提示并返回列表页。
+  - 提交前校验是否存在待提交记录，为零时提示错误。
+- [ ] 若提交需要额外字段（用户、仓库等），从 `UserManager` 或任务数据中补齐。
+
+- [x] 覆盖返回按钮行为：若存在未提交采集记录，则弹窗确认“当前采集记录尚未提交，确定退出采集吗？”；确认后清理扫码监听并返回列表。
+
+### 测试
+- [ ] Bloc 单元测试：扫码流程（成功/失败）、数量校验、删除/提交。
+- [ ] Widget 测试：Tab 切换、表格渲染、底部按钮交互。
+
+- [x] 更新所有 `freezed`/`json_serializable` 模型并运行 `build_runner`。

--- a/docs/arrive_sign_refactor/task_collect_result_todo.md
+++ b/docs/arrive_sign_refactor/task_collect_result_todo.md
@@ -1,0 +1,46 @@
+# 到货签收采集结果页重构 TODO（原 `pages/arrive_sign/task_collect/collect_detail.nvue`）
+
+## 目标
+- 显示并管理采集过程中生成的明细记录，可批量删除并回写任务列表缓存。
+- 对接 Flutter 采集页缓存/状态管理，延续出库模块的交互体验。
+
+## 待办清单
+### 路由与依赖
+- [x] 在 `arrival_sign_module.dart` 中注册 `/arrival-sign/collect/result` 路由，接收或读取共享的采集缓存。
+- [ ] Bloc 可与 `ArrivalCollectBloc` 共享，或单独创建 `ArrivalCollectResultCubit` 管理选中状态。
+
+### 数据模型
+- [x] 复用 `ArrivalCollectSummary`（含 stockId、matcode、batchno、sn、collectQty、taskQty、pdate、vdays、collectFlg 等字段）。
+- [ ] 若单独缓存，需要 `ArrivalCollectResultState`（列表、已选ID集合、loading、error）。
+
+### 数据来源
+- [x] 优先通过依赖注入共享 Bloc 状态；若通过持久化缓存（Hive），进入页面时加载 `stocks` 与 `detailListView` 缓存。
+- [x] 确保进入页面前先同步最新缓存，以便删除后正确刷新主采集页。
+
+-### UI 实现
+- [x] 使用 `Scaffold` + `CustomAppBar` 标题“到货签收采集结果”。
+- [x] 主体使用 `CommonDataGrid` 或 `DataTable` 展示列：物料编码/批次/序列/采集数量/任务数量/生产日期/有效天数/匹配情况。
+- [x] 支持复选：
+  - 使用 `CommonDataGrid` 的多选能力或 `CheckboxListTile` 自定义。
+  - `全选/反选` 功能需映射到 Bloc 状态。
+- [x] 底部操作栏提供“删除”按钮（样式参考 uni-app 蓝底按钮）。
+
+-### 删除逻辑
+- [ ] 删除前校验是否勾选记录，否则弹出 `LoadingDialogManager.showErrorDialog('请至少选择一行记录')`。
+- [x] 弹窗确认删除。
+- [x] 删除后：
+  - 从缓存/Bloc 状态中移除对应记录。
+  - 回写任务列表中 `goodqty`（减去删除的采集数量，最小 0）。
+  - 更新 `updateFlag`，以便主采集页刷新。
+  - 将最新数据重新持久化（Hive 或 Bloc 内存）。
+
+### 导航
+- [x] 删除完成后仍停留在页面；点击 AppBar 返回或系统返回键需通知主采集页刷新（可通过 `Navigator.pop(context, CollectResultPopData)` 返回布尔值）。
+
+### 校验 & 提示
+- [x] 提供空态提示（如“暂无采集记录”）。
+- [ ] 异常捕获后弹出错误提示。
+
+### 测试
+- [ ] Bloc/状态测试：全选、单选、删除回写逻辑。
+- [ ] Widget 测试：列渲染、空态展示。

--- a/docs/arrive_sign_refactor/task_receive_detail_todo.md
+++ b/docs/arrive_sign_refactor/task_receive_detail_todo.md
@@ -1,0 +1,40 @@
+# 接收明细页重构 TODO（原 `pages/arrive_sign/task_receive/receive_detail.nvue`）
+
+## 目标
+- 展示待接收到货单的明细列表，并支持扫码物料二维码过滤。
+- 与接收到货任务列表联动，保持 Flutter 架构风格。
+
+## 待办清单
+### 路由与依赖
+- [x] 在 `arrival_sign_module.dart` 中注册 `/arrival-sign/receive/detail` 路由，接收 `arrivalsBillId`。
+- [x] 通过依赖注入获取 `ArrivalSignService` 与 `ScannerController`。
+
+### 数据模型
+- [x] 复用 `ArrivalSignDetail` 与 `ArrivalSignDetailQuery` 模型（与明细页共享）。
+- [ ] 若过滤条件不同，可扩展 `ArrivalSignDetailQuery` 增加 `mode` 或 `isReceiveMode` 标记。
+
+### 状态管理
+- [x] 可复用 `ArrivalSignDetailBloc`，或创建 `ArrivalReceiveDetailCubit`：
+  - 事件：加载明细、分页切换、扫码过滤、清除过滤。
+  - 状态：包含 `List<ArrivalSignDetail>`、`currentPage`、`totalPages`、`loading`、`error`、`scanFilter`。
+- [x] 处理扫码逻辑：
+  - 接收 `ScannerWidget` 回调。
+  - 若扫码内容包含 `MC`，调用 `getMaterialInfoByQr` 获取物料编码并作为 `searchKey`。
+  - 无效扫码时弹窗提示。
+
+### UI 实现
+- [x] `CustomAppBar` 标题“到货任务接收明细”，左上角返回按钮返回接收列表。
+- [x] 顶部加入 `ScannerWidget`/输入框（placeholder“请扫描单号/物料二维码”），成功后触发过滤。
+- [x] 使用 `CommonDataGrid` 渲染列（与 detail 页一致）。
+- [x] 支持分页。
+
+### 提示 & 校验
+- [x] 扫码错误/空值提示沿用 `LoadingDialogManager`。
+- [x] 数据为空时显示 Toast/空态提示。
+
+### 导航
+- [x] 返回时清理扫码监听、重置 bloc 状态（必要时）。
+
+### 测试
+- [ ] Bloc 测试：扫码成功 -> 过滤列表、扫码失败 -> 错误状态。
+- [ ] Widget 测试：表格渲染、分页交互。

--- a/docs/arrive_sign_refactor/task_receive_list_todo.md
+++ b/docs/arrive_sign_refactor/task_receive_list_todo.md
@@ -1,0 +1,48 @@
+# 接收到货任务列表页重构 TODO（原 `pages/arrive_sign/task_receive/index.nvue`）
+
+## 目标
+- 在 Flutter 中实现待接收到货单列表，支持扫码搜索、分页、接收单据、跳转到接收明细。
+- 参考“平库出库-任务接收”页面（`lib/modules/outbound/task_receive`）。
+
+## 待办清单
+### 模块与路由
+- [x] 在 `arrival_sign_module.dart` 中注册 `/arrival-sign/receive` 路由。
+- [x] 将页面注入模块依赖的 bloc/service。
+
+### 数据模型（Freezed）
+- [x] 定义 `ArrivalReceiveTask` 模型，字段包括：orderno、poNumber、createdate、arrivalsBillno、werks、parname、arrivalsBillid 等。
+- [x] 定义 `ArrivalReceiveTaskPage`（total/rows）。
+
+### 服务层
+- [x] 在 `ArrivalSignService` 添加 `getArrivalUnSignList(query)`（接口 `/system/terminal/arriveUnSignList`）。
+- [x] 添加 `receiveArrivalOrder(String arrivalsBillId)`（接口 `/system/terminal/receArriveSign`）。
+
+### 状态管理
+- [x] 创建 `ArrivalReceiveBloc`（可复用 `CommonDataGridBloc`）：
+  - 事件：初始化加载、扫码/文本搜索、分页切换、接收单据、刷新。
+  - 状态：记录任务列表、分页信息、加载/错误、最近操作结果。
+- [x] 接收成功后刷新列表并提示成功。
+
+### UI 实现
+- [x] 构建 `ArrivalReceivePage`：
+  - `CustomAppBar` 标题“接收到货任务”。
+  - 顶部 `ScannerWidget` 供扫码搜索。
+  - `CommonDataGrid` 渲染列头，与 uni-app 表格对应。
+  - 操作列包含“接收”“明细”两个按钮：
+    - 点击“接收” -> 调用 bloc 接收事件（弹出确认？若无则直接调用）。
+    - 点击“明细” -> 跳转 `/arrival-sign/receive/detail`。
+  - 底部分页控制。
+- [x] 页面销毁时释放扫码控制器。
+
+### 导航
+- [x] 接收成功后自动回到列表并提示成功。
+- [x] 明细按钮通过 `Modular.to.pushNamed('/arrival-sign/receive/detail', arguments: ...)` 跳转。
+
+### 提示 & 校验
+- [x] 空数据时显示提示“当前任务列表没有待处理任务！”。
+- [x] 接收前可选弹出确认框，避免误触。
+- [x] 捕获服务异常并展示错误信息。
+
+### 测试
+- [ ] Bloc 测试：加载成功/失败、接收成功。
+- [ ] Widget 测试：操作列按钮触发、空态渲染。

--- a/lib/app_module.dart
+++ b/lib/app_module.dart
@@ -8,6 +8,7 @@ import 'package:wms_app/modules/home/login/login_page.dart';
 import 'package:wms_app/services/api_service.dart';
 import 'modules/outbound/outbound_module.dart';
 import 'modules/goods_up/goods_up_module.dart';
+import 'modules/arrival_sign/arrival_sign_module.dart';
 
 /// 应用主模块
 class AppModule extends Module {
@@ -44,5 +45,8 @@ class AppModule extends Module {
 
     // 平库上架模块
     r.module('/goods-up', module: GoodsUpModule());
+
+    // 到货签收模块
+    r.module('/arrival-sign', module: ArrivalSignModule());
   }
 }

--- a/lib/common_widgets/scanner_widget/scanner_widget.dart
+++ b/lib/common_widgets/scanner_widget/scanner_widget.dart
@@ -219,6 +219,11 @@ class ScannerController {
     _state = null;
   }
 
+  /// 释放控制器，与组件解绑。
+  void dispose() {
+    _detach();
+  }
+
   /// 请求焦点
   void requestFocus() {
     _state?.requestFocus();

--- a/lib/modules/arrival_sign/arrival_sign_module.dart
+++ b/lib/modules/arrival_sign/arrival_sign_module.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/app_module.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/arrival_receive_page.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/detail/arrival_receive_detail_page.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/bloc/arrival_receive_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/services/arrival_sign_service.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/arrival_collect_page.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/arrival_collect_result_page.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/bloc/arrival_collect_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/models/arrival_collect_progress.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/services/arrival_collect_cache_repository.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/arrival_sign_detail_page.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/arrival_sign_task_list_page.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/bloc/arrival_sign_list_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+import 'package:wms_app/services/dio_client.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+class ArrivalSignModule extends Module {
+  @override
+  List<Module> get imports => [AppModule()];
+
+  @override
+  void binds(Injector i) {
+    i.addSingleton<ArrivalSignService>(
+      () => ArrivalSignService(i.get<DioClient>().dio),
+    );
+
+    i.addSingleton<ArrivalCollectCacheRepository>(
+      ArrivalCollectCacheRepository.new,
+    );
+
+    i.add<ArrivalSignListBloc>(
+      () => ArrivalSignListBloc(
+        arrivalSignService: i.get<ArrivalSignService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+
+    i.add<ArrivalSignDetailBloc>(
+      () => ArrivalSignDetailBloc(
+        service: i.get<ArrivalSignService>(),
+      ),
+    );
+
+    i.add<ArrivalReceiveBloc>(
+      () => ArrivalReceiveBloc(
+        service: i.get<ArrivalSignService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+  }
+
+  @override
+  void routes(RouteManager r) {
+    r.child(
+      '/',
+      child: (context) => BlocProvider(
+        create: (_) => Modular.get<ArrivalSignListBloc>(),
+        child: const ArrivalSignTaskListPage(),
+      ),
+    );
+
+    r.child(
+      '/list',
+      child: (context) => BlocProvider(
+        create: (_) => Modular.get<ArrivalSignListBloc>(),
+        child: const ArrivalSignTaskListPage(),
+      ),
+    );
+
+    r.child(
+      '/detail',
+      child: (context) {
+        final args = Modular.args;
+        final arrivalsBillId =
+            args.data?['arrivalsBillId'] ?? args.queryParams['arrivalsBillId'];
+        if (arrivalsBillId == null || arrivalsBillId.isEmpty) {
+          return const Scaffold(
+            body: Center(child: Text('缺少到货单ID参数')),
+          );
+        }
+        return BlocProvider(
+          create: (_) => Modular.get<ArrivalSignDetailBloc>(),
+          child: ArrivalSignDetailPage(arrivalsBillId: arrivalsBillId),
+        );
+      },
+    );
+
+    r.child(
+      '/receive',
+      child: (context) => BlocProvider(
+        create: (_) => Modular.get<ArrivalReceiveBloc>(),
+        child: const ArrivalReceivePage(),
+      ),
+    );
+
+    r.child(
+      '/receive/detail',
+      child: (context) {
+        final args = Modular.args;
+        final arrivalsBillId =
+            args.data?['arrivalsBillId'] ?? args.queryParams['arrivalsBillId'];
+        if (arrivalsBillId == null || arrivalsBillId.isEmpty) {
+          return const Scaffold(
+            body: Center(child: Text('缺少到货单ID参数')),
+          );
+        }
+
+        return BlocProvider(
+          create: (_) => Modular.get<ArrivalSignDetailBloc>(),
+          child: ArrivalReceiveDetailPage(arrivalsBillId: arrivalsBillId),
+        );
+      },
+    );
+
+    r.child(
+      '/collect',
+      child: (context) {
+        final args = Modular.args.data;
+        if (args is! Map) {
+          return const Scaffold(
+            body: Center(child: Text('缺少到货任务信息')),
+          );
+        }
+
+        final taskJson = args['task'];
+        if (taskJson is! Map<String, dynamic>) {
+          return const Scaffold(
+            body: Center(child: Text('缺少到货任务信息')),
+          );
+        }
+
+        final task = ArrivalSignTask.fromJson(
+          Map<String, dynamic>.from(taskJson),
+        );
+
+        return BlocProvider(
+          create: (_) => ArrivalCollectBloc(
+            service: Modular.get<ArrivalSignService>(),
+            userManager: Modular.get<UserManager>(),
+            cacheRepository: Modular.get<ArrivalCollectCacheRepository>(),
+          ),
+          child: ArrivalCollectPage(task: task),
+        );
+      },
+    );
+
+    r.child(
+      '/collect/result',
+      child: (context) {
+        final args = Modular.args.data;
+        List<Map<String, dynamic>> jsonList = const [];
+        if (args is Map && args['progresses'] is List) {
+          jsonList = (args['progresses'] as List)
+              .whereType<Map>()
+              .map((e) => Map<String, dynamic>.from(e))
+              .toList();
+        }
+
+        final progresses = jsonList
+            .map(ArrivalCollectProgress.fromJson)
+            .toList(growable: false);
+
+        return ArrivalCollectResultPage(progresses: progresses);
+      },
+    );
+  }
+}

--- a/lib/modules/arrival_sign/receive_task/arrival_receive_page.dart
+++ b/lib/modules/arrival_sign/receive_task/arrival_receive_page.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/bloc/arrival_receive_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/bloc/arrival_receive_event.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/bloc/arrival_receive_state.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/config/arrival_receive_grid_config.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/models/arrival_receive_task.dart';
+
+class ArrivalReceivePage extends StatefulWidget {
+  const ArrivalReceivePage({super.key});
+
+  @override
+  State<ArrivalReceivePage> createState() => _ArrivalReceivePageState();
+}
+
+class _ArrivalReceivePageState extends State<ArrivalReceivePage> {
+  late final ArrivalReceiveBloc _bloc;
+  late final CommonDataGridBloc<ArrivalReceiveTask> _gridBloc;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ArrivalReceiveBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+    _bloc.add(const ArrivalReceiveEvent.initialized());
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: CustomAppBar(
+        title: '接收到货任务',
+        onBackPressed: () => Navigator.of(context).pop(),
+      ).appBar,
+      body: BlocListener<ArrivalReceiveBloc, ArrivalReceiveState>(
+        listener: (context, state) {
+          if (state.isProcessing) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+
+          if (state.successMessage != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(state.successMessage!)),
+            );
+          }
+
+          if (state.errorMessage != null) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.errorMessage!,
+            );
+          }
+        },
+        child: Column(
+          children: [
+            _buildScanInput(),
+            Expanded(child: _buildTable()),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScanInput() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '请扫描到货单号',
+      clearOnSubmit: true,
+    );
+
+    return ScannerWidget(
+      controller: _scannerController,
+      config: config,
+      onScanResult: (value) {
+        _bloc.add(ArrivalReceiveEvent.search(value));
+      },
+      onError: (message) {
+        LoadingDialogManager.instance.showErrorDialog(context, message);
+      },
+    );
+  }
+
+  Widget _buildTable() {
+    return BlocProvider.value(
+      value: _gridBloc,
+      child: BlocBuilder<CommonDataGridBloc<ArrivalReceiveTask>,
+          CommonDataGridState<ArrivalReceiveTask>>(
+        builder: (context, state) {
+          if (state.status == GridStatus.loading && state.data.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state.status == GridStatus.error) {
+            return Center(child: Text(state.errorMessage ?? '加载失败'));
+          }
+
+          if (state.data.isEmpty) {
+            return const Center(child: Text('当前任务列表没有待处理任务！'));
+          }
+
+          return CommonDataGrid<ArrivalReceiveTask>(
+            columns: ArrivalReceiveGridConfig.buildColumns((task, action) {
+              switch (action) {
+                case ArrivalReceiveAction.receive:
+                  _confirmReceive(task);
+                  break;
+                case ArrivalReceiveAction.detail:
+                  Modular.to.pushNamed(
+                    '/arrival-sign/receive/detail',
+                    arguments: {'arrivalsBillId': task.arrivalsBillId},
+                  );
+                  break;
+              }
+            }),
+            datas: state.data,
+            currentPage: state.currentPage,
+            totalPages: state.totalPages,
+            onLoadData: (pageIndex) async {
+              _gridBloc.add(LoadDataEvent(pageIndex));
+            },
+            allowPager: true,
+            allowSelect: false,
+            headerHeight: 44,
+            rowHeight: 48,
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _confirmReceive(ArrivalReceiveTask task) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('确认接收'),
+          content: Text('确定接收到货单 ${task.arrivalsBillNo} 吗？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('接收'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (result == true) {
+      _bloc.add(ArrivalReceiveEvent.receive(task.arrivalsBillId));
+    }
+  }
+}

--- a/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_bloc.dart
+++ b/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_bloc.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/models/arrival_receive_task.dart';
+import 'package:wms_app/modules/arrival_sign/services/arrival_sign_service.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+import 'arrival_receive_event.dart';
+import 'arrival_receive_state.dart';
+
+class ArrivalReceiveBloc
+    extends Bloc<ArrivalReceiveEvent, ArrivalReceiveState> {
+  ArrivalReceiveBloc({
+    required this.service,
+    required this.userManager,
+  }) : super(const ArrivalReceiveState()) {
+    on<ArrivalReceiveEvent>(_onEvent);
+  }
+
+  final ArrivalSignService service;
+  final UserManager userManager;
+
+  late ArrivalReceiveTaskQuery currentQuery = _createDefaultQuery();
+
+  late final CommonDataGridBloc<ArrivalReceiveTask> gridBloc =
+      CommonDataGridBloc<ArrivalReceiveTask>(dataLoader: _createLoader());
+
+  DataGridLoader<ArrivalReceiveTask> _createLoader() {
+    return (pageIndex) async {
+      final query = currentQuery.copyWith(pageIndex: pageIndex);
+      final response = await service.getArrivalUnSignList(query: query);
+      final totalPages = response.total == 0
+          ? 1
+          : (response.total / query.pageSize).ceil();
+      return DataGridResponseData(
+        totalPages: totalPages,
+        data: response.rows,
+      );
+    };
+  }
+
+  Future<void> _onEvent(
+    ArrivalReceiveEvent event,
+    Emitter<ArrivalReceiveState> emit,
+  ) async {
+    await event.when(
+      initialized: () => _handleInitialized(emit),
+      search: (keyword) => _handleSearch(keyword, emit),
+      refresh: () => _handleRefresh(emit),
+      receive: (arrivalsBillId) => _handleReceive(arrivalsBillId, emit),
+    );
+  }
+
+  Future<void> _handleInitialized(Emitter<ArrivalReceiveState> emit) async {
+    gridBloc.add(LoadDataEvent(currentQuery.pageIndex));
+  }
+
+  Future<void> _handleSearch(
+    String keyword,
+    Emitter<ArrivalReceiveState> emit,
+  ) async {
+    currentQuery = currentQuery.copyWith(searchKey: keyword, pageIndex: 1);
+    gridBloc.add(const LoadDataEvent(1));
+  }
+
+  Future<void> _handleRefresh(
+    Emitter<ArrivalReceiveState> emit,
+  ) async {
+    gridBloc.add(LoadDataEvent(gridBloc.state.currentPage));
+  }
+
+  Future<void> _handleReceive(
+    String arrivalsBillId,
+    Emitter<ArrivalReceiveState> emit,
+  ) async {
+    emit(
+      state.copyWith(isProcessing: true, errorMessage: null, successMessage: null),
+    );
+    try {
+      await service.receiveArrivalOrder(arrivalsBillId: arrivalsBillId);
+      emit(state.copyWith(isProcessing: false, successMessage: '接收成功'));
+      gridBloc.add(const LoadDataEvent(1));
+    } catch (error) {
+      emit(
+        state.copyWith(
+          isProcessing: false,
+          errorMessage: error.toString(),
+        ),
+      );
+    }
+  }
+
+  ArrivalReceiveTaskQuery _createDefaultQuery() {
+    final user = userManager.userInfo;
+    if (user == null) {
+      return const ArrivalReceiveTaskQuery(userId: '', roleOrUserId: '');
+    }
+    return ArrivalReceiveTaskQuery(
+      userId: '${user.userId}',
+      roleOrUserId: '${user.userId}',
+      pageSize: 100,
+    );
+  }
+}

--- a/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_event.dart
+++ b/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_event.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'arrival_receive_event.freezed.dart';
+
+@freezed
+class ArrivalReceiveEvent with _$ArrivalReceiveEvent {
+  const factory ArrivalReceiveEvent.initialized() = _Initialized;
+  const factory ArrivalReceiveEvent.search(String keyword) = _Search;
+  const factory ArrivalReceiveEvent.refresh() = _Refresh;
+  const factory ArrivalReceiveEvent.receive(String arrivalsBillId) = _Receive;
+}

--- a/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_event.freezed.dart
+++ b/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_event.freezed.dart
@@ -1,0 +1,606 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_receive_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ArrivalReceiveEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) receive,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? receive,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? receive,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Receive value) receive,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Receive value)? receive,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Receive value)? receive,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalReceiveEventCopyWith<$Res> {
+  factory $ArrivalReceiveEventCopyWith(
+          ArrivalReceiveEvent value, $Res Function(ArrivalReceiveEvent) then) =
+      _$ArrivalReceiveEventCopyWithImpl<$Res, ArrivalReceiveEvent>;
+}
+
+/// @nodoc
+class _$ArrivalReceiveEventCopyWithImpl<$Res, $Val extends ArrivalReceiveEvent>
+    implements $ArrivalReceiveEventCopyWith<$Res> {
+  _$ArrivalReceiveEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$InitializedImplCopyWith<$Res> {
+  factory _$$InitializedImplCopyWith(
+          _$InitializedImpl value, $Res Function(_$InitializedImpl) then) =
+      __$$InitializedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InitializedImplCopyWithImpl<$Res>
+    extends _$ArrivalReceiveEventCopyWithImpl<$Res, _$InitializedImpl>
+    implements _$$InitializedImplCopyWith<$Res> {
+  __$$InitializedImplCopyWithImpl(
+      _$InitializedImpl _value, $Res Function(_$InitializedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$InitializedImpl implements _Initialized {
+  const _$InitializedImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalReceiveEvent.initialized()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitializedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) receive,
+  }) {
+    return initialized();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? receive,
+  }) {
+    return initialized?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? receive,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Receive value) receive,
+  }) {
+    return initialized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Receive value)? receive,
+  }) {
+    return initialized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Receive value)? receive,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initialized implements ArrivalReceiveEvent {
+  const factory _Initialized() = _$InitializedImpl;
+}
+
+/// @nodoc
+abstract class _$$SearchImplCopyWith<$Res> {
+  factory _$$SearchImplCopyWith(
+          _$SearchImpl value, $Res Function(_$SearchImpl) then) =
+      __$$SearchImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String keyword});
+}
+
+/// @nodoc
+class __$$SearchImplCopyWithImpl<$Res>
+    extends _$ArrivalReceiveEventCopyWithImpl<$Res, _$SearchImpl>
+    implements _$$SearchImplCopyWith<$Res> {
+  __$$SearchImplCopyWithImpl(
+      _$SearchImpl _value, $Res Function(_$SearchImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? keyword = null,
+  }) {
+    return _then(_$SearchImpl(
+      null == keyword
+          ? _value.keyword
+          : keyword // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SearchImpl implements _Search {
+  const _$SearchImpl(this.keyword);
+
+  @override
+  final String keyword;
+
+  @override
+  String toString() {
+    return 'ArrivalReceiveEvent.search(keyword: $keyword)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SearchImpl &&
+            (identical(other.keyword, keyword) || other.keyword == keyword));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, keyword);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+      __$$SearchImplCopyWithImpl<_$SearchImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) receive,
+  }) {
+    return search(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? receive,
+  }) {
+    return search?.call(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? receive,
+    required TResult orElse(),
+  }) {
+    if (search != null) {
+      return search(keyword);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Receive value) receive,
+  }) {
+    return search(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Receive value)? receive,
+  }) {
+    return search?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Receive value)? receive,
+    required TResult orElse(),
+  }) {
+    if (search != null) {
+      return search(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Search implements ArrivalReceiveEvent {
+  const factory _Search(final String keyword) = _$SearchImpl;
+
+  String get keyword;
+  @JsonKey(ignore: true)
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$RefreshImplCopyWith<$Res> {
+  factory _$$RefreshImplCopyWith(
+          _$RefreshImpl value, $Res Function(_$RefreshImpl) then) =
+      __$$RefreshImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RefreshImplCopyWithImpl<$Res>
+    extends _$ArrivalReceiveEventCopyWithImpl<$Res, _$RefreshImpl>
+    implements _$$RefreshImplCopyWith<$Res> {
+  __$$RefreshImplCopyWithImpl(
+      _$RefreshImpl _value, $Res Function(_$RefreshImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$RefreshImpl implements _Refresh {
+  const _$RefreshImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalReceiveEvent.refresh()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$RefreshImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) receive,
+  }) {
+    return refresh();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? receive,
+  }) {
+    return refresh?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? receive,
+    required TResult orElse(),
+  }) {
+    if (refresh != null) {
+      return refresh();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Receive value) receive,
+  }) {
+    return refresh(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Receive value)? receive,
+  }) {
+    return refresh?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Receive value)? receive,
+    required TResult orElse(),
+  }) {
+    if (refresh != null) {
+      return refresh(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Refresh implements ArrivalReceiveEvent {
+  const factory _Refresh() = _$RefreshImpl;
+}
+
+/// @nodoc
+abstract class _$$ReceiveImplCopyWith<$Res> {
+  factory _$$ReceiveImplCopyWith(
+          _$ReceiveImpl value, $Res Function(_$ReceiveImpl) then) =
+      __$$ReceiveImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String arrivalsBillId});
+}
+
+/// @nodoc
+class __$$ReceiveImplCopyWithImpl<$Res>
+    extends _$ArrivalReceiveEventCopyWithImpl<$Res, _$ReceiveImpl>
+    implements _$$ReceiveImplCopyWith<$Res> {
+  __$$ReceiveImplCopyWithImpl(
+      _$ReceiveImpl _value, $Res Function(_$ReceiveImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? arrivalsBillId = null,
+  }) {
+    return _then(_$ReceiveImpl(
+      null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ReceiveImpl implements _Receive {
+  const _$ReceiveImpl(this.arrivalsBillId);
+
+  @override
+  final String arrivalsBillId;
+
+  @override
+  String toString() {
+    return 'ArrivalReceiveEvent.receive(arrivalsBillId: $arrivalsBillId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReceiveImpl &&
+            (identical(other.arrivalsBillId, arrivalsBillId) ||
+                other.arrivalsBillId == arrivalsBillId));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, arrivalsBillId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReceiveImplCopyWith<_$ReceiveImpl> get copyWith =>
+      __$$ReceiveImplCopyWithImpl<_$ReceiveImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) receive,
+  }) {
+    return receive(arrivalsBillId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? receive,
+  }) {
+    return receive?.call(arrivalsBillId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? receive,
+    required TResult orElse(),
+  }) {
+    if (receive != null) {
+      return receive(arrivalsBillId);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Receive value) receive,
+  }) {
+    return receive(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Receive value)? receive,
+  }) {
+    return receive?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Receive value)? receive,
+    required TResult orElse(),
+  }) {
+    if (receive != null) {
+      return receive(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Receive implements ArrivalReceiveEvent {
+  const factory _Receive(final String arrivalsBillId) = _$ReceiveImpl;
+
+  String get arrivalsBillId;
+  @JsonKey(ignore: true)
+  _$$ReceiveImplCopyWith<_$ReceiveImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_state.dart
+++ b/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_state.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'arrival_receive_state.freezed.dart';
+
+@freezed
+class ArrivalReceiveState with _$ArrivalReceiveState {
+  const factory ArrivalReceiveState({
+    @Default(false) bool isProcessing,
+    String? errorMessage,
+    String? successMessage,
+  }) = _ArrivalReceiveState;
+}

--- a/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_state.freezed.dart
+++ b/lib/modules/arrival_sign/receive_task/bloc/arrival_receive_state.freezed.dart
@@ -1,0 +1,174 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_receive_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ArrivalReceiveState {
+  bool get isProcessing => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+  String? get successMessage => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ArrivalReceiveStateCopyWith<ArrivalReceiveState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalReceiveStateCopyWith<$Res> {
+  factory $ArrivalReceiveStateCopyWith(
+          ArrivalReceiveState value, $Res Function(ArrivalReceiveState) then) =
+      _$ArrivalReceiveStateCopyWithImpl<$Res, ArrivalReceiveState>;
+  @useResult
+  $Res call({bool isProcessing, String? errorMessage, String? successMessage});
+}
+
+/// @nodoc
+class _$ArrivalReceiveStateCopyWithImpl<$Res, $Val extends ArrivalReceiveState>
+    implements $ArrivalReceiveStateCopyWith<$Res> {
+  _$ArrivalReceiveStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isProcessing = null,
+    Object? errorMessage = freezed,
+    Object? successMessage = freezed,
+  }) {
+    return _then(_value.copyWith(
+      isProcessing: null == isProcessing
+          ? _value.isProcessing
+          : isProcessing // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      successMessage: freezed == successMessage
+          ? _value.successMessage
+          : successMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalReceiveStateImplCopyWith<$Res>
+    implements $ArrivalReceiveStateCopyWith<$Res> {
+  factory _$$ArrivalReceiveStateImplCopyWith(_$ArrivalReceiveStateImpl value,
+          $Res Function(_$ArrivalReceiveStateImpl) then) =
+      __$$ArrivalReceiveStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool isProcessing, String? errorMessage, String? successMessage});
+}
+
+/// @nodoc
+class __$$ArrivalReceiveStateImplCopyWithImpl<$Res>
+    extends _$ArrivalReceiveStateCopyWithImpl<$Res, _$ArrivalReceiveStateImpl>
+    implements _$$ArrivalReceiveStateImplCopyWith<$Res> {
+  __$$ArrivalReceiveStateImplCopyWithImpl(_$ArrivalReceiveStateImpl _value,
+      $Res Function(_$ArrivalReceiveStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isProcessing = null,
+    Object? errorMessage = freezed,
+    Object? successMessage = freezed,
+  }) {
+    return _then(_$ArrivalReceiveStateImpl(
+      isProcessing: null == isProcessing
+          ? _value.isProcessing
+          : isProcessing // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      successMessage: freezed == successMessage
+          ? _value.successMessage
+          : successMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ArrivalReceiveStateImpl implements _ArrivalReceiveState {
+  const _$ArrivalReceiveStateImpl(
+      {this.isProcessing = false, this.errorMessage, this.successMessage});
+
+  @override
+  @JsonKey()
+  final bool isProcessing;
+  @override
+  final String? errorMessage;
+  @override
+  final String? successMessage;
+
+  @override
+  String toString() {
+    return 'ArrivalReceiveState(isProcessing: $isProcessing, errorMessage: $errorMessage, successMessage: $successMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalReceiveStateImpl &&
+            (identical(other.isProcessing, isProcessing) ||
+                other.isProcessing == isProcessing) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage) &&
+            (identical(other.successMessage, successMessage) ||
+                other.successMessage == successMessage));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, isProcessing, errorMessage, successMessage);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalReceiveStateImplCopyWith<_$ArrivalReceiveStateImpl> get copyWith =>
+      __$$ArrivalReceiveStateImplCopyWithImpl<_$ArrivalReceiveStateImpl>(
+          this, _$identity);
+}
+
+abstract class _ArrivalReceiveState implements ArrivalReceiveState {
+  const factory _ArrivalReceiveState(
+      {final bool isProcessing,
+      final String? errorMessage,
+      final String? successMessage}) = _$ArrivalReceiveStateImpl;
+
+  @override
+  bool get isProcessing;
+  @override
+  String? get errorMessage;
+  @override
+  String? get successMessage;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalReceiveStateImplCopyWith<_$ArrivalReceiveStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/receive_task/config/arrival_receive_grid_config.dart
+++ b/lib/modules/arrival_sign/receive_task/config/arrival_receive_grid_config.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/models/arrival_receive_task.dart';
+
+typedef ArrivalReceiveOperation = void Function(
+  ArrivalReceiveTask task,
+  ArrivalReceiveAction action,
+);
+
+enum ArrivalReceiveAction { receive, detail }
+
+class ArrivalReceiveGridConfig {
+  static List<GridColumnConfig<ArrivalReceiveTask>> buildColumns(
+    ArrivalReceiveOperation onAction,
+  ) {
+    return [
+      GridColumnConfig<ArrivalReceiveTask>(
+        name: 'actions',
+        headerText: '操作',
+        width: 180,
+        valueGetter: (task) => null,
+        cellBuilder: (task, columnName, cellValue) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SizedBox(
+                height: 30,
+                child: ElevatedButton(
+                  onPressed: () => onAction(task, ArrivalReceiveAction.receive),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF43A047),
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                  ),
+                  child: const Text('接收'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              SizedBox(
+                height: 30,
+                child: OutlinedButton(
+                  onPressed: () => onAction(task, ArrivalReceiveAction.detail),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: const Color(0xFF1E88E5),
+                    side: const BorderSide(color: Color(0xFF1E88E5)),
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                  ),
+                  child: const Text('明细'),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+      GridColumnConfig<ArrivalReceiveTask>(
+        name: 'arrivalsBillNo',
+        headerText: '到货单号',
+        width: 160,
+        valueGetter: (task) => task.arrivalsBillNo,
+      ),
+      GridColumnConfig<ArrivalReceiveTask>(
+        name: 'orderNo',
+        headerText: '采购单号',
+        width: 150,
+        valueGetter: (task) => task.orderNo,
+      ),
+      GridColumnConfig<ArrivalReceiveTask>(
+        name: 'poNumber',
+        headerText: '采购订单',
+        width: 150,
+        valueGetter: (task) => task.poNumber,
+      ),
+      GridColumnConfig<ArrivalReceiveTask>(
+        name: 'createDate',
+        headerText: '到货日期',
+        width: 140,
+        valueGetter: (task) => task.createDate,
+      ),
+      GridColumnConfig<ArrivalReceiveTask>(
+        name: 'plant',
+        headerText: '工厂',
+        width: 100,
+        valueGetter: (task) => task.plant,
+      ),
+      GridColumnConfig<ArrivalReceiveTask>(
+        name: 'supplierName',
+        headerText: '供应商',
+        width: 160,
+        valueGetter: (task) => task.supplierName,
+      ),
+      GridColumnConfig<ArrivalReceiveTask>(
+        name: 'arrivalsBillId',
+        headerText: '到货单ID',
+        width: 140,
+        valueGetter: (task) => task.arrivalsBillId,
+      ),
+    ];
+  }
+}

--- a/lib/modules/arrival_sign/receive_task/detail/arrival_receive_detail_page.dart
+++ b/lib/modules/arrival_sign/receive_task/detail/arrival_receive_detail_page.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+import 'package:wms_app/modules/arrival_sign/services/arrival_sign_service.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_event.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_state.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/config/arrival_sign_detail_grid_config.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart';
+
+class ArrivalReceiveDetailPage extends StatefulWidget {
+  const ArrivalReceiveDetailPage({
+    super.key,
+    required this.arrivalsBillId,
+  });
+
+  final String arrivalsBillId;
+
+  @override
+  State<ArrivalReceiveDetailPage> createState() => _ArrivalReceiveDetailPageState();
+}
+
+class _ArrivalReceiveDetailPageState extends State<ArrivalReceiveDetailPage> {
+  late final ArrivalSignDetailBloc _bloc;
+  late final ArrivalSignService _service;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ArrivalSignDetailBloc>(context);
+    _service = Modular.get<ArrivalSignService>();
+    _bloc.add(ArrivalSignDetailEvent.initialized(widget.arrivalsBillId));
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: CustomAppBar(
+        title: '到货任务接收明细',
+        onBackPressed: () => Navigator.of(context).pop(),
+      ).appBar,
+      body: BlocConsumer<ArrivalSignDetailBloc, ArrivalSignDetailState>(
+        listener: (context, state) {
+          if (state.isLoading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+
+          if (state.errorMessage != null) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.errorMessage!,
+            );
+          }
+        },
+        builder: (context, state) {
+          if (state.details.isEmpty && state.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state.details.isEmpty && state.errorMessage != null) {
+            return Center(child: Text(state.errorMessage!));
+          }
+
+          return Column(
+            children: [
+              _buildScanner(),
+              Expanded(
+                child: state.details.isEmpty
+                    ? const Center(child: Text('当前任务列表没有待处理任务！'))
+                    : CommonDataGrid<ArrivalSignDetail>(
+                        columns: ArrivalSignDetailGridConfig.buildColumns(),
+                        datas: state.details,
+                        currentPage: state.currentPage,
+                        totalPages: state.totalPages,
+                        onLoadData: (pageIndex) async {
+                          _bloc.add(
+                            ArrivalSignDetailEvent.pageChanged(pageIndex),
+                          );
+                        },
+                        allowPager: true,
+                        allowSelect: false,
+                        headerHeight: 44,
+                        rowHeight: 48,
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '请扫描单号/物料二维码',
+      clearOnSubmit: true,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: ScannerWidget(
+        controller: _scannerController,
+        config: config,
+        onScanResult: (value) {
+          _handleScan(value);
+        },
+        onError: (message) {
+          LoadingDialogManager.instance.showErrorDialog(context, message);
+        },
+      ),
+    );
+  }
+
+  Future<void> _handleScan(String value) async {
+    final keyword = value.trim();
+    if (keyword.isEmpty) {
+      LoadingDialogManager.instance.showErrorDialog(context, '请输入或扫描有效内容');
+      return;
+    }
+
+    try {
+      String searchKey = keyword;
+      if (keyword.contains('MC')) {
+        searchKey = await _service.getMaterialCodeByQr(keyword);
+      }
+      _bloc.add(ArrivalSignDetailEvent.search(searchKey));
+    } catch (error) {
+      LoadingDialogManager.instance.showErrorDialog(
+        context,
+        error.toString(),
+      );
+    }
+  }
+}

--- a/lib/modules/arrival_sign/receive_task/models/arrival_receive_task.dart
+++ b/lib/modules/arrival_sign/receive_task/models/arrival_receive_task.dart
@@ -1,0 +1,81 @@
+// ignore_for_file: invalid_annotation_target
+import 'package:equatable/equatable.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'arrival_receive_task.freezed.dart';
+part 'arrival_receive_task.g.dart';
+
+/// 接收到货任务数据模型
+@freezed
+class ArrivalReceiveTask with _$ArrivalReceiveTask {
+  const factory ArrivalReceiveTask({
+    @JsonKey(name: 'arrivalsBillid') required String arrivalsBillId,
+    @JsonKey(name: 'arrivalsBillno') required String arrivalsBillNo,
+    @JsonKey(name: 'orderno') required String orderNo,
+    @JsonKey(name: 'poNumber') required String poNumber,
+    @JsonKey(name: 'createdate') required String createDate,
+    @JsonKey(name: 'werks') required String plant,
+    @JsonKey(name: 'parname') required String supplierName,
+  }) = _ArrivalReceiveTask;
+
+  factory ArrivalReceiveTask.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalReceiveTaskFromJson(json);
+}
+
+@freezed
+class ArrivalReceiveTaskPage with _$ArrivalReceiveTaskPage {
+  const factory ArrivalReceiveTaskPage({
+    @JsonKey(name: 'total') @Default(0) int total,
+    @JsonKey(name: 'rows')
+    @Default(<ArrivalReceiveTask>[])
+    List<ArrivalReceiveTask> rows,
+  }) = _ArrivalReceiveTaskPage;
+
+  factory ArrivalReceiveTaskPage.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalReceiveTaskPageFromJson(json);
+}
+
+class ArrivalReceiveTaskQuery extends Equatable {
+  const ArrivalReceiveTaskQuery({
+    required this.userId,
+    required this.roleOrUserId,
+    this.searchKey = '',
+    this.pageIndex = 1,
+    this.pageSize = 100,
+  });
+
+  final String userId;
+  final String roleOrUserId;
+  final String searchKey;
+  final int pageIndex;
+  final int pageSize;
+
+  ArrivalReceiveTaskQuery copyWith({
+    String? userId,
+    String? roleOrUserId,
+    String? searchKey,
+    int? pageIndex,
+    int? pageSize,
+  }) {
+    return ArrivalReceiveTaskQuery(
+      userId: userId ?? this.userId,
+      roleOrUserId: roleOrUserId ?? this.roleOrUserId,
+      searchKey: searchKey ?? this.searchKey,
+      pageIndex: pageIndex ?? this.pageIndex,
+      pageSize: pageSize ?? this.pageSize,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'userId': userId,
+      'roleoRuserId': roleOrUserId,
+      'searchKey': searchKey,
+      'pageIndex': pageIndex,
+      'pageSize': pageSize,
+    };
+  }
+
+  @override
+  List<Object?> get props => [userId, roleOrUserId, searchKey, pageIndex, pageSize];
+}

--- a/lib/modules/arrival_sign/receive_task/models/arrival_receive_task.freezed.dart
+++ b/lib/modules/arrival_sign/receive_task/models/arrival_receive_task.freezed.dart
@@ -1,0 +1,485 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_receive_task.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ArrivalReceiveTask _$ArrivalReceiveTaskFromJson(Map<String, dynamic> json) {
+  return _ArrivalReceiveTask.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalReceiveTask {
+  @JsonKey(name: 'arrivalsBillid')
+  String get arrivalsBillId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'arrivalsBillno')
+  String get arrivalsBillNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'orderno')
+  String get orderNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'poNumber')
+  String get poNumber => throw _privateConstructorUsedError;
+  @JsonKey(name: 'createdate')
+  String get createDate => throw _privateConstructorUsedError;
+  @JsonKey(name: 'werks')
+  String get plant => throw _privateConstructorUsedError;
+  @JsonKey(name: 'parname')
+  String get supplierName => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalReceiveTaskCopyWith<ArrivalReceiveTask> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalReceiveTaskCopyWith<$Res> {
+  factory $ArrivalReceiveTaskCopyWith(
+          ArrivalReceiveTask value, $Res Function(ArrivalReceiveTask) then) =
+      _$ArrivalReceiveTaskCopyWithImpl<$Res, ArrivalReceiveTask>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'arrivalsBillid') String arrivalsBillId,
+      @JsonKey(name: 'arrivalsBillno') String arrivalsBillNo,
+      @JsonKey(name: 'orderno') String orderNo,
+      @JsonKey(name: 'poNumber') String poNumber,
+      @JsonKey(name: 'createdate') String createDate,
+      @JsonKey(name: 'werks') String plant,
+      @JsonKey(name: 'parname') String supplierName});
+}
+
+/// @nodoc
+class _$ArrivalReceiveTaskCopyWithImpl<$Res, $Val extends ArrivalReceiveTask>
+    implements $ArrivalReceiveTaskCopyWith<$Res> {
+  _$ArrivalReceiveTaskCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? arrivalsBillId = null,
+    Object? arrivalsBillNo = null,
+    Object? orderNo = null,
+    Object? poNumber = null,
+    Object? createDate = null,
+    Object? plant = null,
+    Object? supplierName = null,
+  }) {
+    return _then(_value.copyWith(
+      arrivalsBillId: null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+      arrivalsBillNo: null == arrivalsBillNo
+          ? _value.arrivalsBillNo
+          : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      orderNo: null == orderNo
+          ? _value.orderNo
+          : orderNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      poNumber: null == poNumber
+          ? _value.poNumber
+          : poNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      createDate: null == createDate
+          ? _value.createDate
+          : createDate // ignore: cast_nullable_to_non_nullable
+              as String,
+      plant: null == plant
+          ? _value.plant
+          : plant // ignore: cast_nullable_to_non_nullable
+              as String,
+      supplierName: null == supplierName
+          ? _value.supplierName
+          : supplierName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalReceiveTaskImplCopyWith<$Res>
+    implements $ArrivalReceiveTaskCopyWith<$Res> {
+  factory _$$ArrivalReceiveTaskImplCopyWith(_$ArrivalReceiveTaskImpl value,
+          $Res Function(_$ArrivalReceiveTaskImpl) then) =
+      __$$ArrivalReceiveTaskImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'arrivalsBillid') String arrivalsBillId,
+      @JsonKey(name: 'arrivalsBillno') String arrivalsBillNo,
+      @JsonKey(name: 'orderno') String orderNo,
+      @JsonKey(name: 'poNumber') String poNumber,
+      @JsonKey(name: 'createdate') String createDate,
+      @JsonKey(name: 'werks') String plant,
+      @JsonKey(name: 'parname') String supplierName});
+}
+
+/// @nodoc
+class __$$ArrivalReceiveTaskImplCopyWithImpl<$Res>
+    extends _$ArrivalReceiveTaskCopyWithImpl<$Res, _$ArrivalReceiveTaskImpl>
+    implements _$$ArrivalReceiveTaskImplCopyWith<$Res> {
+  __$$ArrivalReceiveTaskImplCopyWithImpl(_$ArrivalReceiveTaskImpl _value,
+      $Res Function(_$ArrivalReceiveTaskImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? arrivalsBillId = null,
+    Object? arrivalsBillNo = null,
+    Object? orderNo = null,
+    Object? poNumber = null,
+    Object? createDate = null,
+    Object? plant = null,
+    Object? supplierName = null,
+  }) {
+    return _then(_$ArrivalReceiveTaskImpl(
+      arrivalsBillId: null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+      arrivalsBillNo: null == arrivalsBillNo
+          ? _value.arrivalsBillNo
+          : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      orderNo: null == orderNo
+          ? _value.orderNo
+          : orderNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      poNumber: null == poNumber
+          ? _value.poNumber
+          : poNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      createDate: null == createDate
+          ? _value.createDate
+          : createDate // ignore: cast_nullable_to_non_nullable
+              as String,
+      plant: null == plant
+          ? _value.plant
+          : plant // ignore: cast_nullable_to_non_nullable
+              as String,
+      supplierName: null == supplierName
+          ? _value.supplierName
+          : supplierName // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalReceiveTaskImpl implements _ArrivalReceiveTask {
+  const _$ArrivalReceiveTaskImpl(
+      {@JsonKey(name: 'arrivalsBillid') required this.arrivalsBillId,
+      @JsonKey(name: 'arrivalsBillno') required this.arrivalsBillNo,
+      @JsonKey(name: 'orderno') required this.orderNo,
+      @JsonKey(name: 'poNumber') required this.poNumber,
+      @JsonKey(name: 'createdate') required this.createDate,
+      @JsonKey(name: 'werks') required this.plant,
+      @JsonKey(name: 'parname') required this.supplierName});
+
+  factory _$ArrivalReceiveTaskImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalReceiveTaskImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'arrivalsBillid')
+  final String arrivalsBillId;
+  @override
+  @JsonKey(name: 'arrivalsBillno')
+  final String arrivalsBillNo;
+  @override
+  @JsonKey(name: 'orderno')
+  final String orderNo;
+  @override
+  @JsonKey(name: 'poNumber')
+  final String poNumber;
+  @override
+  @JsonKey(name: 'createdate')
+  final String createDate;
+  @override
+  @JsonKey(name: 'werks')
+  final String plant;
+  @override
+  @JsonKey(name: 'parname')
+  final String supplierName;
+
+  @override
+  String toString() {
+    return 'ArrivalReceiveTask(arrivalsBillId: $arrivalsBillId, arrivalsBillNo: $arrivalsBillNo, orderNo: $orderNo, poNumber: $poNumber, createDate: $createDate, plant: $plant, supplierName: $supplierName)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalReceiveTaskImpl &&
+            (identical(other.arrivalsBillId, arrivalsBillId) ||
+                other.arrivalsBillId == arrivalsBillId) &&
+            (identical(other.arrivalsBillNo, arrivalsBillNo) ||
+                other.arrivalsBillNo == arrivalsBillNo) &&
+            (identical(other.orderNo, orderNo) || other.orderNo == orderNo) &&
+            (identical(other.poNumber, poNumber) ||
+                other.poNumber == poNumber) &&
+            (identical(other.createDate, createDate) ||
+                other.createDate == createDate) &&
+            (identical(other.plant, plant) || other.plant == plant) &&
+            (identical(other.supplierName, supplierName) ||
+                other.supplierName == supplierName));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, arrivalsBillId, arrivalsBillNo,
+      orderNo, poNumber, createDate, plant, supplierName);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalReceiveTaskImplCopyWith<_$ArrivalReceiveTaskImpl> get copyWith =>
+      __$$ArrivalReceiveTaskImplCopyWithImpl<_$ArrivalReceiveTaskImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalReceiveTaskImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ArrivalReceiveTask implements ArrivalReceiveTask {
+  const factory _ArrivalReceiveTask(
+      {@JsonKey(name: 'arrivalsBillid') required final String arrivalsBillId,
+      @JsonKey(name: 'arrivalsBillno') required final String arrivalsBillNo,
+      @JsonKey(name: 'orderno') required final String orderNo,
+      @JsonKey(name: 'poNumber') required final String poNumber,
+      @JsonKey(name: 'createdate') required final String createDate,
+      @JsonKey(name: 'werks') required final String plant,
+      @JsonKey(name: 'parname')
+      required final String supplierName}) = _$ArrivalReceiveTaskImpl;
+
+  factory _ArrivalReceiveTask.fromJson(Map<String, dynamic> json) =
+      _$ArrivalReceiveTaskImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'arrivalsBillid')
+  String get arrivalsBillId;
+  @override
+  @JsonKey(name: 'arrivalsBillno')
+  String get arrivalsBillNo;
+  @override
+  @JsonKey(name: 'orderno')
+  String get orderNo;
+  @override
+  @JsonKey(name: 'poNumber')
+  String get poNumber;
+  @override
+  @JsonKey(name: 'createdate')
+  String get createDate;
+  @override
+  @JsonKey(name: 'werks')
+  String get plant;
+  @override
+  @JsonKey(name: 'parname')
+  String get supplierName;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalReceiveTaskImplCopyWith<_$ArrivalReceiveTaskImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+ArrivalReceiveTaskPage _$ArrivalReceiveTaskPageFromJson(
+    Map<String, dynamic> json) {
+  return _ArrivalReceiveTaskPage.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalReceiveTaskPage {
+  @JsonKey(name: 'total')
+  int get total => throw _privateConstructorUsedError;
+  @JsonKey(name: 'rows')
+  List<ArrivalReceiveTask> get rows => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalReceiveTaskPageCopyWith<ArrivalReceiveTaskPage> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalReceiveTaskPageCopyWith<$Res> {
+  factory $ArrivalReceiveTaskPageCopyWith(ArrivalReceiveTaskPage value,
+          $Res Function(ArrivalReceiveTaskPage) then) =
+      _$ArrivalReceiveTaskPageCopyWithImpl<$Res, ArrivalReceiveTaskPage>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'total') int total,
+      @JsonKey(name: 'rows') List<ArrivalReceiveTask> rows});
+}
+
+/// @nodoc
+class _$ArrivalReceiveTaskPageCopyWithImpl<$Res,
+        $Val extends ArrivalReceiveTaskPage>
+    implements $ArrivalReceiveTaskPageCopyWith<$Res> {
+  _$ArrivalReceiveTaskPageCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? total = null,
+    Object? rows = null,
+  }) {
+    return _then(_value.copyWith(
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      rows: null == rows
+          ? _value.rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalReceiveTask>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalReceiveTaskPageImplCopyWith<$Res>
+    implements $ArrivalReceiveTaskPageCopyWith<$Res> {
+  factory _$$ArrivalReceiveTaskPageImplCopyWith(
+          _$ArrivalReceiveTaskPageImpl value,
+          $Res Function(_$ArrivalReceiveTaskPageImpl) then) =
+      __$$ArrivalReceiveTaskPageImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'total') int total,
+      @JsonKey(name: 'rows') List<ArrivalReceiveTask> rows});
+}
+
+/// @nodoc
+class __$$ArrivalReceiveTaskPageImplCopyWithImpl<$Res>
+    extends _$ArrivalReceiveTaskPageCopyWithImpl<$Res,
+        _$ArrivalReceiveTaskPageImpl>
+    implements _$$ArrivalReceiveTaskPageImplCopyWith<$Res> {
+  __$$ArrivalReceiveTaskPageImplCopyWithImpl(
+      _$ArrivalReceiveTaskPageImpl _value,
+      $Res Function(_$ArrivalReceiveTaskPageImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? total = null,
+    Object? rows = null,
+  }) {
+    return _then(_$ArrivalReceiveTaskPageImpl(
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      rows: null == rows
+          ? _value._rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalReceiveTask>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalReceiveTaskPageImpl implements _ArrivalReceiveTaskPage {
+  const _$ArrivalReceiveTaskPageImpl(
+      {@JsonKey(name: 'total') this.total = 0,
+      @JsonKey(name: 'rows')
+      final List<ArrivalReceiveTask> rows = const <ArrivalReceiveTask>[]})
+      : _rows = rows;
+
+  factory _$ArrivalReceiveTaskPageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalReceiveTaskPageImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'total')
+  final int total;
+  final List<ArrivalReceiveTask> _rows;
+  @override
+  @JsonKey(name: 'rows')
+  List<ArrivalReceiveTask> get rows {
+    if (_rows is EqualUnmodifiableListView) return _rows;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_rows);
+  }
+
+  @override
+  String toString() {
+    return 'ArrivalReceiveTaskPage(total: $total, rows: $rows)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalReceiveTaskPageImpl &&
+            (identical(other.total, total) || other.total == total) &&
+            const DeepCollectionEquality().equals(other._rows, _rows));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, total, const DeepCollectionEquality().hash(_rows));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalReceiveTaskPageImplCopyWith<_$ArrivalReceiveTaskPageImpl>
+      get copyWith => __$$ArrivalReceiveTaskPageImplCopyWithImpl<
+          _$ArrivalReceiveTaskPageImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalReceiveTaskPageImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ArrivalReceiveTaskPage implements ArrivalReceiveTaskPage {
+  const factory _ArrivalReceiveTaskPage(
+          {@JsonKey(name: 'total') final int total,
+          @JsonKey(name: 'rows') final List<ArrivalReceiveTask> rows}) =
+      _$ArrivalReceiveTaskPageImpl;
+
+  factory _ArrivalReceiveTaskPage.fromJson(Map<String, dynamic> json) =
+      _$ArrivalReceiveTaskPageImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'total')
+  int get total;
+  @override
+  @JsonKey(name: 'rows')
+  List<ArrivalReceiveTask> get rows;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalReceiveTaskPageImplCopyWith<_$ArrivalReceiveTaskPageImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/receive_task/models/arrival_receive_task.g.dart
+++ b/lib/modules/arrival_sign/receive_task/models/arrival_receive_task.g.dart
@@ -1,0 +1,49 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'arrival_receive_task.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ArrivalReceiveTaskImpl _$$ArrivalReceiveTaskImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ArrivalReceiveTaskImpl(
+      arrivalsBillId: json['arrivalsBillid'] as String,
+      arrivalsBillNo: json['arrivalsBillno'] as String,
+      orderNo: json['orderno'] as String,
+      poNumber: json['poNumber'] as String,
+      createDate: json['createdate'] as String,
+      plant: json['werks'] as String,
+      supplierName: json['parname'] as String,
+    );
+
+Map<String, dynamic> _$$ArrivalReceiveTaskImplToJson(
+        _$ArrivalReceiveTaskImpl instance) =>
+    <String, dynamic>{
+      'arrivalsBillid': instance.arrivalsBillId,
+      'arrivalsBillno': instance.arrivalsBillNo,
+      'orderno': instance.orderNo,
+      'poNumber': instance.poNumber,
+      'createdate': instance.createDate,
+      'werks': instance.plant,
+      'parname': instance.supplierName,
+    };
+
+_$ArrivalReceiveTaskPageImpl _$$ArrivalReceiveTaskPageImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ArrivalReceiveTaskPageImpl(
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      rows: (json['rows'] as List<dynamic>?)
+              ?.map(
+                  (e) => ArrivalReceiveTask.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <ArrivalReceiveTask>[],
+    );
+
+Map<String, dynamic> _$$ArrivalReceiveTaskPageImplToJson(
+        _$ArrivalReceiveTaskPageImpl instance) =>
+    <String, dynamic>{
+      'total': instance.total,
+      'rows': instance.rows,
+    };

--- a/lib/modules/arrival_sign/services/arrival_sign_service.dart
+++ b/lib/modules/arrival_sign/services/arrival_sign_service.dart
@@ -1,0 +1,116 @@
+import 'package:dio/dio.dart';
+import 'package:wms_app/modules/arrival_sign/receive_task/models/arrival_receive_task.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+import 'package:wms_app/services/api_response_handler.dart';
+
+/// 到货签收模块服务封装
+class ArrivalSignService {
+  ArrivalSignService(this._dio);
+
+  final Dio _dio;
+
+  /// 获取到货签收任务列表
+  Future<ArrivalSignTaskPage> getArrivalSignTasks({
+    required ArrivalSignTaskQuery query,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/arriveSignList',
+      queryParameters: query.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => ArrivalSignTaskPage.fromJson(data),
+    );
+  }
+
+  /// 撤销到货签收单据
+  Future<void> cancelArrivalSign({required String arrivalsBillId}) async {
+    await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/cancelArriveSign',
+      data: {
+        'arrivalsBillid': arrivalsBillId,
+      },
+    );
+  }
+
+  /// 获取到货签收明细
+  Future<ArrivalSignDetailPage> getArrivalSignDetails({
+    required ArrivalSignDetailQuery query,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/arriveSignDetailList',
+      queryParameters: query.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => ArrivalSignDetailPage.fromJson(data),
+    );
+  }
+
+  /// 查询待接收到货任务列表
+  Future<ArrivalReceiveTaskPage> getArrivalUnSignList({
+    required ArrivalReceiveTaskQuery query,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/arriveUnSignList',
+      queryParameters: query.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => ArrivalReceiveTaskPage.fromJson(data),
+    );
+  }
+
+  /// 接收到货单据
+  Future<void> receiveArrivalOrder({required String arrivalsBillId}) async {
+    await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/receArriveSign',
+      data: {'arrivalsBillid': arrivalsBillId},
+    );
+  }
+
+  /// 提交采集数据
+  Future<void> commitSignShelves(
+    ArrivalCollectSubmitRequest request,
+  ) async {
+    await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/commitSign',
+      data: request.toJson(),
+      options: Options(contentType: Headers.jsonContentType),
+    );
+  }
+
+  /// 根据二维码解析物料信息
+  Future<String> getMaterialCodeByQr(String qr) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/materialInfo',
+      queryParameters: {'QRstring': qr},
+    );
+
+    final data = response.data;
+    if (data == null) {
+      throw Exception('物料条码识别失败：返回数据为空');
+    }
+
+    final code = data['code'] as int?;
+    if (code != 200) {
+      throw Exception(data['msg']?.toString() ?? '物料条码识别失败');
+    }
+
+    final material = data['data'];
+    final matCode = material is Map<String, dynamic>
+        ? material['matcode']?.toString()
+        : null;
+
+    if (matCode == null || matCode.isEmpty) {
+      throw Exception('物料条码识别失败：未获取到物料编码');
+    }
+
+    return matCode;
+  }
+}

--- a/lib/modules/arrival_sign/task_collect/arrival_collect_page.dart
+++ b/lib/modules/arrival_sign/task_collect/arrival_collect_page.dart
@@ -1,0 +1,342 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/bloc/arrival_collect_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/bloc/arrival_collect_event.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/bloc/arrival_collect_state.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/config/arrival_collect_grid_config.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/models/arrival_collect_progress.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/models/arrival_collect_task.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/widgets/collect_info_header.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+
+class ArrivalCollectPage extends StatefulWidget {
+  const ArrivalCollectPage({super.key, required this.task});
+
+  final ArrivalSignTask task;
+
+  @override
+  State<ArrivalCollectPage> createState() => _ArrivalCollectPageState();
+}
+
+class _ArrivalCollectPageState extends State<ArrivalCollectPage>
+    with SingleTickerProviderStateMixin {
+  late final ArrivalCollectBloc _bloc;
+  late final TabController _tabController;
+  final ScannerController _scannerController = ScannerController();
+  final TextEditingController _quantityController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ArrivalCollectBloc>(context);
+    _bloc.add(ArrivalCollectEvent.initialized(widget.task));
+    _tabController = TabController(length: 2, vsync: this);
+    _tabController.addListener(() {
+      if (_tabController.indexIsChanging) return;
+      _bloc.add(ArrivalCollectEvent.switchTab(_tabController.index));
+    });
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    _tabController.dispose();
+    _quantityController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ArrivalCollectBloc, ArrivalCollectState>(
+      listenWhen: (previous, current) =>
+          previous.errorMessage != current.errorMessage ||
+          previous.successMessage != current.successMessage ||
+          previous.isSubmitting != current.isSubmitting,
+      listener: (context, state) {
+        if (state.isSubmitting) {
+          LoadingDialogManager.instance.showLoadingDialog(context);
+        } else {
+          LoadingDialogManager.instance.hideLoadingDialog(context);
+        }
+
+        if (state.errorMessage != null) {
+          LoadingDialogManager.instance.showErrorDialog(
+            context,
+            state.errorMessage!,
+          );
+        }
+
+        if (state.successMessage != null) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(state.successMessage!)));
+        }
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF6F6F6),
+        appBar: CustomAppBar(
+          title: '到货签收采集',
+          onBackPressed: () async {
+            if (mounted) {
+              final shouldExit = await _confirmLeave(context);
+              if (shouldExit == true && mounted) {
+                Navigator.of(context).pop();
+              }
+            }
+          },
+        ).appBar,
+        body: SafeArea(
+          child: BlocBuilder<ArrivalCollectBloc, ArrivalCollectState>(
+            builder: (context, state) {
+              return Column(
+                children: [
+                  _buildScanner(state),
+                  CollectInfoHeader(state: state),
+                  _buildTabs(state),
+                  _buildTabContent(state),
+                  _buildBottomBar(state),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScanner(ArrivalCollectState state) {
+    final config = ScannerConfig().copyWith(
+      placeholder: state.currentStep == ArrivalCollectScanStep.quantity
+          ? '请输入采集数量'
+          : '请扫描物料二维码',
+      clearOnSubmit: true,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: ScannerWidget(
+        controller: _scannerController,
+        config: config,
+        onScanResult: (value) {
+          if (state.currentStep == ArrivalCollectScanStep.quantity) {
+            final quantity = double.tryParse(value);
+            if (quantity != null) {
+              _bloc.add(ArrivalCollectEvent.quantitySubmitted(quantity));
+              return;
+            }
+          }
+          _bloc.add(ArrivalCollectEvent.scanSubmitted(value));
+        },
+        onError: (message) {
+          LoadingDialogManager.instance.showErrorDialog(context, message);
+        },
+        suffix: IconButton(
+          icon: const Icon(Icons.refresh),
+          onPressed: () =>
+              _bloc.add(const ArrivalCollectEvent.refreshDetails()),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTabs(ArrivalCollectState state) {
+    if (_tabController.index != state.activeTabIndex) {
+      _tabController.index = state.activeTabIndex;
+    }
+    return Container(
+      color: Colors.white,
+      child: TabBar(
+        controller: _tabController,
+        labelColor: Theme.of(context).primaryColor,
+        unselectedLabelColor: Colors.black54,
+        tabs: const [
+          Tab(text: '任务列表'),
+          Tab(text: '正在采集'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabContent(ArrivalCollectState state) {
+    return Expanded(
+      child: TabBarView(
+        controller: _tabController,
+        physics: const NeverScrollableScrollPhysics(),
+        children: [_buildTaskGrid(state), _buildCollectingGrid(state)],
+      ),
+    );
+  }
+
+  Widget _buildTaskGrid(ArrivalCollectState state) {
+    if (state.isLoading && state.taskItems.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.taskItems.isEmpty) {
+      return const Center(child: Text('暂无任务行'));
+    }
+
+    return CommonDataGrid<ArrivalCollectTask>(
+      columns: ArrivalCollectGridConfig.taskColumns(
+        onSelect: (task) => _bloc.add(ArrivalCollectEvent.selectTask(task)),
+      ),
+      datas: state.taskItems,
+      allowPager: false,
+      allowSelect: false,
+      onLoadData: (index) async {},
+      currentPage: 1,
+      totalPages: 1,
+    );
+  }
+
+  Widget _buildCollectingGrid(ArrivalCollectState state) {
+    if (state.progresses.isEmpty) {
+      return const Center(child: Text('暂无采集记录'));
+    }
+
+    return CommonDataGrid<ArrivalCollectProgress>(
+      columns: ArrivalCollectGridConfig.collectingColumns(
+        selectedIds: state.selectedProgressIds,
+        onSelect: (id, selected) {
+          _bloc.add(ArrivalCollectEvent.toggleCollectSelection(id));
+        },
+      ),
+      datas: state.progresses,
+      allowPager: false,
+      allowSelect: false,
+      onLoadData: (index) async {},
+      currentPage: 1,
+      totalPages: 1,
+    );
+  }
+
+  Widget _buildBottomBar(ArrivalCollectState state) {
+    return Container(
+      color: Colors.white,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _quantityController,
+                  keyboardType: const TextInputType.numberWithOptions(
+                    decimal: true,
+                  ),
+                  decoration: const InputDecoration(
+                    labelText: '手动输入数量',
+                    border: OutlineInputBorder(),
+                  ),
+                  onSubmitted: (value) {
+                    final qty = double.tryParse(value);
+                    if (qty != null) {
+                      _bloc.add(ArrivalCollectEvent.quantitySubmitted(qty));
+                      _quantityController.clear();
+                    }
+                  },
+                ),
+              ),
+              const SizedBox(width: 12),
+              ElevatedButton(
+                onPressed: () {
+                  final qty = double.tryParse(_quantityController.text);
+                  if (qty != null) {
+                    _bloc.add(ArrivalCollectEvent.quantitySubmitted(qty));
+                    _quantityController.clear();
+                  }
+                },
+                child: const Text('添加'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: state.progresses.isEmpty
+                      ? null
+                      : () => _navigateToResult(state),
+                  child: const Text('采集结果'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: state.selectedProgressIds.isEmpty
+                      ? null
+                      : () => _bloc.add(
+                          const ArrivalCollectEvent.deleteSelected(),
+                        ),
+                  child: const Text('删除'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: state.progresses.isEmpty || state.isSubmitting
+                      ? null
+                      : () => _bloc.add(const ArrivalCollectEvent.submit()),
+                  child: const Text('提交'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _navigateToResult(ArrivalCollectState state) async {
+    final result = await Modular.to.pushNamed<List<Map<String, dynamic>>>(
+      '/arrival-sign/collect/result',
+      arguments: {
+        'progresses': state.progresses
+            .map((progress) => progress.toJson())
+            .toList(),
+      },
+    );
+    if (result != null) {
+      final progresses = result
+          .map(ArrivalCollectProgress.fromJson)
+          .toList(growable: false);
+      _bloc.add(ArrivalCollectEvent.resultPageClosed(progresses));
+    }
+  }
+
+  Future<bool?> _confirmLeave(BuildContext context) async {
+    final state = _bloc.state;
+    if (state.progresses.isEmpty) {
+      return true;
+    }
+
+    return showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('退出确认'),
+          content: const Text('当前采集记录尚未提交，确定退出采集吗？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('确定'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/modules/arrival_sign/task_collect/arrival_collect_result_page.dart
+++ b/lib/modules/arrival_sign/task_collect/arrival_collect_result_page.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/config/arrival_collect_grid_config.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/models/arrival_collect_progress.dart';
+
+class ArrivalCollectResultPage extends StatefulWidget {
+  const ArrivalCollectResultPage({super.key, required this.progresses});
+
+  final List<ArrivalCollectProgress> progresses;
+
+  @override
+  State<ArrivalCollectResultPage> createState() =>
+      _ArrivalCollectResultPageState();
+}
+
+class _ArrivalCollectResultPageState extends State<ArrivalCollectResultPage> {
+  late List<ArrivalCollectProgress> _progresses;
+  late List<ArrivalCollectSummary> _summaries;
+  final Set<String> _selectedIds = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _progresses = List.of(widget.progresses);
+    _summaries = _progresses.map(ArrivalCollectSummary.fromProgress).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async {
+        Modular.to.pop(_progresses.map((e) => e.toJson()).toList());
+        return false;
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF6F6F6),
+        appBar: CustomAppBar(
+          title: '到货签收采集结果',
+          onBackPressed: () =>
+              Modular.to.pop(_progresses.map((e) => e.toJson()).toList()),
+        ).appBar,
+        body: Column(
+          children: [
+            Expanded(child: _buildGrid()),
+            _buildBottomBar(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGrid() {
+    if (_summaries.isEmpty) {
+      return const Center(child: Text('暂无采集记录'));
+    }
+
+    return CommonDataGrid<ArrivalCollectSummary>(
+      columns: ArrivalCollectGridConfig.summaryColumns(
+        selectedIds: _selectedIds,
+        onSelect: (id, selected) {
+          setState(() {
+            if (selected) {
+              _selectedIds.add(id);
+            } else {
+              _selectedIds.remove(id);
+            }
+          });
+        },
+      ),
+      datas: _summaries,
+      allowPager: false,
+      allowSelect: false,
+      onLoadData: (index) async {},
+      currentPage: 1,
+      totalPages: 1,
+    );
+  }
+
+  Widget _buildBottomBar() {
+    return Container(
+      color: Colors.white,
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          Expanded(
+            child: ElevatedButton(
+              onPressed: _selectedIds.isEmpty
+                  ? null
+                  : () => _confirmDelete(context),
+              child: const Text('删除'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(BuildContext context) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('删除确认'),
+          content: const Text('确定删除选中的采集记录吗？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('删除'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (result != true) {
+      return;
+    }
+
+    setState(() {
+      _progresses = _progresses
+          .where((p) => !_selectedIds.contains(p.id))
+          .toList();
+      _summaries = _summaries
+          .where((summary) => !_selectedIds.contains(summary.id))
+          .toList();
+      _selectedIds.clear();
+    });
+
+    LoadingDialogManager.instance.showSnackSuccessMsg(context, '删除成功');
+  }
+}

--- a/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_bloc.dart
+++ b/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_bloc.dart
@@ -1,0 +1,472 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+import 'package:wms_app/modules/arrival_sign/services/arrival_sign_service.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/services/arrival_collect_cache_repository.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+import '../models/arrival_collect_cache.dart';
+import '../models/arrival_collect_progress.dart';
+import '../models/arrival_collect_task.dart';
+import 'arrival_collect_event.dart';
+import 'arrival_collect_state.dart';
+
+class ArrivalCollectBloc
+    extends Bloc<ArrivalCollectEvent, ArrivalCollectState> {
+  ArrivalCollectBloc({
+    required ArrivalSignService service,
+    required UserManager userManager,
+    required ArrivalCollectCacheRepository cacheRepository,
+  }) : _service = service,
+       _userManager = userManager,
+       _cacheRepository = cacheRepository,
+       super(const ArrivalCollectState()) {
+    on<_Initialized>(_onInitialized);
+    on<_RefreshDetails>(_onRefreshDetails);
+    on<_SelectTask>(_onSelectTask);
+    on<_ScanSubmitted>(_onScanSubmitted);
+    on<_QuantitySubmitted>(_onQuantitySubmitted);
+    on<_SwitchTab>(_onSwitchTab);
+    on<_ToggleCollectSelection>(_onToggleCollectSelection);
+    on<_DeleteSelected>(_onDeleteSelected);
+    on<_Submit>(_onSubmit);
+    on<_RestoreFromCache>(_onRestoreFromCache);
+    on<_PersistCache>(_onPersistCache);
+    on<_ResultPageClosed>(_onResultPageClosed);
+  }
+
+  final ArrivalSignService _service;
+  final UserManager _userManager;
+  final ArrivalCollectCacheRepository _cacheRepository;
+  final Uuid _uuid = const Uuid();
+
+  Future<void> _onInitialized(
+    _Initialized event,
+    Emitter<ArrivalCollectState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        headerTask: event.task,
+        isLoading: true,
+        errorMessage: null,
+        successMessage: null,
+        progresses: const [],
+        selectedProgressIds: const {},
+      ),
+    );
+
+    try {
+      await _loadDetails(emit: emit, task: event.task);
+      add(const ArrivalCollectEvent.restoreFromCache());
+    } catch (error, stackTrace) {
+      debugPrint('到货采集加载失败: $error\n$stackTrace');
+      emit(state.copyWith(isLoading: false, errorMessage: error.toString()));
+    }
+  }
+
+  Future<void> _loadDetails({
+    required Emitter<ArrivalCollectState> emit,
+    required ArrivalSignTask task,
+  }) async {
+    final response = await _service.getArrivalSignDetails(
+      query: ArrivalSignDetailQuery(
+        arrivalsBillId: task.arrivalsBillId,
+        pageIndex: 1,
+        pageSize: 200,
+      ),
+    );
+
+    final items = response.rows
+        .map(
+          (detail) => ArrivalCollectTask.fromDetail(
+            detail,
+            arrivalsBillId: task.arrivalsBillId,
+          ),
+        )
+        .toList();
+
+    emit(
+      state.copyWith(
+        isLoading: false,
+        taskItems: items,
+        selectedTask: items.isNotEmpty ? items.first : null,
+        errorMessage: null,
+      ),
+    );
+  }
+
+  Future<void> _onRefreshDetails(
+    _RefreshDetails event,
+    Emitter<ArrivalCollectState> emit,
+  ) async {
+    final task = state.headerTask;
+    if (task == null) return;
+
+    emit(state.copyWith(isLoading: true));
+    try {
+      await _loadDetails(emit: emit, task: task);
+    } catch (error) {
+      emit(state.copyWith(isLoading: false, errorMessage: error.toString()));
+    }
+  }
+
+  void _onSelectTask(_SelectTask event, Emitter<ArrivalCollectState> emit) {
+    emit(
+      state.copyWith(
+        selectedTask: event.task,
+        currentStep: ArrivalCollectScanStep.materialQRCode,
+        errorMessage: null,
+        successMessage: null,
+      ),
+    );
+  }
+
+  Future<void> _onScanSubmitted(
+    _ScanSubmitted event,
+    Emitter<ArrivalCollectState> emit,
+  ) async {
+    final value = event.value.trim();
+    if (value.isEmpty) {
+      emit(state.copyWith(errorMessage: '扫码内容为空'));
+      return;
+    }
+
+    switch (state.currentStep) {
+      case ArrivalCollectScanStep.materialQRCode:
+        await _handleMaterialScan(value, emit);
+        break;
+      case ArrivalCollectScanStep.quantity:
+        final quantity = double.tryParse(value);
+        if (quantity == null) {
+          emit(state.copyWith(errorMessage: '请输入正确的数量'));
+          return;
+        }
+        add(ArrivalCollectEvent.quantitySubmitted(quantity));
+        break;
+      case ArrivalCollectScanStep.location:
+        emit(
+          state.copyWith(
+            successMessage: '库位\"$value\" 已记录',
+            currentStep: ArrivalCollectScanStep.quantity,
+          ),
+        );
+        break;
+    }
+  }
+
+  Future<void> _handleMaterialScan(
+    String value,
+    Emitter<ArrivalCollectState> emit,
+  ) async {
+    final items = state.taskItems;
+    if (items.isEmpty) {
+      emit(state.copyWith(errorMessage: '暂无可采集的物料'));
+      return;
+    }
+
+    try {
+      String materialCode = value;
+      if (value.contains('MC')) {
+        materialCode = await _service.getMaterialCodeByQr(value);
+      }
+
+      final matchedTask = items.firstWhereOrNull(
+        (task) => task.materialCode == materialCode,
+      );
+
+      if (matchedTask == null) {
+        emit(state.copyWith(errorMessage: '未找到对应物料: $materialCode'));
+        return;
+      }
+
+      emit(
+        state.copyWith(
+          selectedTask: matchedTask,
+          currentStep: ArrivalCollectScanStep.quantity,
+          successMessage: '物料 ${matchedTask.materialCode} 已匹配，请输入数量',
+          errorMessage: null,
+        ),
+      );
+    } catch (error) {
+      emit(state.copyWith(errorMessage: error.toString()));
+    }
+  }
+
+  Future<void> _onQuantitySubmitted(
+    _QuantitySubmitted event,
+    Emitter<ArrivalCollectState> emit,
+  ) async {
+    final task = state.selectedTask;
+    if (task == null) {
+      emit(state.copyWith(errorMessage: '请先选择或扫描物料'));
+      return;
+    }
+
+    final quantity = event.quantity;
+    if (quantity <= 0) {
+      emit(state.copyWith(errorMessage: '数量必须大于0'));
+      return;
+    }
+
+    final remaining = task.remainingQuantity;
+    if (quantity > remaining + 1e-6) {
+      emit(state.copyWith(errorMessage: '采集数量不能超过剩余数量'));
+      return;
+    }
+
+    if (task.materialControlType == 2) {
+      final hasSerial = state.progresses.any(
+        (element) =>
+            (element.serialNumber ?? element.task.serialNumber) ==
+            task.serialNumber,
+      );
+      if (hasSerial) {
+        emit(state.copyWith(errorMessage: '序列号已采集，不能重复'));
+        return;
+      }
+    }
+
+    final progress = ArrivalCollectProgress(
+      id: _uuid.v4(),
+      task: task,
+      collectQty: quantity,
+      batchNo: task.batchNo,
+      serialNumber: task.serialNumber,
+      productionDate: task.productionDate,
+      validDays: task.validDays,
+    );
+
+    final updatedTasks = state.taskItems.map((item) {
+      if (item.materialCode == task.materialCode) {
+        return item.copyWith(
+          collectedQuantity: item.collectedQuantity + quantity,
+        );
+      }
+      return item;
+    }).toList();
+
+    final newProgresses = List<ArrivalCollectProgress>.from(state.progresses)
+      ..add(progress);
+
+    final updatedSelectedTask = updatedTasks.firstWhereOrNull(
+      (item) => item.materialCode == task.materialCode,
+    );
+
+    emit(
+      state.copyWith(
+        taskItems: updatedTasks,
+        progresses: newProgresses,
+        selectedProgressIds: const {},
+        currentStep: ArrivalCollectScanStep.materialQRCode,
+        selectedTask: updatedSelectedTask ?? state.selectedTask,
+        successMessage: '已采集 ${task.materialCode} 数量 $quantity',
+        errorMessage: null,
+      ),
+    );
+
+    add(const ArrivalCollectEvent.persistCache());
+  }
+
+  void _onSwitchTab(_SwitchTab event, Emitter<ArrivalCollectState> emit) {
+    emit(state.copyWith(activeTabIndex: event.index));
+  }
+
+  void _onToggleCollectSelection(
+    _ToggleCollectSelection event,
+    Emitter<ArrivalCollectState> emit,
+  ) {
+    final selections = Set<String>.from(state.selectedProgressIds);
+    if (selections.contains(event.id)) {
+      selections.remove(event.id);
+    } else {
+      selections.add(event.id);
+    }
+    emit(state.copyWith(selectedProgressIds: selections));
+  }
+
+  void _onDeleteSelected(
+    _DeleteSelected event,
+    Emitter<ArrivalCollectState> emit,
+  ) {
+    if (state.selectedProgressIds.isEmpty) {
+      emit(state.copyWith(errorMessage: '请先选择需要删除的记录'));
+      return;
+    }
+
+    final removedIds = state.selectedProgressIds;
+    final remainingProgresses = state.progresses
+        .where((p) => !removedIds.contains(p.id))
+        .toList();
+
+    final restoredTasks = state.taskItems.map((task) {
+      final removedQty = state.progresses
+          .where((p) => removedIds.contains(p.id))
+          .where((p) => p.task.materialCode == task.materialCode)
+          .fold<double>(0, (prev, p) => prev + p.collectQty);
+      if (removedQty == 0) {
+        return task;
+      }
+      final newQty = task.collectedQuantity - removedQty;
+      final normalized = newQty < task.baseCollectedQuantity
+          ? task.baseCollectedQuantity
+          : newQty;
+      return task.copyWith(collectedQuantity: normalized);
+    }).toList();
+
+    emit(
+      state.copyWith(
+        progresses: remainingProgresses,
+        taskItems: restoredTasks,
+        selectedProgressIds: const {},
+        successMessage: '已删除选中的采集记录',
+        errorMessage: null,
+      ),
+    );
+
+    add(const ArrivalCollectEvent.persistCache());
+  }
+
+  Future<void> _onSubmit(
+    _Submit event,
+    Emitter<ArrivalCollectState> emit,
+  ) async {
+    if (state.progresses.isEmpty) {
+      emit(state.copyWith(errorMessage: '暂无可提交的采集记录'));
+      return;
+    }
+
+    final task = state.headerTask;
+    if (task == null) {
+      emit(state.copyWith(errorMessage: '缺少到货任务信息'));
+      return;
+    }
+
+    emit(state.copyWith(isSubmitting: true, errorMessage: null));
+
+    try {
+      final user = await _userManager.getUserInfo();
+      final request = ArrivalCollectSubmitRequest.fromProgressList(
+        progresses: state.progresses,
+        userCode: user?.userCode,
+        arrivalsBillId: task.arrivalsBillId,
+      );
+
+      await _service.commitSignShelves(request);
+      await _cacheRepository.clearCache(task.arrivalsBillId);
+
+      emit(
+        state.copyWith(
+          isSubmitting: false,
+          progresses: const [],
+          selectedProgressIds: const {},
+          successMessage: '提交成功',
+        ),
+      );
+      add(const ArrivalCollectEvent.refreshDetails());
+    } catch (error) {
+      emit(state.copyWith(isSubmitting: false, errorMessage: error.toString()));
+    }
+  }
+
+  Future<void> _onRestoreFromCache(
+    _RestoreFromCache event,
+    Emitter<ArrivalCollectState> emit,
+  ) async {
+    final task = state.headerTask;
+    if (task == null) return;
+
+    try {
+      final cache = await _cacheRepository.loadCache(task.arrivalsBillId);
+      if (cache == null) {
+        return;
+      }
+
+      final progresses = cache.progresses;
+
+      final updatedTasks = state.taskItems.map((item) {
+        final collected = progresses
+            .where((p) => p.task.materialCode == item.materialCode)
+            .fold<double>(0, (prev, p) => prev + p.collectQty);
+        if (collected == 0) {
+          return item;
+        }
+        return item.copyWith(
+          collectedQuantity: item.baseCollectedQuantity + collected,
+        );
+      }).toList();
+
+      ArrivalCollectTask? updatedSelected = state.selectedTask;
+      if (updatedSelected != null) {
+        updatedSelected = updatedTasks.firstWhereOrNull(
+          (item) => item.materialCode == updatedSelected!.materialCode,
+        );
+      }
+
+      emit(
+        state.copyWith(
+          progresses: progresses,
+          taskItems: updatedTasks,
+          selectedTask: updatedSelected ?? state.selectedTask,
+          cache: cache,
+        ),
+      );
+    } catch (error) {
+      debugPrint('恢复采集缓存失败: $error');
+    }
+  }
+
+  Future<void> _onPersistCache(
+    _PersistCache event,
+    Emitter<ArrivalCollectState> emit,
+  ) async {
+    final task = state.headerTask;
+    if (task == null) return;
+
+    final cache = ArrivalCollectCache(
+      progresses: state.progresses,
+      hasPendingSubmit: state.progresses.isNotEmpty,
+      arrivalsBillId: task.arrivalsBillId,
+    );
+
+    await _cacheRepository.saveCache(key: task.arrivalsBillId, cache: cache);
+    emit(state.copyWith(cache: cache));
+  }
+
+  void _onResultPageClosed(
+    _ResultPageClosed event,
+    Emitter<ArrivalCollectState> emit,
+  ) {
+    final progresses = event.progresses;
+    final updatedTasks = state.taskItems.map((item) {
+      final collected = progresses
+          .where((p) => p.task.materialCode == item.materialCode)
+          .fold<double>(0, (prev, p) => prev + p.collectQty);
+      return item.copyWith(
+        collectedQuantity: item.baseCollectedQuantity + collected,
+      );
+    }).toList();
+
+    ArrivalCollectTask? updatedSelected = state.selectedTask;
+    if (updatedSelected != null) {
+      updatedSelected = updatedTasks.firstWhereOrNull(
+        (item) => item.materialCode == updatedSelected!.materialCode,
+      );
+    }
+
+    emit(
+      state.copyWith(
+        progresses: progresses,
+        taskItems: updatedTasks,
+        selectedProgressIds: const {},
+        selectedTask: updatedSelected ?? state.selectedTask,
+      ),
+    );
+    add(const ArrivalCollectEvent.persistCache());
+  }
+}

--- a/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_event.dart
+++ b/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_event.dart
@@ -1,0 +1,41 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+
+import '../models/arrival_collect_progress.dart';
+import '../models/arrival_collect_task.dart';
+
+part 'arrival_collect_event.freezed.dart';
+
+@freezed
+class ArrivalCollectEvent with _$ArrivalCollectEvent {
+  const factory ArrivalCollectEvent.initialized(ArrivalSignTask task) =
+      _Initialized;
+
+  const factory ArrivalCollectEvent.refreshDetails() = _RefreshDetails;
+
+  const factory ArrivalCollectEvent.selectTask(ArrivalCollectTask task) =
+      _SelectTask;
+
+  const factory ArrivalCollectEvent.scanSubmitted(String value) =
+      _ScanSubmitted;
+
+  const factory ArrivalCollectEvent.quantitySubmitted(double quantity) =
+      _QuantitySubmitted;
+
+  const factory ArrivalCollectEvent.switchTab(int index) = _SwitchTab;
+
+  const factory ArrivalCollectEvent.toggleCollectSelection(String id) =
+      _ToggleCollectSelection;
+
+  const factory ArrivalCollectEvent.deleteSelected() = _DeleteSelected;
+
+  const factory ArrivalCollectEvent.submit() = _Submit;
+
+  const factory ArrivalCollectEvent.restoreFromCache() = _RestoreFromCache;
+
+  const factory ArrivalCollectEvent.persistCache() = _PersistCache;
+
+  const factory ArrivalCollectEvent.resultPageClosed(
+    List<ArrivalCollectProgress> progresses,
+  ) = _ResultPageClosed;
+}

--- a/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_event.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_event.freezed.dart
@@ -1,0 +1,2403 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_collect_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$ArrivalCollectEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectEventCopyWith<$Res> {
+  factory $ArrivalCollectEventCopyWith(
+    ArrivalCollectEvent value,
+    $Res Function(ArrivalCollectEvent) then,
+  ) = _$ArrivalCollectEventCopyWithImpl<$Res, ArrivalCollectEvent>;
+}
+
+/// @nodoc
+class _$ArrivalCollectEventCopyWithImpl<$Res, $Val extends ArrivalCollectEvent>
+    implements $ArrivalCollectEventCopyWith<$Res> {
+  _$ArrivalCollectEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$InitializedImplCopyWith<$Res> {
+  factory _$$InitializedImplCopyWith(
+    _$InitializedImpl value,
+    $Res Function(_$InitializedImpl) then,
+  ) = __$$InitializedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({ArrivalSignTask task});
+
+  $ArrivalSignTaskCopyWith<$Res> get task;
+}
+
+/// @nodoc
+class __$$InitializedImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$InitializedImpl>
+    implements _$$InitializedImplCopyWith<$Res> {
+  __$$InitializedImplCopyWithImpl(
+    _$InitializedImpl _value,
+    $Res Function(_$InitializedImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? task = null}) {
+    return _then(
+      _$InitializedImpl(
+        null == task
+            ? _value.task
+            : task // ignore: cast_nullable_to_non_nullable
+                  as ArrivalSignTask,
+      ),
+    );
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ArrivalSignTaskCopyWith<$Res> get task {
+    return $ArrivalSignTaskCopyWith<$Res>(_value.task, (value) {
+      return _then(_value.copyWith(task: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$InitializedImpl implements _Initialized {
+  const _$InitializedImpl(this.task);
+
+  @override
+  final ArrivalSignTask task;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.initialized(task: $task)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InitializedImpl &&
+            (identical(other.task, task) || other.task == task));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, task);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InitializedImplCopyWith<_$InitializedImpl> get copyWith =>
+      __$$InitializedImplCopyWithImpl<_$InitializedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return initialized(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return initialized?.call(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(task);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return initialized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return initialized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initialized implements ArrivalCollectEvent {
+  const factory _Initialized(final ArrivalSignTask task) = _$InitializedImpl;
+
+  ArrivalSignTask get task;
+  @JsonKey(ignore: true)
+  _$$InitializedImplCopyWith<_$InitializedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$RefreshDetailsImplCopyWith<$Res> {
+  factory _$$RefreshDetailsImplCopyWith(
+    _$RefreshDetailsImpl value,
+    $Res Function(_$RefreshDetailsImpl) then,
+  ) = __$$RefreshDetailsImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RefreshDetailsImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$RefreshDetailsImpl>
+    implements _$$RefreshDetailsImplCopyWith<$Res> {
+  __$$RefreshDetailsImplCopyWithImpl(
+    _$RefreshDetailsImpl _value,
+    $Res Function(_$RefreshDetailsImpl) _then,
+  ) : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$RefreshDetailsImpl implements _RefreshDetails {
+  const _$RefreshDetailsImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.refreshDetails()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$RefreshDetailsImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return refreshDetails();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return refreshDetails?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (refreshDetails != null) {
+      return refreshDetails();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return refreshDetails(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return refreshDetails?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (refreshDetails != null) {
+      return refreshDetails(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _RefreshDetails implements ArrivalCollectEvent {
+  const factory _RefreshDetails() = _$RefreshDetailsImpl;
+}
+
+/// @nodoc
+abstract class _$$SelectTaskImplCopyWith<$Res> {
+  factory _$$SelectTaskImplCopyWith(
+    _$SelectTaskImpl value,
+    $Res Function(_$SelectTaskImpl) then,
+  ) = __$$SelectTaskImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({ArrivalCollectTask task});
+
+  $ArrivalCollectTaskCopyWith<$Res> get task;
+}
+
+/// @nodoc
+class __$$SelectTaskImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$SelectTaskImpl>
+    implements _$$SelectTaskImplCopyWith<$Res> {
+  __$$SelectTaskImplCopyWithImpl(
+    _$SelectTaskImpl _value,
+    $Res Function(_$SelectTaskImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? task = null}) {
+    return _then(
+      _$SelectTaskImpl(
+        null == task
+            ? _value.task
+            : task // ignore: cast_nullable_to_non_nullable
+                  as ArrivalCollectTask,
+      ),
+    );
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ArrivalCollectTaskCopyWith<$Res> get task {
+    return $ArrivalCollectTaskCopyWith<$Res>(_value.task, (value) {
+      return _then(_value.copyWith(task: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$SelectTaskImpl implements _SelectTask {
+  const _$SelectTaskImpl(this.task);
+
+  @override
+  final ArrivalCollectTask task;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.selectTask(task: $task)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SelectTaskImpl &&
+            (identical(other.task, task) || other.task == task));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, task);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SelectTaskImplCopyWith<_$SelectTaskImpl> get copyWith =>
+      __$$SelectTaskImplCopyWithImpl<_$SelectTaskImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return selectTask(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return selectTask?.call(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (selectTask != null) {
+      return selectTask(task);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return selectTask(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return selectTask?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (selectTask != null) {
+      return selectTask(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _SelectTask implements ArrivalCollectEvent {
+  const factory _SelectTask(final ArrivalCollectTask task) = _$SelectTaskImpl;
+
+  ArrivalCollectTask get task;
+  @JsonKey(ignore: true)
+  _$$SelectTaskImplCopyWith<_$SelectTaskImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ScanSubmittedImplCopyWith<$Res> {
+  factory _$$ScanSubmittedImplCopyWith(
+    _$ScanSubmittedImpl value,
+    $Res Function(_$ScanSubmittedImpl) then,
+  ) = __$$ScanSubmittedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String value});
+}
+
+/// @nodoc
+class __$$ScanSubmittedImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$ScanSubmittedImpl>
+    implements _$$ScanSubmittedImplCopyWith<$Res> {
+  __$$ScanSubmittedImplCopyWithImpl(
+    _$ScanSubmittedImpl _value,
+    $Res Function(_$ScanSubmittedImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? value = null}) {
+    return _then(
+      _$ScanSubmittedImpl(
+        null == value
+            ? _value.value
+            : value // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ScanSubmittedImpl implements _ScanSubmitted {
+  const _$ScanSubmittedImpl(this.value);
+
+  @override
+  final String value;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.scanSubmitted(value: $value)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ScanSubmittedImpl &&
+            (identical(other.value, value) || other.value == value));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, value);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ScanSubmittedImplCopyWith<_$ScanSubmittedImpl> get copyWith =>
+      __$$ScanSubmittedImplCopyWithImpl<_$ScanSubmittedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return scanSubmitted(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return scanSubmitted?.call(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (scanSubmitted != null) {
+      return scanSubmitted(value);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return scanSubmitted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return scanSubmitted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (scanSubmitted != null) {
+      return scanSubmitted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ScanSubmitted implements ArrivalCollectEvent {
+  const factory _ScanSubmitted(final String value) = _$ScanSubmittedImpl;
+
+  String get value;
+  @JsonKey(ignore: true)
+  _$$ScanSubmittedImplCopyWith<_$ScanSubmittedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$QuantitySubmittedImplCopyWith<$Res> {
+  factory _$$QuantitySubmittedImplCopyWith(
+    _$QuantitySubmittedImpl value,
+    $Res Function(_$QuantitySubmittedImpl) then,
+  ) = __$$QuantitySubmittedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double quantity});
+}
+
+/// @nodoc
+class __$$QuantitySubmittedImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$QuantitySubmittedImpl>
+    implements _$$QuantitySubmittedImplCopyWith<$Res> {
+  __$$QuantitySubmittedImplCopyWithImpl(
+    _$QuantitySubmittedImpl _value,
+    $Res Function(_$QuantitySubmittedImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? quantity = null}) {
+    return _then(
+      _$QuantitySubmittedImpl(
+        null == quantity
+            ? _value.quantity
+            : quantity // ignore: cast_nullable_to_non_nullable
+                  as double,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$QuantitySubmittedImpl implements _QuantitySubmitted {
+  const _$QuantitySubmittedImpl(this.quantity);
+
+  @override
+  final double quantity;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.quantitySubmitted(quantity: $quantity)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$QuantitySubmittedImpl &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, quantity);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$QuantitySubmittedImplCopyWith<_$QuantitySubmittedImpl> get copyWith =>
+      __$$QuantitySubmittedImplCopyWithImpl<_$QuantitySubmittedImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return quantitySubmitted(quantity);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return quantitySubmitted?.call(quantity);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (quantitySubmitted != null) {
+      return quantitySubmitted(quantity);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return quantitySubmitted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return quantitySubmitted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (quantitySubmitted != null) {
+      return quantitySubmitted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _QuantitySubmitted implements ArrivalCollectEvent {
+  const factory _QuantitySubmitted(final double quantity) =
+      _$QuantitySubmittedImpl;
+
+  double get quantity;
+  @JsonKey(ignore: true)
+  _$$QuantitySubmittedImplCopyWith<_$QuantitySubmittedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SwitchTabImplCopyWith<$Res> {
+  factory _$$SwitchTabImplCopyWith(
+    _$SwitchTabImpl value,
+    $Res Function(_$SwitchTabImpl) then,
+  ) = __$$SwitchTabImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int index});
+}
+
+/// @nodoc
+class __$$SwitchTabImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$SwitchTabImpl>
+    implements _$$SwitchTabImplCopyWith<$Res> {
+  __$$SwitchTabImplCopyWithImpl(
+    _$SwitchTabImpl _value,
+    $Res Function(_$SwitchTabImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? index = null}) {
+    return _then(
+      _$SwitchTabImpl(
+        null == index
+            ? _value.index
+            : index // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$SwitchTabImpl implements _SwitchTab {
+  const _$SwitchTabImpl(this.index);
+
+  @override
+  final int index;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.switchTab(index: $index)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SwitchTabImpl &&
+            (identical(other.index, index) || other.index == index));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, index);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SwitchTabImplCopyWith<_$SwitchTabImpl> get copyWith =>
+      __$$SwitchTabImplCopyWithImpl<_$SwitchTabImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return switchTab(index);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return switchTab?.call(index);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (switchTab != null) {
+      return switchTab(index);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return switchTab(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return switchTab?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (switchTab != null) {
+      return switchTab(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _SwitchTab implements ArrivalCollectEvent {
+  const factory _SwitchTab(final int index) = _$SwitchTabImpl;
+
+  int get index;
+  @JsonKey(ignore: true)
+  _$$SwitchTabImplCopyWith<_$SwitchTabImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ToggleCollectSelectionImplCopyWith<$Res> {
+  factory _$$ToggleCollectSelectionImplCopyWith(
+    _$ToggleCollectSelectionImpl value,
+    $Res Function(_$ToggleCollectSelectionImpl) then,
+  ) = __$$ToggleCollectSelectionImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String id});
+}
+
+/// @nodoc
+class __$$ToggleCollectSelectionImplCopyWithImpl<$Res>
+    extends
+        _$ArrivalCollectEventCopyWithImpl<$Res, _$ToggleCollectSelectionImpl>
+    implements _$$ToggleCollectSelectionImplCopyWith<$Res> {
+  __$$ToggleCollectSelectionImplCopyWithImpl(
+    _$ToggleCollectSelectionImpl _value,
+    $Res Function(_$ToggleCollectSelectionImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? id = null}) {
+    return _then(
+      _$ToggleCollectSelectionImpl(
+        null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ToggleCollectSelectionImpl implements _ToggleCollectSelection {
+  const _$ToggleCollectSelectionImpl(this.id);
+
+  @override
+  final String id;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.toggleCollectSelection(id: $id)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ToggleCollectSelectionImpl &&
+            (identical(other.id, id) || other.id == id));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ToggleCollectSelectionImplCopyWith<_$ToggleCollectSelectionImpl>
+  get copyWith =>
+      __$$ToggleCollectSelectionImplCopyWithImpl<_$ToggleCollectSelectionImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return toggleCollectSelection(id);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return toggleCollectSelection?.call(id);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (toggleCollectSelection != null) {
+      return toggleCollectSelection(id);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return toggleCollectSelection(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return toggleCollectSelection?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (toggleCollectSelection != null) {
+      return toggleCollectSelection(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ToggleCollectSelection implements ArrivalCollectEvent {
+  const factory _ToggleCollectSelection(final String id) =
+      _$ToggleCollectSelectionImpl;
+
+  String get id;
+  @JsonKey(ignore: true)
+  _$$ToggleCollectSelectionImplCopyWith<_$ToggleCollectSelectionImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$DeleteSelectedImplCopyWith<$Res> {
+  factory _$$DeleteSelectedImplCopyWith(
+    _$DeleteSelectedImpl value,
+    $Res Function(_$DeleteSelectedImpl) then,
+  ) = __$$DeleteSelectedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$DeleteSelectedImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$DeleteSelectedImpl>
+    implements _$$DeleteSelectedImplCopyWith<$Res> {
+  __$$DeleteSelectedImplCopyWithImpl(
+    _$DeleteSelectedImpl _value,
+    $Res Function(_$DeleteSelectedImpl) _then,
+  ) : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$DeleteSelectedImpl implements _DeleteSelected {
+  const _$DeleteSelectedImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.deleteSelected()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$DeleteSelectedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return deleteSelected();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return deleteSelected?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (deleteSelected != null) {
+      return deleteSelected();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return deleteSelected(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return deleteSelected?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (deleteSelected != null) {
+      return deleteSelected(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _DeleteSelected implements ArrivalCollectEvent {
+  const factory _DeleteSelected() = _$DeleteSelectedImpl;
+}
+
+/// @nodoc
+abstract class _$$SubmitImplCopyWith<$Res> {
+  factory _$$SubmitImplCopyWith(
+    _$SubmitImpl value,
+    $Res Function(_$SubmitImpl) then,
+  ) = __$$SubmitImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$SubmitImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$SubmitImpl>
+    implements _$$SubmitImplCopyWith<$Res> {
+  __$$SubmitImplCopyWithImpl(
+    _$SubmitImpl _value,
+    $Res Function(_$SubmitImpl) _then,
+  ) : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$SubmitImpl implements _Submit {
+  const _$SubmitImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.submit()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$SubmitImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return submit();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return submit?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (submit != null) {
+      return submit();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return submit(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return submit?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (submit != null) {
+      return submit(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Submit implements ArrivalCollectEvent {
+  const factory _Submit() = _$SubmitImpl;
+}
+
+/// @nodoc
+abstract class _$$RestoreFromCacheImplCopyWith<$Res> {
+  factory _$$RestoreFromCacheImplCopyWith(
+    _$RestoreFromCacheImpl value,
+    $Res Function(_$RestoreFromCacheImpl) then,
+  ) = __$$RestoreFromCacheImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RestoreFromCacheImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$RestoreFromCacheImpl>
+    implements _$$RestoreFromCacheImplCopyWith<$Res> {
+  __$$RestoreFromCacheImplCopyWithImpl(
+    _$RestoreFromCacheImpl _value,
+    $Res Function(_$RestoreFromCacheImpl) _then,
+  ) : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$RestoreFromCacheImpl implements _RestoreFromCache {
+  const _$RestoreFromCacheImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.restoreFromCache()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$RestoreFromCacheImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return restoreFromCache();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return restoreFromCache?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (restoreFromCache != null) {
+      return restoreFromCache();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return restoreFromCache(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return restoreFromCache?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (restoreFromCache != null) {
+      return restoreFromCache(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _RestoreFromCache implements ArrivalCollectEvent {
+  const factory _RestoreFromCache() = _$RestoreFromCacheImpl;
+}
+
+/// @nodoc
+abstract class _$$PersistCacheImplCopyWith<$Res> {
+  factory _$$PersistCacheImplCopyWith(
+    _$PersistCacheImpl value,
+    $Res Function(_$PersistCacheImpl) then,
+  ) = __$$PersistCacheImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$PersistCacheImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$PersistCacheImpl>
+    implements _$$PersistCacheImplCopyWith<$Res> {
+  __$$PersistCacheImplCopyWithImpl(
+    _$PersistCacheImpl _value,
+    $Res Function(_$PersistCacheImpl) _then,
+  ) : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$PersistCacheImpl implements _PersistCache {
+  const _$PersistCacheImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.persistCache()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$PersistCacheImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return persistCache();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return persistCache?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (persistCache != null) {
+      return persistCache();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return persistCache(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return persistCache?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (persistCache != null) {
+      return persistCache(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _PersistCache implements ArrivalCollectEvent {
+  const factory _PersistCache() = _$PersistCacheImpl;
+}
+
+/// @nodoc
+abstract class _$$ResultPageClosedImplCopyWith<$Res> {
+  factory _$$ResultPageClosedImplCopyWith(
+    _$ResultPageClosedImpl value,
+    $Res Function(_$ResultPageClosedImpl) then,
+  ) = __$$ResultPageClosedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({List<ArrivalCollectProgress> progresses});
+}
+
+/// @nodoc
+class __$$ResultPageClosedImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res, _$ResultPageClosedImpl>
+    implements _$$ResultPageClosedImplCopyWith<$Res> {
+  __$$ResultPageClosedImplCopyWithImpl(
+    _$ResultPageClosedImpl _value,
+    $Res Function(_$ResultPageClosedImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? progresses = null}) {
+    return _then(
+      _$ResultPageClosedImpl(
+        null == progresses
+            ? _value._progresses
+            : progresses // ignore: cast_nullable_to_non_nullable
+                  as List<ArrivalCollectProgress>,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ResultPageClosedImpl implements _ResultPageClosed {
+  const _$ResultPageClosedImpl(final List<ArrivalCollectProgress> progresses)
+    : _progresses = progresses;
+
+  final List<ArrivalCollectProgress> _progresses;
+  @override
+  List<ArrivalCollectProgress> get progresses {
+    if (_progresses is EqualUnmodifiableListView) return _progresses;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_progresses);
+  }
+
+  @override
+  String toString() {
+    return 'ArrivalCollectEvent.resultPageClosed(progresses: $progresses)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ResultPageClosedImpl &&
+            const DeepCollectionEquality().equals(
+              other._progresses,
+              _progresses,
+            ));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_progresses),
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ResultPageClosedImplCopyWith<_$ResultPageClosedImpl> get copyWith =>
+      __$$ResultPageClosedImplCopyWithImpl<_$ResultPageClosedImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ArrivalSignTask task) initialized,
+    required TResult Function() refreshDetails,
+    required TResult Function(ArrivalCollectTask task) selectTask,
+    required TResult Function(String value) scanSubmitted,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) switchTab,
+    required TResult Function(String id) toggleCollectSelection,
+    required TResult Function() deleteSelected,
+    required TResult Function() submit,
+    required TResult Function() restoreFromCache,
+    required TResult Function() persistCache,
+    required TResult Function(List<ArrivalCollectProgress> progresses)
+    resultPageClosed,
+  }) {
+    return resultPageClosed(progresses);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ArrivalSignTask task)? initialized,
+    TResult? Function()? refreshDetails,
+    TResult? Function(ArrivalCollectTask task)? selectTask,
+    TResult? Function(String value)? scanSubmitted,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? switchTab,
+    TResult? Function(String id)? toggleCollectSelection,
+    TResult? Function()? deleteSelected,
+    TResult? Function()? submit,
+    TResult? Function()? restoreFromCache,
+    TResult? Function()? persistCache,
+    TResult? Function(List<ArrivalCollectProgress> progresses)?
+    resultPageClosed,
+  }) {
+    return resultPageClosed?.call(progresses);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ArrivalSignTask task)? initialized,
+    TResult Function()? refreshDetails,
+    TResult Function(ArrivalCollectTask task)? selectTask,
+    TResult Function(String value)? scanSubmitted,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? switchTab,
+    TResult Function(String id)? toggleCollectSelection,
+    TResult Function()? deleteSelected,
+    TResult Function()? submit,
+    TResult Function()? restoreFromCache,
+    TResult Function()? persistCache,
+    TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (resultPageClosed != null) {
+      return resultPageClosed(progresses);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_RefreshDetails value) refreshDetails,
+    required TResult Function(_SelectTask value) selectTask,
+    required TResult Function(_ScanSubmitted value) scanSubmitted,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_SwitchTab value) switchTab,
+    required TResult Function(_ToggleCollectSelection value)
+    toggleCollectSelection,
+    required TResult Function(_DeleteSelected value) deleteSelected,
+    required TResult Function(_Submit value) submit,
+    required TResult Function(_RestoreFromCache value) restoreFromCache,
+    required TResult Function(_PersistCache value) persistCache,
+    required TResult Function(_ResultPageClosed value) resultPageClosed,
+  }) {
+    return resultPageClosed(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_RefreshDetails value)? refreshDetails,
+    TResult? Function(_SelectTask value)? selectTask,
+    TResult? Function(_ScanSubmitted value)? scanSubmitted,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_SwitchTab value)? switchTab,
+    TResult? Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult? Function(_DeleteSelected value)? deleteSelected,
+    TResult? Function(_Submit value)? submit,
+    TResult? Function(_RestoreFromCache value)? restoreFromCache,
+    TResult? Function(_PersistCache value)? persistCache,
+    TResult? Function(_ResultPageClosed value)? resultPageClosed,
+  }) {
+    return resultPageClosed?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_RefreshDetails value)? refreshDetails,
+    TResult Function(_SelectTask value)? selectTask,
+    TResult Function(_ScanSubmitted value)? scanSubmitted,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_SwitchTab value)? switchTab,
+    TResult Function(_ToggleCollectSelection value)? toggleCollectSelection,
+    TResult Function(_DeleteSelected value)? deleteSelected,
+    TResult Function(_Submit value)? submit,
+    TResult Function(_RestoreFromCache value)? restoreFromCache,
+    TResult Function(_PersistCache value)? persistCache,
+    TResult Function(_ResultPageClosed value)? resultPageClosed,
+    required TResult orElse(),
+  }) {
+    if (resultPageClosed != null) {
+      return resultPageClosed(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ResultPageClosed implements ArrivalCollectEvent {
+  const factory _ResultPageClosed(
+    final List<ArrivalCollectProgress> progresses,
+  ) = _$ResultPageClosedImpl;
+
+  List<ArrivalCollectProgress> get progresses;
+  @JsonKey(ignore: true)
+  _$$ResultPageClosedImplCopyWith<_$ResultPageClosedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_state.dart
+++ b/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_state.dart
@@ -1,0 +1,28 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+
+import '../models/arrival_collect_cache.dart';
+import '../models/arrival_collect_progress.dart';
+import '../models/arrival_collect_task.dart';
+
+part 'arrival_collect_state.freezed.dart';
+
+@freezed
+class ArrivalCollectState with _$ArrivalCollectState {
+  const factory ArrivalCollectState({
+    ArrivalSignTask? headerTask,
+    @Default(false) bool isLoading,
+    @Default(false) bool isSubmitting,
+    @Default(<ArrivalCollectTask>[]) List<ArrivalCollectTask> taskItems,
+    ArrivalCollectTask? selectedTask,
+    @Default(<ArrivalCollectProgress>[])
+    List<ArrivalCollectProgress> progresses,
+    @Default(ArrivalCollectScanStep.materialQRCode)
+    ArrivalCollectScanStep currentStep,
+    @Default(<String>{}) Set<String> selectedProgressIds,
+    @Default(0) int activeTabIndex,
+    String? successMessage,
+    String? errorMessage,
+    ArrivalCollectCache? cache,
+  }) = _ArrivalCollectState;
+}

--- a/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_state.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_state.freezed.dart
@@ -1,0 +1,480 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_collect_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$ArrivalCollectState {
+  ArrivalSignTask? get headerTask => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+  bool get isSubmitting => throw _privateConstructorUsedError;
+  List<ArrivalCollectTask> get taskItems => throw _privateConstructorUsedError;
+  ArrivalCollectTask? get selectedTask => throw _privateConstructorUsedError;
+  List<ArrivalCollectProgress> get progresses =>
+      throw _privateConstructorUsedError;
+  ArrivalCollectScanStep get currentStep => throw _privateConstructorUsedError;
+  Set<String> get selectedProgressIds => throw _privateConstructorUsedError;
+  int get activeTabIndex => throw _privateConstructorUsedError;
+  String? get successMessage => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+  ArrivalCollectCache? get cache => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ArrivalCollectStateCopyWith<ArrivalCollectState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectStateCopyWith<$Res> {
+  factory $ArrivalCollectStateCopyWith(
+    ArrivalCollectState value,
+    $Res Function(ArrivalCollectState) then,
+  ) = _$ArrivalCollectStateCopyWithImpl<$Res, ArrivalCollectState>;
+  @useResult
+  $Res call({
+    ArrivalSignTask? headerTask,
+    bool isLoading,
+    bool isSubmitting,
+    List<ArrivalCollectTask> taskItems,
+    ArrivalCollectTask? selectedTask,
+    List<ArrivalCollectProgress> progresses,
+    ArrivalCollectScanStep currentStep,
+    Set<String> selectedProgressIds,
+    int activeTabIndex,
+    String? successMessage,
+    String? errorMessage,
+    ArrivalCollectCache? cache,
+  });
+
+  $ArrivalSignTaskCopyWith<$Res>? get headerTask;
+  $ArrivalCollectTaskCopyWith<$Res>? get selectedTask;
+  $ArrivalCollectCacheCopyWith<$Res>? get cache;
+}
+
+/// @nodoc
+class _$ArrivalCollectStateCopyWithImpl<$Res, $Val extends ArrivalCollectState>
+    implements $ArrivalCollectStateCopyWith<$Res> {
+  _$ArrivalCollectStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? headerTask = freezed,
+    Object? isLoading = null,
+    Object? isSubmitting = null,
+    Object? taskItems = null,
+    Object? selectedTask = freezed,
+    Object? progresses = null,
+    Object? currentStep = null,
+    Object? selectedProgressIds = null,
+    Object? activeTabIndex = null,
+    Object? successMessage = freezed,
+    Object? errorMessage = freezed,
+    Object? cache = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            headerTask: freezed == headerTask
+                ? _value.headerTask
+                : headerTask // ignore: cast_nullable_to_non_nullable
+                      as ArrivalSignTask?,
+            isLoading: null == isLoading
+                ? _value.isLoading
+                : isLoading // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            isSubmitting: null == isSubmitting
+                ? _value.isSubmitting
+                : isSubmitting // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            taskItems: null == taskItems
+                ? _value.taskItems
+                : taskItems // ignore: cast_nullable_to_non_nullable
+                      as List<ArrivalCollectTask>,
+            selectedTask: freezed == selectedTask
+                ? _value.selectedTask
+                : selectedTask // ignore: cast_nullable_to_non_nullable
+                      as ArrivalCollectTask?,
+            progresses: null == progresses
+                ? _value.progresses
+                : progresses // ignore: cast_nullable_to_non_nullable
+                      as List<ArrivalCollectProgress>,
+            currentStep: null == currentStep
+                ? _value.currentStep
+                : currentStep // ignore: cast_nullable_to_non_nullable
+                      as ArrivalCollectScanStep,
+            selectedProgressIds: null == selectedProgressIds
+                ? _value.selectedProgressIds
+                : selectedProgressIds // ignore: cast_nullable_to_non_nullable
+                      as Set<String>,
+            activeTabIndex: null == activeTabIndex
+                ? _value.activeTabIndex
+                : activeTabIndex // ignore: cast_nullable_to_non_nullable
+                      as int,
+            successMessage: freezed == successMessage
+                ? _value.successMessage
+                : successMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            cache: freezed == cache
+                ? _value.cache
+                : cache // ignore: cast_nullable_to_non_nullable
+                      as ArrivalCollectCache?,
+          )
+          as $Val,
+    );
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ArrivalSignTaskCopyWith<$Res>? get headerTask {
+    if (_value.headerTask == null) {
+      return null;
+    }
+
+    return $ArrivalSignTaskCopyWith<$Res>(_value.headerTask!, (value) {
+      return _then(_value.copyWith(headerTask: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ArrivalCollectTaskCopyWith<$Res>? get selectedTask {
+    if (_value.selectedTask == null) {
+      return null;
+    }
+
+    return $ArrivalCollectTaskCopyWith<$Res>(_value.selectedTask!, (value) {
+      return _then(_value.copyWith(selectedTask: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ArrivalCollectCacheCopyWith<$Res>? get cache {
+    if (_value.cache == null) {
+      return null;
+    }
+
+    return $ArrivalCollectCacheCopyWith<$Res>(_value.cache!, (value) {
+      return _then(_value.copyWith(cache: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalCollectStateImplCopyWith<$Res>
+    implements $ArrivalCollectStateCopyWith<$Res> {
+  factory _$$ArrivalCollectStateImplCopyWith(
+    _$ArrivalCollectStateImpl value,
+    $Res Function(_$ArrivalCollectStateImpl) then,
+  ) = __$$ArrivalCollectStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    ArrivalSignTask? headerTask,
+    bool isLoading,
+    bool isSubmitting,
+    List<ArrivalCollectTask> taskItems,
+    ArrivalCollectTask? selectedTask,
+    List<ArrivalCollectProgress> progresses,
+    ArrivalCollectScanStep currentStep,
+    Set<String> selectedProgressIds,
+    int activeTabIndex,
+    String? successMessage,
+    String? errorMessage,
+    ArrivalCollectCache? cache,
+  });
+
+  @override
+  $ArrivalSignTaskCopyWith<$Res>? get headerTask;
+  @override
+  $ArrivalCollectTaskCopyWith<$Res>? get selectedTask;
+  @override
+  $ArrivalCollectCacheCopyWith<$Res>? get cache;
+}
+
+/// @nodoc
+class __$$ArrivalCollectStateImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectStateCopyWithImpl<$Res, _$ArrivalCollectStateImpl>
+    implements _$$ArrivalCollectStateImplCopyWith<$Res> {
+  __$$ArrivalCollectStateImplCopyWithImpl(
+    _$ArrivalCollectStateImpl _value,
+    $Res Function(_$ArrivalCollectStateImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? headerTask = freezed,
+    Object? isLoading = null,
+    Object? isSubmitting = null,
+    Object? taskItems = null,
+    Object? selectedTask = freezed,
+    Object? progresses = null,
+    Object? currentStep = null,
+    Object? selectedProgressIds = null,
+    Object? activeTabIndex = null,
+    Object? successMessage = freezed,
+    Object? errorMessage = freezed,
+    Object? cache = freezed,
+  }) {
+    return _then(
+      _$ArrivalCollectStateImpl(
+        headerTask: freezed == headerTask
+            ? _value.headerTask
+            : headerTask // ignore: cast_nullable_to_non_nullable
+                  as ArrivalSignTask?,
+        isLoading: null == isLoading
+            ? _value.isLoading
+            : isLoading // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        isSubmitting: null == isSubmitting
+            ? _value.isSubmitting
+            : isSubmitting // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        taskItems: null == taskItems
+            ? _value._taskItems
+            : taskItems // ignore: cast_nullable_to_non_nullable
+                  as List<ArrivalCollectTask>,
+        selectedTask: freezed == selectedTask
+            ? _value.selectedTask
+            : selectedTask // ignore: cast_nullable_to_non_nullable
+                  as ArrivalCollectTask?,
+        progresses: null == progresses
+            ? _value._progresses
+            : progresses // ignore: cast_nullable_to_non_nullable
+                  as List<ArrivalCollectProgress>,
+        currentStep: null == currentStep
+            ? _value.currentStep
+            : currentStep // ignore: cast_nullable_to_non_nullable
+                  as ArrivalCollectScanStep,
+        selectedProgressIds: null == selectedProgressIds
+            ? _value._selectedProgressIds
+            : selectedProgressIds // ignore: cast_nullable_to_non_nullable
+                  as Set<String>,
+        activeTabIndex: null == activeTabIndex
+            ? _value.activeTabIndex
+            : activeTabIndex // ignore: cast_nullable_to_non_nullable
+                  as int,
+        successMessage: freezed == successMessage
+            ? _value.successMessage
+            : successMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        cache: freezed == cache
+            ? _value.cache
+            : cache // ignore: cast_nullable_to_non_nullable
+                  as ArrivalCollectCache?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ArrivalCollectStateImpl implements _ArrivalCollectState {
+  const _$ArrivalCollectStateImpl({
+    this.headerTask,
+    this.isLoading = false,
+    this.isSubmitting = false,
+    final List<ArrivalCollectTask> taskItems = const <ArrivalCollectTask>[],
+    this.selectedTask,
+    final List<ArrivalCollectProgress> progresses =
+        const <ArrivalCollectProgress>[],
+    this.currentStep = ArrivalCollectScanStep.materialQRCode,
+    final Set<String> selectedProgressIds = const <String>{},
+    this.activeTabIndex = 0,
+    this.successMessage,
+    this.errorMessage,
+    this.cache,
+  }) : _taskItems = taskItems,
+       _progresses = progresses,
+       _selectedProgressIds = selectedProgressIds;
+
+  @override
+  final ArrivalSignTask? headerTask;
+  @override
+  @JsonKey()
+  final bool isLoading;
+  @override
+  @JsonKey()
+  final bool isSubmitting;
+  final List<ArrivalCollectTask> _taskItems;
+  @override
+  @JsonKey()
+  List<ArrivalCollectTask> get taskItems {
+    if (_taskItems is EqualUnmodifiableListView) return _taskItems;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_taskItems);
+  }
+
+  @override
+  final ArrivalCollectTask? selectedTask;
+  final List<ArrivalCollectProgress> _progresses;
+  @override
+  @JsonKey()
+  List<ArrivalCollectProgress> get progresses {
+    if (_progresses is EqualUnmodifiableListView) return _progresses;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_progresses);
+  }
+
+  @override
+  @JsonKey()
+  final ArrivalCollectScanStep currentStep;
+  final Set<String> _selectedProgressIds;
+  @override
+  @JsonKey()
+  Set<String> get selectedProgressIds {
+    if (_selectedProgressIds is EqualUnmodifiableSetView)
+      return _selectedProgressIds;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableSetView(_selectedProgressIds);
+  }
+
+  @override
+  @JsonKey()
+  final int activeTabIndex;
+  @override
+  final String? successMessage;
+  @override
+  final String? errorMessage;
+  @override
+  final ArrivalCollectCache? cache;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectState(headerTask: $headerTask, isLoading: $isLoading, isSubmitting: $isSubmitting, taskItems: $taskItems, selectedTask: $selectedTask, progresses: $progresses, currentStep: $currentStep, selectedProgressIds: $selectedProgressIds, activeTabIndex: $activeTabIndex, successMessage: $successMessage, errorMessage: $errorMessage, cache: $cache)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalCollectStateImpl &&
+            (identical(other.headerTask, headerTask) ||
+                other.headerTask == headerTask) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            (identical(other.isSubmitting, isSubmitting) ||
+                other.isSubmitting == isSubmitting) &&
+            const DeepCollectionEquality().equals(
+              other._taskItems,
+              _taskItems,
+            ) &&
+            (identical(other.selectedTask, selectedTask) ||
+                other.selectedTask == selectedTask) &&
+            const DeepCollectionEquality().equals(
+              other._progresses,
+              _progresses,
+            ) &&
+            (identical(other.currentStep, currentStep) ||
+                other.currentStep == currentStep) &&
+            const DeepCollectionEquality().equals(
+              other._selectedProgressIds,
+              _selectedProgressIds,
+            ) &&
+            (identical(other.activeTabIndex, activeTabIndex) ||
+                other.activeTabIndex == activeTabIndex) &&
+            (identical(other.successMessage, successMessage) ||
+                other.successMessage == successMessage) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage) &&
+            (identical(other.cache, cache) || other.cache == cache));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    headerTask,
+    isLoading,
+    isSubmitting,
+    const DeepCollectionEquality().hash(_taskItems),
+    selectedTask,
+    const DeepCollectionEquality().hash(_progresses),
+    currentStep,
+    const DeepCollectionEquality().hash(_selectedProgressIds),
+    activeTabIndex,
+    successMessage,
+    errorMessage,
+    cache,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalCollectStateImplCopyWith<_$ArrivalCollectStateImpl> get copyWith =>
+      __$$ArrivalCollectStateImplCopyWithImpl<_$ArrivalCollectStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _ArrivalCollectState implements ArrivalCollectState {
+  const factory _ArrivalCollectState({
+    final ArrivalSignTask? headerTask,
+    final bool isLoading,
+    final bool isSubmitting,
+    final List<ArrivalCollectTask> taskItems,
+    final ArrivalCollectTask? selectedTask,
+    final List<ArrivalCollectProgress> progresses,
+    final ArrivalCollectScanStep currentStep,
+    final Set<String> selectedProgressIds,
+    final int activeTabIndex,
+    final String? successMessage,
+    final String? errorMessage,
+    final ArrivalCollectCache? cache,
+  }) = _$ArrivalCollectStateImpl;
+
+  @override
+  ArrivalSignTask? get headerTask;
+  @override
+  bool get isLoading;
+  @override
+  bool get isSubmitting;
+  @override
+  List<ArrivalCollectTask> get taskItems;
+  @override
+  ArrivalCollectTask? get selectedTask;
+  @override
+  List<ArrivalCollectProgress> get progresses;
+  @override
+  ArrivalCollectScanStep get currentStep;
+  @override
+  Set<String> get selectedProgressIds;
+  @override
+  int get activeTabIndex;
+  @override
+  String? get successMessage;
+  @override
+  String? get errorMessage;
+  @override
+  ArrivalCollectCache? get cache;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalCollectStateImplCopyWith<_$ArrivalCollectStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_collect/config/arrival_collect_grid_config.dart
+++ b/lib/modules/arrival_sign/task_collect/config/arrival_collect_grid_config.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+
+import '../models/arrival_collect_progress.dart';
+import '../models/arrival_collect_task.dart';
+
+class ArrivalCollectGridConfig {
+  static List<GridColumnConfig<ArrivalCollectTask>> taskColumns({
+    required void Function(ArrivalCollectTask task) onSelect,
+  }) {
+    return [
+      GridColumnConfig<ArrivalCollectTask>(
+        name: 'matcode',
+        headerText: '物料编码',
+        valueGetter: (row) => row.materialCode,
+        cellBuilder: (row, _, __) => GestureDetector(
+          onTap: () => onSelect(row),
+          child: Text(row.materialCode),
+        ),
+      ),
+      GridColumnConfig<ArrivalCollectTask>(
+        name: 'matname',
+        headerText: '物料名称',
+        valueGetter: (row) => row.materialName,
+      ),
+      GridColumnConfig<ArrivalCollectTask>(
+        name: 'batchno',
+        headerText: '批次',
+        valueGetter: (row) => row.batchNo,
+      ),
+      GridColumnConfig<ArrivalCollectTask>(
+        name: 'sn',
+        headerText: '序列',
+        valueGetter: (row) => row.serialNumber,
+      ),
+      GridColumnConfig<ArrivalCollectTask>(
+        name: 'qty',
+        headerText: '任务数量',
+        valueGetter: (row) => row.plannedQuantity.toString(),
+      ),
+      GridColumnConfig<ArrivalCollectTask>(
+        name: 'goodqty',
+        headerText: '已采集',
+        valueGetter: (row) => row.collectedQuantity.toString(),
+      ),
+    ];
+  }
+
+  static List<GridColumnConfig<ArrivalCollectProgress>> collectingColumns({
+    required void Function(String id, bool selected) onSelect,
+    required Set<String> selectedIds,
+  }) {
+    return [
+      GridColumnConfig<ArrivalCollectProgress>(
+        name: 'checkbox',
+        headerText: '',
+        width: 56,
+        valueGetter: (row) => row.id,
+        cellBuilder: (row, _, __) {
+          final isSelected = selectedIds.contains(row.id);
+          return Center(
+            child: Checkbox(
+              value: isSelected,
+              onChanged: (value) => onSelect(row.id, value ?? false),
+            ),
+          );
+        },
+      ),
+      GridColumnConfig<ArrivalCollectProgress>(
+        name: 'matcode',
+        headerText: '物料编码',
+        valueGetter: (row) => row.task.materialCode,
+      ),
+      GridColumnConfig<ArrivalCollectProgress>(
+        name: 'collectQty',
+        headerText: '采集数量',
+        valueGetter: (row) => row.collectQty.toString(),
+      ),
+      GridColumnConfig<ArrivalCollectProgress>(
+        name: 'batchno',
+        headerText: '批次',
+        valueGetter: (row) => row.batchNo ?? row.task.batchNo,
+      ),
+      GridColumnConfig<ArrivalCollectProgress>(
+        name: 'sn',
+        headerText: '序列',
+        valueGetter: (row) => row.serialNumber ?? row.task.serialNumber,
+      ),
+      GridColumnConfig<ArrivalCollectProgress>(
+        name: 'pdate',
+        headerText: '生产日期',
+        valueGetter: (row) => row.productionDate ?? row.task.productionDate,
+      ),
+      GridColumnConfig<ArrivalCollectProgress>(
+        name: 'vdays',
+        headerText: '有效期',
+        valueGetter: (row) => row.validDays ?? row.task.validDays,
+      ),
+    ];
+  }
+
+  static List<GridColumnConfig<ArrivalCollectSummary>> summaryColumns({
+    required void Function(String id, bool selected) onSelect,
+    required Set<String> selectedIds,
+  }) {
+    return [
+      GridColumnConfig<ArrivalCollectSummary>(
+        name: 'checkbox',
+        headerText: '',
+        width: 56,
+        valueGetter: (row) => row.id,
+        cellBuilder: (row, _, __) {
+          final isSelected = selectedIds.contains(row.id);
+          return Center(
+            child: Checkbox(
+              value: isSelected,
+              onChanged: (value) => onSelect(row.id, value ?? false),
+            ),
+          );
+        },
+      ),
+      GridColumnConfig<ArrivalCollectSummary>(
+        name: 'matcode',
+        headerText: '物料编码',
+        valueGetter: (row) => row.materialCode,
+      ),
+      GridColumnConfig<ArrivalCollectSummary>(
+        name: 'collectQty',
+        headerText: '采集数量',
+        valueGetter: (row) => row.collectQty?.toString(),
+      ),
+      GridColumnConfig<ArrivalCollectSummary>(
+        name: 'taskQty',
+        headerText: '任务数量',
+        valueGetter: (row) => row.taskQty?.toString(),
+      ),
+      GridColumnConfig<ArrivalCollectSummary>(
+        name: 'batchno',
+        headerText: '批次',
+        valueGetter: (row) => row.batchNo,
+      ),
+      GridColumnConfig<ArrivalCollectSummary>(
+        name: 'sn',
+        headerText: '序列',
+        valueGetter: (row) => row.serialNumber,
+      ),
+      GridColumnConfig<ArrivalCollectSummary>(
+        name: 'pdate',
+        headerText: '生产日期',
+        valueGetter: (row) => row.productionDate,
+      ),
+      GridColumnConfig<ArrivalCollectSummary>(
+        name: 'vdays',
+        headerText: '有效期',
+        valueGetter: (row) => row.validDays,
+      ),
+    ];
+  }
+}

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'arrival_collect_progress.dart';
+
+part 'arrival_collect_cache.freezed.dart';
+part 'arrival_collect_cache.g.dart';
+
+/// Hive 缓存模型（后续可扩展为 HiveType）。
+@freezed
+class ArrivalCollectCache with _$ArrivalCollectCache {
+  @JsonSerializable(explicitToJson: true)
+  const factory ArrivalCollectCache({
+    @Default(<ArrivalCollectProgress>[])
+    List<ArrivalCollectProgress> progresses,
+    @Default(false) bool hasPendingSubmit,
+    String? arrivalsBillId,
+  }) = _ArrivalCollectCache;
+
+  factory ArrivalCollectCache.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalCollectCacheFromJson(json);
+}

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.freezed.dart
@@ -1,0 +1,230 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_collect_cache.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+ArrivalCollectCache _$ArrivalCollectCacheFromJson(Map<String, dynamic> json) {
+  return _ArrivalCollectCache.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalCollectCache {
+  List<ArrivalCollectProgress> get progresses =>
+      throw _privateConstructorUsedError;
+  bool get hasPendingSubmit => throw _privateConstructorUsedError;
+  String? get arrivalsBillId => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalCollectCacheCopyWith<ArrivalCollectCache> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectCacheCopyWith<$Res> {
+  factory $ArrivalCollectCacheCopyWith(
+    ArrivalCollectCache value,
+    $Res Function(ArrivalCollectCache) then,
+  ) = _$ArrivalCollectCacheCopyWithImpl<$Res, ArrivalCollectCache>;
+  @useResult
+  $Res call({
+    List<ArrivalCollectProgress> progresses,
+    bool hasPendingSubmit,
+    String? arrivalsBillId,
+  });
+}
+
+/// @nodoc
+class _$ArrivalCollectCacheCopyWithImpl<$Res, $Val extends ArrivalCollectCache>
+    implements $ArrivalCollectCacheCopyWith<$Res> {
+  _$ArrivalCollectCacheCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? progresses = null,
+    Object? hasPendingSubmit = null,
+    Object? arrivalsBillId = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            progresses: null == progresses
+                ? _value.progresses
+                : progresses // ignore: cast_nullable_to_non_nullable
+                      as List<ArrivalCollectProgress>,
+            hasPendingSubmit: null == hasPendingSubmit
+                ? _value.hasPendingSubmit
+                : hasPendingSubmit // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            arrivalsBillId: freezed == arrivalsBillId
+                ? _value.arrivalsBillId
+                : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalCollectCacheImplCopyWith<$Res>
+    implements $ArrivalCollectCacheCopyWith<$Res> {
+  factory _$$ArrivalCollectCacheImplCopyWith(
+    _$ArrivalCollectCacheImpl value,
+    $Res Function(_$ArrivalCollectCacheImpl) then,
+  ) = __$$ArrivalCollectCacheImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    List<ArrivalCollectProgress> progresses,
+    bool hasPendingSubmit,
+    String? arrivalsBillId,
+  });
+}
+
+/// @nodoc
+class __$$ArrivalCollectCacheImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectCacheCopyWithImpl<$Res, _$ArrivalCollectCacheImpl>
+    implements _$$ArrivalCollectCacheImplCopyWith<$Res> {
+  __$$ArrivalCollectCacheImplCopyWithImpl(
+    _$ArrivalCollectCacheImpl _value,
+    $Res Function(_$ArrivalCollectCacheImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? progresses = null,
+    Object? hasPendingSubmit = null,
+    Object? arrivalsBillId = freezed,
+  }) {
+    return _then(
+      _$ArrivalCollectCacheImpl(
+        progresses: null == progresses
+            ? _value._progresses
+            : progresses // ignore: cast_nullable_to_non_nullable
+                  as List<ArrivalCollectProgress>,
+        hasPendingSubmit: null == hasPendingSubmit
+            ? _value.hasPendingSubmit
+            : hasPendingSubmit // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        arrivalsBillId: freezed == arrivalsBillId
+            ? _value.arrivalsBillId
+            : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _$ArrivalCollectCacheImpl implements _ArrivalCollectCache {
+  const _$ArrivalCollectCacheImpl({
+    final List<ArrivalCollectProgress> progresses =
+        const <ArrivalCollectProgress>[],
+    this.hasPendingSubmit = false,
+    this.arrivalsBillId,
+  }) : _progresses = progresses;
+
+  factory _$ArrivalCollectCacheImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalCollectCacheImplFromJson(json);
+
+  final List<ArrivalCollectProgress> _progresses;
+  @override
+  @JsonKey()
+  List<ArrivalCollectProgress> get progresses {
+    if (_progresses is EqualUnmodifiableListView) return _progresses;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_progresses);
+  }
+
+  @override
+  @JsonKey()
+  final bool hasPendingSubmit;
+  @override
+  final String? arrivalsBillId;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectCache(progresses: $progresses, hasPendingSubmit: $hasPendingSubmit, arrivalsBillId: $arrivalsBillId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalCollectCacheImpl &&
+            const DeepCollectionEquality().equals(
+              other._progresses,
+              _progresses,
+            ) &&
+            (identical(other.hasPendingSubmit, hasPendingSubmit) ||
+                other.hasPendingSubmit == hasPendingSubmit) &&
+            (identical(other.arrivalsBillId, arrivalsBillId) ||
+                other.arrivalsBillId == arrivalsBillId));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_progresses),
+    hasPendingSubmit,
+    arrivalsBillId,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalCollectCacheImplCopyWith<_$ArrivalCollectCacheImpl> get copyWith =>
+      __$$ArrivalCollectCacheImplCopyWithImpl<_$ArrivalCollectCacheImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalCollectCacheImplToJson(this);
+  }
+}
+
+abstract class _ArrivalCollectCache implements ArrivalCollectCache {
+  const factory _ArrivalCollectCache({
+    final List<ArrivalCollectProgress> progresses,
+    final bool hasPendingSubmit,
+    final String? arrivalsBillId,
+  }) = _$ArrivalCollectCacheImpl;
+
+  factory _ArrivalCollectCache.fromJson(Map<String, dynamic> json) =
+      _$ArrivalCollectCacheImpl.fromJson;
+
+  @override
+  List<ArrivalCollectProgress> get progresses;
+  @override
+  bool get hasPendingSubmit;
+  @override
+  String? get arrivalsBillId;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalCollectCacheImplCopyWith<_$ArrivalCollectCacheImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.g.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'arrival_collect_cache.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ArrivalCollectCacheImpl _$$ArrivalCollectCacheImplFromJson(
+  Map<String, dynamic> json,
+) => _$ArrivalCollectCacheImpl(
+  progresses:
+      (json['progresses'] as List<dynamic>?)
+          ?.map(
+            (e) => ArrivalCollectProgress.fromJson(e as Map<String, dynamic>),
+          )
+          .toList() ??
+      const <ArrivalCollectProgress>[],
+  hasPendingSubmit: json['hasPendingSubmit'] as bool? ?? false,
+  arrivalsBillId: json['arrivalsBillId'] as String?,
+);
+
+Map<String, dynamic> _$$ArrivalCollectCacheImplToJson(
+  _$ArrivalCollectCacheImpl instance,
+) => <String, dynamic>{
+  'progresses': instance.progresses.map((e) => e.toJson()).toList(),
+  'hasPendingSubmit': instance.hasPendingSubmit,
+  'arrivalsBillId': instance.arrivalsBillId,
+};

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.dart
@@ -1,0 +1,65 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'arrival_collect_task.dart';
+
+part 'arrival_collect_progress.freezed.dart';
+part 'arrival_collect_progress.g.dart';
+
+/// 描述采集中临时记录
+@freezed
+class ArrivalCollectProgress with _$ArrivalCollectProgress {
+  @JsonSerializable(explicitToJson: true)
+  const factory ArrivalCollectProgress({
+    required String id,
+    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+    required ArrivalCollectTask task,
+    required double collectQty,
+    String? batchNo,
+    String? serialNumber,
+    String? productionDate,
+    String? validDays,
+    @Default(false) bool submitted,
+  }) = _ArrivalCollectProgress;
+
+  factory ArrivalCollectProgress.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalCollectProgressFromJson(json);
+}
+
+/// 多步扫码流程
+enum ArrivalCollectScanStep { materialQRCode, quantity, location }
+
+/// 采集结果摘要
+@freezed
+class ArrivalCollectSummary with _$ArrivalCollectSummary {
+  const factory ArrivalCollectSummary({
+    required String id,
+    required String materialCode,
+    String? materialName,
+    String? batchNo,
+    String? serialNumber,
+    double? collectQty,
+    double? taskQty,
+    String? productionDate,
+    String? validDays,
+    @Default(false) bool committed,
+  }) = _ArrivalCollectSummary;
+
+  factory ArrivalCollectSummary.fromProgress(ArrivalCollectProgress progress) {
+    return ArrivalCollectSummary(
+      id: progress.id,
+      materialCode: progress.task.materialCode,
+      materialName: progress.task.materialName,
+      batchNo: progress.batchNo ?? progress.task.batchNo,
+      serialNumber: progress.serialNumber ?? progress.task.serialNumber,
+      collectQty: progress.collectQty,
+      taskQty: progress.task.plannedQuantity,
+      productionDate: progress.productionDate ?? progress.task.productionDate,
+      validDays: progress.validDays ?? progress.task.validDays,
+    );
+  }
+
+  factory ArrivalCollectSummary.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalCollectSummaryFromJson(json);
+}
+
+Map<String, dynamic> _taskToJson(ArrivalCollectTask task) => task.toJson();

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.freezed.dart
@@ -1,0 +1,713 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_collect_progress.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+ArrivalCollectProgress _$ArrivalCollectProgressFromJson(
+  Map<String, dynamic> json,
+) {
+  return _ArrivalCollectProgress.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalCollectProgress {
+  String get id => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+  ArrivalCollectTask get task => throw _privateConstructorUsedError;
+  double get collectQty => throw _privateConstructorUsedError;
+  String? get batchNo => throw _privateConstructorUsedError;
+  String? get serialNumber => throw _privateConstructorUsedError;
+  String? get productionDate => throw _privateConstructorUsedError;
+  String? get validDays => throw _privateConstructorUsedError;
+  bool get submitted => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalCollectProgressCopyWith<ArrivalCollectProgress> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectProgressCopyWith<$Res> {
+  factory $ArrivalCollectProgressCopyWith(
+    ArrivalCollectProgress value,
+    $Res Function(ArrivalCollectProgress) then,
+  ) = _$ArrivalCollectProgressCopyWithImpl<$Res, ArrivalCollectProgress>;
+  @useResult
+  $Res call({
+    String id,
+    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+    ArrivalCollectTask task,
+    double collectQty,
+    String? batchNo,
+    String? serialNumber,
+    String? productionDate,
+    String? validDays,
+    bool submitted,
+  });
+
+  $ArrivalCollectTaskCopyWith<$Res> get task;
+}
+
+/// @nodoc
+class _$ArrivalCollectProgressCopyWithImpl<
+  $Res,
+  $Val extends ArrivalCollectProgress
+>
+    implements $ArrivalCollectProgressCopyWith<$Res> {
+  _$ArrivalCollectProgressCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? task = null,
+    Object? collectQty = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? submitted = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            task: null == task
+                ? _value.task
+                : task // ignore: cast_nullable_to_non_nullable
+                      as ArrivalCollectTask,
+            collectQty: null == collectQty
+                ? _value.collectQty
+                : collectQty // ignore: cast_nullable_to_non_nullable
+                      as double,
+            batchNo: freezed == batchNo
+                ? _value.batchNo
+                : batchNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            serialNumber: freezed == serialNumber
+                ? _value.serialNumber
+                : serialNumber // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            productionDate: freezed == productionDate
+                ? _value.productionDate
+                : productionDate // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            validDays: freezed == validDays
+                ? _value.validDays
+                : validDays // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            submitted: null == submitted
+                ? _value.submitted
+                : submitted // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ArrivalCollectTaskCopyWith<$Res> get task {
+    return $ArrivalCollectTaskCopyWith<$Res>(_value.task, (value) {
+      return _then(_value.copyWith(task: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalCollectProgressImplCopyWith<$Res>
+    implements $ArrivalCollectProgressCopyWith<$Res> {
+  factory _$$ArrivalCollectProgressImplCopyWith(
+    _$ArrivalCollectProgressImpl value,
+    $Res Function(_$ArrivalCollectProgressImpl) then,
+  ) = __$$ArrivalCollectProgressImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+    ArrivalCollectTask task,
+    double collectQty,
+    String? batchNo,
+    String? serialNumber,
+    String? productionDate,
+    String? validDays,
+    bool submitted,
+  });
+
+  @override
+  $ArrivalCollectTaskCopyWith<$Res> get task;
+}
+
+/// @nodoc
+class __$$ArrivalCollectProgressImplCopyWithImpl<$Res>
+    extends
+        _$ArrivalCollectProgressCopyWithImpl<$Res, _$ArrivalCollectProgressImpl>
+    implements _$$ArrivalCollectProgressImplCopyWith<$Res> {
+  __$$ArrivalCollectProgressImplCopyWithImpl(
+    _$ArrivalCollectProgressImpl _value,
+    $Res Function(_$ArrivalCollectProgressImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? task = null,
+    Object? collectQty = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? submitted = null,
+  }) {
+    return _then(
+      _$ArrivalCollectProgressImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        task: null == task
+            ? _value.task
+            : task // ignore: cast_nullable_to_non_nullable
+                  as ArrivalCollectTask,
+        collectQty: null == collectQty
+            ? _value.collectQty
+            : collectQty // ignore: cast_nullable_to_non_nullable
+                  as double,
+        batchNo: freezed == batchNo
+            ? _value.batchNo
+            : batchNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        serialNumber: freezed == serialNumber
+            ? _value.serialNumber
+            : serialNumber // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        productionDate: freezed == productionDate
+            ? _value.productionDate
+            : productionDate // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        validDays: freezed == validDays
+            ? _value.validDays
+            : validDays // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        submitted: null == submitted
+            ? _value.submitted
+            : submitted // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+@JsonSerializable(explicitToJson: true)
+class _$ArrivalCollectProgressImpl implements _ArrivalCollectProgress {
+  const _$ArrivalCollectProgressImpl({
+    required this.id,
+    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+    required this.task,
+    required this.collectQty,
+    this.batchNo,
+    this.serialNumber,
+    this.productionDate,
+    this.validDays,
+    this.submitted = false,
+  });
+
+  factory _$ArrivalCollectProgressImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalCollectProgressImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+  final ArrivalCollectTask task;
+  @override
+  final double collectQty;
+  @override
+  final String? batchNo;
+  @override
+  final String? serialNumber;
+  @override
+  final String? productionDate;
+  @override
+  final String? validDays;
+  @override
+  @JsonKey()
+  final bool submitted;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectProgress(id: $id, task: $task, collectQty: $collectQty, batchNo: $batchNo, serialNumber: $serialNumber, productionDate: $productionDate, validDays: $validDays, submitted: $submitted)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalCollectProgressImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.task, task) || other.task == task) &&
+            (identical(other.collectQty, collectQty) ||
+                other.collectQty == collectQty) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNumber, serialNumber) ||
+                other.serialNumber == serialNumber) &&
+            (identical(other.productionDate, productionDate) ||
+                other.productionDate == productionDate) &&
+            (identical(other.validDays, validDays) ||
+                other.validDays == validDays) &&
+            (identical(other.submitted, submitted) ||
+                other.submitted == submitted));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    task,
+    collectQty,
+    batchNo,
+    serialNumber,
+    productionDate,
+    validDays,
+    submitted,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalCollectProgressImplCopyWith<_$ArrivalCollectProgressImpl>
+  get copyWith =>
+      __$$ArrivalCollectProgressImplCopyWithImpl<_$ArrivalCollectProgressImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalCollectProgressImplToJson(this);
+  }
+}
+
+abstract class _ArrivalCollectProgress implements ArrivalCollectProgress {
+  const factory _ArrivalCollectProgress({
+    required final String id,
+    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+    required final ArrivalCollectTask task,
+    required final double collectQty,
+    final String? batchNo,
+    final String? serialNumber,
+    final String? productionDate,
+    final String? validDays,
+    final bool submitted,
+  }) = _$ArrivalCollectProgressImpl;
+
+  factory _ArrivalCollectProgress.fromJson(Map<String, dynamic> json) =
+      _$ArrivalCollectProgressImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+  ArrivalCollectTask get task;
+  @override
+  double get collectQty;
+  @override
+  String? get batchNo;
+  @override
+  String? get serialNumber;
+  @override
+  String? get productionDate;
+  @override
+  String? get validDays;
+  @override
+  bool get submitted;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalCollectProgressImplCopyWith<_$ArrivalCollectProgressImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+ArrivalCollectSummary _$ArrivalCollectSummaryFromJson(
+  Map<String, dynamic> json,
+) {
+  return _ArrivalCollectSummary.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalCollectSummary {
+  String get id => throw _privateConstructorUsedError;
+  String get materialCode => throw _privateConstructorUsedError;
+  String? get materialName => throw _privateConstructorUsedError;
+  String? get batchNo => throw _privateConstructorUsedError;
+  String? get serialNumber => throw _privateConstructorUsedError;
+  double? get collectQty => throw _privateConstructorUsedError;
+  double? get taskQty => throw _privateConstructorUsedError;
+  String? get productionDate => throw _privateConstructorUsedError;
+  String? get validDays => throw _privateConstructorUsedError;
+  bool get committed => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalCollectSummaryCopyWith<ArrivalCollectSummary> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectSummaryCopyWith<$Res> {
+  factory $ArrivalCollectSummaryCopyWith(
+    ArrivalCollectSummary value,
+    $Res Function(ArrivalCollectSummary) then,
+  ) = _$ArrivalCollectSummaryCopyWithImpl<$Res, ArrivalCollectSummary>;
+  @useResult
+  $Res call({
+    String id,
+    String materialCode,
+    String? materialName,
+    String? batchNo,
+    String? serialNumber,
+    double? collectQty,
+    double? taskQty,
+    String? productionDate,
+    String? validDays,
+    bool committed,
+  });
+}
+
+/// @nodoc
+class _$ArrivalCollectSummaryCopyWithImpl<
+  $Res,
+  $Val extends ArrivalCollectSummary
+>
+    implements $ArrivalCollectSummaryCopyWith<$Res> {
+  _$ArrivalCollectSummaryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? collectQty = freezed,
+    Object? taskQty = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? committed = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            materialCode: null == materialCode
+                ? _value.materialCode
+                : materialCode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            materialName: freezed == materialName
+                ? _value.materialName
+                : materialName // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            batchNo: freezed == batchNo
+                ? _value.batchNo
+                : batchNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            serialNumber: freezed == serialNumber
+                ? _value.serialNumber
+                : serialNumber // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            collectQty: freezed == collectQty
+                ? _value.collectQty
+                : collectQty // ignore: cast_nullable_to_non_nullable
+                      as double?,
+            taskQty: freezed == taskQty
+                ? _value.taskQty
+                : taskQty // ignore: cast_nullable_to_non_nullable
+                      as double?,
+            productionDate: freezed == productionDate
+                ? _value.productionDate
+                : productionDate // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            validDays: freezed == validDays
+                ? _value.validDays
+                : validDays // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            committed: null == committed
+                ? _value.committed
+                : committed // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalCollectSummaryImplCopyWith<$Res>
+    implements $ArrivalCollectSummaryCopyWith<$Res> {
+  factory _$$ArrivalCollectSummaryImplCopyWith(
+    _$ArrivalCollectSummaryImpl value,
+    $Res Function(_$ArrivalCollectSummaryImpl) then,
+  ) = __$$ArrivalCollectSummaryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String materialCode,
+    String? materialName,
+    String? batchNo,
+    String? serialNumber,
+    double? collectQty,
+    double? taskQty,
+    String? productionDate,
+    String? validDays,
+    bool committed,
+  });
+}
+
+/// @nodoc
+class __$$ArrivalCollectSummaryImplCopyWithImpl<$Res>
+    extends
+        _$ArrivalCollectSummaryCopyWithImpl<$Res, _$ArrivalCollectSummaryImpl>
+    implements _$$ArrivalCollectSummaryImplCopyWith<$Res> {
+  __$$ArrivalCollectSummaryImplCopyWithImpl(
+    _$ArrivalCollectSummaryImpl _value,
+    $Res Function(_$ArrivalCollectSummaryImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? collectQty = freezed,
+    Object? taskQty = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? committed = null,
+  }) {
+    return _then(
+      _$ArrivalCollectSummaryImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        materialCode: null == materialCode
+            ? _value.materialCode
+            : materialCode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        materialName: freezed == materialName
+            ? _value.materialName
+            : materialName // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        batchNo: freezed == batchNo
+            ? _value.batchNo
+            : batchNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        serialNumber: freezed == serialNumber
+            ? _value.serialNumber
+            : serialNumber // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        collectQty: freezed == collectQty
+            ? _value.collectQty
+            : collectQty // ignore: cast_nullable_to_non_nullable
+                  as double?,
+        taskQty: freezed == taskQty
+            ? _value.taskQty
+            : taskQty // ignore: cast_nullable_to_non_nullable
+                  as double?,
+        productionDate: freezed == productionDate
+            ? _value.productionDate
+            : productionDate // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        validDays: freezed == validDays
+            ? _value.validDays
+            : validDays // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        committed: null == committed
+            ? _value.committed
+            : committed // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalCollectSummaryImpl implements _ArrivalCollectSummary {
+  const _$ArrivalCollectSummaryImpl({
+    required this.id,
+    required this.materialCode,
+    this.materialName,
+    this.batchNo,
+    this.serialNumber,
+    this.collectQty,
+    this.taskQty,
+    this.productionDate,
+    this.validDays,
+    this.committed = false,
+  });
+
+  factory _$ArrivalCollectSummaryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalCollectSummaryImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String materialCode;
+  @override
+  final String? materialName;
+  @override
+  final String? batchNo;
+  @override
+  final String? serialNumber;
+  @override
+  final double? collectQty;
+  @override
+  final double? taskQty;
+  @override
+  final String? productionDate;
+  @override
+  final String? validDays;
+  @override
+  @JsonKey()
+  final bool committed;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectSummary(id: $id, materialCode: $materialCode, materialName: $materialName, batchNo: $batchNo, serialNumber: $serialNumber, collectQty: $collectQty, taskQty: $taskQty, productionDate: $productionDate, validDays: $validDays, committed: $committed)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalCollectSummaryImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNumber, serialNumber) ||
+                other.serialNumber == serialNumber) &&
+            (identical(other.collectQty, collectQty) ||
+                other.collectQty == collectQty) &&
+            (identical(other.taskQty, taskQty) || other.taskQty == taskQty) &&
+            (identical(other.productionDate, productionDate) ||
+                other.productionDate == productionDate) &&
+            (identical(other.validDays, validDays) ||
+                other.validDays == validDays) &&
+            (identical(other.committed, committed) ||
+                other.committed == committed));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    materialCode,
+    materialName,
+    batchNo,
+    serialNumber,
+    collectQty,
+    taskQty,
+    productionDate,
+    validDays,
+    committed,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalCollectSummaryImplCopyWith<_$ArrivalCollectSummaryImpl>
+  get copyWith =>
+      __$$ArrivalCollectSummaryImplCopyWithImpl<_$ArrivalCollectSummaryImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalCollectSummaryImplToJson(this);
+  }
+}
+
+abstract class _ArrivalCollectSummary implements ArrivalCollectSummary {
+  const factory _ArrivalCollectSummary({
+    required final String id,
+    required final String materialCode,
+    final String? materialName,
+    final String? batchNo,
+    final String? serialNumber,
+    final double? collectQty,
+    final double? taskQty,
+    final String? productionDate,
+    final String? validDays,
+    final bool committed,
+  }) = _$ArrivalCollectSummaryImpl;
+
+  factory _ArrivalCollectSummary.fromJson(Map<String, dynamic> json) =
+      _$ArrivalCollectSummaryImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get materialCode;
+  @override
+  String? get materialName;
+  @override
+  String? get batchNo;
+  @override
+  String? get serialNumber;
+  @override
+  double? get collectQty;
+  @override
+  double? get taskQty;
+  @override
+  String? get productionDate;
+  @override
+  String? get validDays;
+  @override
+  bool get committed;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalCollectSummaryImplCopyWith<_$ArrivalCollectSummaryImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.g.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'arrival_collect_progress.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ArrivalCollectProgressImpl _$$ArrivalCollectProgressImplFromJson(
+  Map<String, dynamic> json,
+) => _$ArrivalCollectProgressImpl(
+  id: json['id'] as String,
+  task: ArrivalCollectTask.fromJson(json['task'] as Map<String, dynamic>),
+  collectQty: (json['collectQty'] as num).toDouble(),
+  batchNo: json['batchNo'] as String?,
+  serialNumber: json['serialNumber'] as String?,
+  productionDate: json['productionDate'] as String?,
+  validDays: json['validDays'] as String?,
+  submitted: json['submitted'] as bool? ?? false,
+);
+
+Map<String, dynamic> _$$ArrivalCollectProgressImplToJson(
+  _$ArrivalCollectProgressImpl instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'task': _taskToJson(instance.task),
+  'collectQty': instance.collectQty,
+  'batchNo': instance.batchNo,
+  'serialNumber': instance.serialNumber,
+  'productionDate': instance.productionDate,
+  'validDays': instance.validDays,
+  'submitted': instance.submitted,
+};
+
+_$ArrivalCollectSummaryImpl _$$ArrivalCollectSummaryImplFromJson(
+  Map<String, dynamic> json,
+) => _$ArrivalCollectSummaryImpl(
+  id: json['id'] as String,
+  materialCode: json['materialCode'] as String,
+  materialName: json['materialName'] as String?,
+  batchNo: json['batchNo'] as String?,
+  serialNumber: json['serialNumber'] as String?,
+  collectQty: (json['collectQty'] as num?)?.toDouble(),
+  taskQty: (json['taskQty'] as num?)?.toDouble(),
+  productionDate: json['productionDate'] as String?,
+  validDays: json['validDays'] as String?,
+  committed: json['committed'] as bool? ?? false,
+);
+
+Map<String, dynamic> _$$ArrivalCollectSummaryImplToJson(
+  _$ArrivalCollectSummaryImpl instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'materialCode': instance.materialCode,
+  'materialName': instance.materialName,
+  'batchNo': instance.batchNo,
+  'serialNumber': instance.serialNumber,
+  'collectQty': instance.collectQty,
+  'taskQty': instance.taskQty,
+  'productionDate': instance.productionDate,
+  'validDays': instance.validDays,
+  'committed': instance.committed,
+};

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.dart
@@ -1,0 +1,72 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'arrival_collect_progress.dart';
+
+part 'arrival_collect_submit_request.freezed.dart';
+part 'arrival_collect_submit_request.g.dart';
+
+@freezed
+class ArrivalCollectSubmitRequest with _$ArrivalCollectSubmitRequest {
+  const factory ArrivalCollectSubmitRequest({
+    @JsonKey(name: 'upShelvesInfos')
+    @Default(<ArrivalCollectSubmitItem>[])
+    List<ArrivalCollectSubmitItem> upShelvesInfos,
+    @JsonKey(name: 'itemListInfos')
+    @Default(<ArrivalCollectSubmitItem>[])
+    List<ArrivalCollectSubmitItem> itemListInfos,
+    @JsonKey(name: 'filter') ArrivalCollectSubmitFilter? filter,
+  }) = _ArrivalCollectSubmitRequest;
+
+  factory ArrivalCollectSubmitRequest.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalCollectSubmitRequestFromJson(json);
+
+  factory ArrivalCollectSubmitRequest.fromProgressList({
+    required List<ArrivalCollectProgress> progresses,
+    required String? userCode,
+    required String? arrivalsBillId,
+  }) {
+    final items = progresses
+        .map(
+          (progress) => ArrivalCollectSubmitItem(
+            matCode: progress.task.materialCode,
+            batchNo: progress.batchNo ?? progress.task.batchNo,
+            serialNumber: progress.serialNumber ?? progress.task.serialNumber,
+            quantity: progress.collectQty,
+          ),
+        )
+        .toList();
+
+    return ArrivalCollectSubmitRequest(
+      upShelvesInfos: items,
+      itemListInfos: items,
+      filter: ArrivalCollectSubmitFilter(
+        userCode: userCode ?? '',
+        arrivalsBillId: arrivalsBillId ?? '',
+      ),
+    );
+  }
+}
+
+@freezed
+class ArrivalCollectSubmitItem with _$ArrivalCollectSubmitItem {
+  const factory ArrivalCollectSubmitItem({
+    @JsonKey(name: 'matcode') required String matCode,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNumber,
+    @JsonKey(name: 'qty') required double quantity,
+  }) = _ArrivalCollectSubmitItem;
+
+  factory ArrivalCollectSubmitItem.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalCollectSubmitItemFromJson(json);
+}
+
+@freezed
+class ArrivalCollectSubmitFilter with _$ArrivalCollectSubmitFilter {
+  const factory ArrivalCollectSubmitFilter({
+    @JsonKey(name: 'userCode') required String userCode,
+    @JsonKey(name: 'arrivalsBillid') required String arrivalsBillId,
+  }) = _ArrivalCollectSubmitFilter;
+
+  factory ArrivalCollectSubmitFilter.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalCollectSubmitFilterFromJson(json);
+}

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.freezed.dart
@@ -1,0 +1,714 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_collect_submit_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+ArrivalCollectSubmitRequest _$ArrivalCollectSubmitRequestFromJson(
+  Map<String, dynamic> json,
+) {
+  return _ArrivalCollectSubmitRequest.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalCollectSubmitRequest {
+  @JsonKey(name: 'upShelvesInfos')
+  List<ArrivalCollectSubmitItem> get upShelvesInfos =>
+      throw _privateConstructorUsedError;
+  @JsonKey(name: 'itemListInfos')
+  List<ArrivalCollectSubmitItem> get itemListInfos =>
+      throw _privateConstructorUsedError;
+  @JsonKey(name: 'filter')
+  ArrivalCollectSubmitFilter? get filter => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalCollectSubmitRequestCopyWith<ArrivalCollectSubmitRequest>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectSubmitRequestCopyWith<$Res> {
+  factory $ArrivalCollectSubmitRequestCopyWith(
+    ArrivalCollectSubmitRequest value,
+    $Res Function(ArrivalCollectSubmitRequest) then,
+  ) =
+      _$ArrivalCollectSubmitRequestCopyWithImpl<
+        $Res,
+        ArrivalCollectSubmitRequest
+      >;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'upShelvesInfos')
+    List<ArrivalCollectSubmitItem> upShelvesInfos,
+    @JsonKey(name: 'itemListInfos')
+    List<ArrivalCollectSubmitItem> itemListInfos,
+    @JsonKey(name: 'filter') ArrivalCollectSubmitFilter? filter,
+  });
+
+  $ArrivalCollectSubmitFilterCopyWith<$Res>? get filter;
+}
+
+/// @nodoc
+class _$ArrivalCollectSubmitRequestCopyWithImpl<
+  $Res,
+  $Val extends ArrivalCollectSubmitRequest
+>
+    implements $ArrivalCollectSubmitRequestCopyWith<$Res> {
+  _$ArrivalCollectSubmitRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? upShelvesInfos = null,
+    Object? itemListInfos = null,
+    Object? filter = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            upShelvesInfos: null == upShelvesInfos
+                ? _value.upShelvesInfos
+                : upShelvesInfos // ignore: cast_nullable_to_non_nullable
+                      as List<ArrivalCollectSubmitItem>,
+            itemListInfos: null == itemListInfos
+                ? _value.itemListInfos
+                : itemListInfos // ignore: cast_nullable_to_non_nullable
+                      as List<ArrivalCollectSubmitItem>,
+            filter: freezed == filter
+                ? _value.filter
+                : filter // ignore: cast_nullable_to_non_nullable
+                      as ArrivalCollectSubmitFilter?,
+          )
+          as $Val,
+    );
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ArrivalCollectSubmitFilterCopyWith<$Res>? get filter {
+    if (_value.filter == null) {
+      return null;
+    }
+
+    return $ArrivalCollectSubmitFilterCopyWith<$Res>(_value.filter!, (value) {
+      return _then(_value.copyWith(filter: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalCollectSubmitRequestImplCopyWith<$Res>
+    implements $ArrivalCollectSubmitRequestCopyWith<$Res> {
+  factory _$$ArrivalCollectSubmitRequestImplCopyWith(
+    _$ArrivalCollectSubmitRequestImpl value,
+    $Res Function(_$ArrivalCollectSubmitRequestImpl) then,
+  ) = __$$ArrivalCollectSubmitRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'upShelvesInfos')
+    List<ArrivalCollectSubmitItem> upShelvesInfos,
+    @JsonKey(name: 'itemListInfos')
+    List<ArrivalCollectSubmitItem> itemListInfos,
+    @JsonKey(name: 'filter') ArrivalCollectSubmitFilter? filter,
+  });
+
+  @override
+  $ArrivalCollectSubmitFilterCopyWith<$Res>? get filter;
+}
+
+/// @nodoc
+class __$$ArrivalCollectSubmitRequestImplCopyWithImpl<$Res>
+    extends
+        _$ArrivalCollectSubmitRequestCopyWithImpl<
+          $Res,
+          _$ArrivalCollectSubmitRequestImpl
+        >
+    implements _$$ArrivalCollectSubmitRequestImplCopyWith<$Res> {
+  __$$ArrivalCollectSubmitRequestImplCopyWithImpl(
+    _$ArrivalCollectSubmitRequestImpl _value,
+    $Res Function(_$ArrivalCollectSubmitRequestImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? upShelvesInfos = null,
+    Object? itemListInfos = null,
+    Object? filter = freezed,
+  }) {
+    return _then(
+      _$ArrivalCollectSubmitRequestImpl(
+        upShelvesInfos: null == upShelvesInfos
+            ? _value._upShelvesInfos
+            : upShelvesInfos // ignore: cast_nullable_to_non_nullable
+                  as List<ArrivalCollectSubmitItem>,
+        itemListInfos: null == itemListInfos
+            ? _value._itemListInfos
+            : itemListInfos // ignore: cast_nullable_to_non_nullable
+                  as List<ArrivalCollectSubmitItem>,
+        filter: freezed == filter
+            ? _value.filter
+            : filter // ignore: cast_nullable_to_non_nullable
+                  as ArrivalCollectSubmitFilter?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalCollectSubmitRequestImpl
+    implements _ArrivalCollectSubmitRequest {
+  const _$ArrivalCollectSubmitRequestImpl({
+    @JsonKey(name: 'upShelvesInfos')
+    final List<ArrivalCollectSubmitItem> upShelvesInfos =
+        const <ArrivalCollectSubmitItem>[],
+    @JsonKey(name: 'itemListInfos')
+    final List<ArrivalCollectSubmitItem> itemListInfos =
+        const <ArrivalCollectSubmitItem>[],
+    @JsonKey(name: 'filter') this.filter,
+  }) : _upShelvesInfos = upShelvesInfos,
+       _itemListInfos = itemListInfos;
+
+  factory _$ArrivalCollectSubmitRequestImpl.fromJson(
+    Map<String, dynamic> json,
+  ) => _$$ArrivalCollectSubmitRequestImplFromJson(json);
+
+  final List<ArrivalCollectSubmitItem> _upShelvesInfos;
+  @override
+  @JsonKey(name: 'upShelvesInfos')
+  List<ArrivalCollectSubmitItem> get upShelvesInfos {
+    if (_upShelvesInfos is EqualUnmodifiableListView) return _upShelvesInfos;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_upShelvesInfos);
+  }
+
+  final List<ArrivalCollectSubmitItem> _itemListInfos;
+  @override
+  @JsonKey(name: 'itemListInfos')
+  List<ArrivalCollectSubmitItem> get itemListInfos {
+    if (_itemListInfos is EqualUnmodifiableListView) return _itemListInfos;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_itemListInfos);
+  }
+
+  @override
+  @JsonKey(name: 'filter')
+  final ArrivalCollectSubmitFilter? filter;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectSubmitRequest(upShelvesInfos: $upShelvesInfos, itemListInfos: $itemListInfos, filter: $filter)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalCollectSubmitRequestImpl &&
+            const DeepCollectionEquality().equals(
+              other._upShelvesInfos,
+              _upShelvesInfos,
+            ) &&
+            const DeepCollectionEquality().equals(
+              other._itemListInfos,
+              _itemListInfos,
+            ) &&
+            (identical(other.filter, filter) || other.filter == filter));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_upShelvesInfos),
+    const DeepCollectionEquality().hash(_itemListInfos),
+    filter,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalCollectSubmitRequestImplCopyWith<_$ArrivalCollectSubmitRequestImpl>
+  get copyWith =>
+      __$$ArrivalCollectSubmitRequestImplCopyWithImpl<
+        _$ArrivalCollectSubmitRequestImpl
+      >(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalCollectSubmitRequestImplToJson(this);
+  }
+}
+
+abstract class _ArrivalCollectSubmitRequest
+    implements ArrivalCollectSubmitRequest {
+  const factory _ArrivalCollectSubmitRequest({
+    @JsonKey(name: 'upShelvesInfos')
+    final List<ArrivalCollectSubmitItem> upShelvesInfos,
+    @JsonKey(name: 'itemListInfos')
+    final List<ArrivalCollectSubmitItem> itemListInfos,
+    @JsonKey(name: 'filter') final ArrivalCollectSubmitFilter? filter,
+  }) = _$ArrivalCollectSubmitRequestImpl;
+
+  factory _ArrivalCollectSubmitRequest.fromJson(Map<String, dynamic> json) =
+      _$ArrivalCollectSubmitRequestImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'upShelvesInfos')
+  List<ArrivalCollectSubmitItem> get upShelvesInfos;
+  @override
+  @JsonKey(name: 'itemListInfos')
+  List<ArrivalCollectSubmitItem> get itemListInfos;
+  @override
+  @JsonKey(name: 'filter')
+  ArrivalCollectSubmitFilter? get filter;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalCollectSubmitRequestImplCopyWith<_$ArrivalCollectSubmitRequestImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+ArrivalCollectSubmitItem _$ArrivalCollectSubmitItemFromJson(
+  Map<String, dynamic> json,
+) {
+  return _ArrivalCollectSubmitItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalCollectSubmitItem {
+  @JsonKey(name: 'matcode')
+  String get matCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'batchno')
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sn')
+  String? get serialNumber => throw _privateConstructorUsedError;
+  @JsonKey(name: 'qty')
+  double get quantity => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalCollectSubmitItemCopyWith<ArrivalCollectSubmitItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectSubmitItemCopyWith<$Res> {
+  factory $ArrivalCollectSubmitItemCopyWith(
+    ArrivalCollectSubmitItem value,
+    $Res Function(ArrivalCollectSubmitItem) then,
+  ) = _$ArrivalCollectSubmitItemCopyWithImpl<$Res, ArrivalCollectSubmitItem>;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'matcode') String matCode,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNumber,
+    @JsonKey(name: 'qty') double quantity,
+  });
+}
+
+/// @nodoc
+class _$ArrivalCollectSubmitItemCopyWithImpl<
+  $Res,
+  $Val extends ArrivalCollectSubmitItem
+>
+    implements $ArrivalCollectSubmitItemCopyWith<$Res> {
+  _$ArrivalCollectSubmitItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? matCode = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? quantity = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            matCode: null == matCode
+                ? _value.matCode
+                : matCode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            batchNo: freezed == batchNo
+                ? _value.batchNo
+                : batchNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            serialNumber: freezed == serialNumber
+                ? _value.serialNumber
+                : serialNumber // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            quantity: null == quantity
+                ? _value.quantity
+                : quantity // ignore: cast_nullable_to_non_nullable
+                      as double,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalCollectSubmitItemImplCopyWith<$Res>
+    implements $ArrivalCollectSubmitItemCopyWith<$Res> {
+  factory _$$ArrivalCollectSubmitItemImplCopyWith(
+    _$ArrivalCollectSubmitItemImpl value,
+    $Res Function(_$ArrivalCollectSubmitItemImpl) then,
+  ) = __$$ArrivalCollectSubmitItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'matcode') String matCode,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNumber,
+    @JsonKey(name: 'qty') double quantity,
+  });
+}
+
+/// @nodoc
+class __$$ArrivalCollectSubmitItemImplCopyWithImpl<$Res>
+    extends
+        _$ArrivalCollectSubmitItemCopyWithImpl<
+          $Res,
+          _$ArrivalCollectSubmitItemImpl
+        >
+    implements _$$ArrivalCollectSubmitItemImplCopyWith<$Res> {
+  __$$ArrivalCollectSubmitItemImplCopyWithImpl(
+    _$ArrivalCollectSubmitItemImpl _value,
+    $Res Function(_$ArrivalCollectSubmitItemImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? matCode = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? quantity = null,
+  }) {
+    return _then(
+      _$ArrivalCollectSubmitItemImpl(
+        matCode: null == matCode
+            ? _value.matCode
+            : matCode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        batchNo: freezed == batchNo
+            ? _value.batchNo
+            : batchNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        serialNumber: freezed == serialNumber
+            ? _value.serialNumber
+            : serialNumber // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        quantity: null == quantity
+            ? _value.quantity
+            : quantity // ignore: cast_nullable_to_non_nullable
+                  as double,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalCollectSubmitItemImpl implements _ArrivalCollectSubmitItem {
+  const _$ArrivalCollectSubmitItemImpl({
+    @JsonKey(name: 'matcode') required this.matCode,
+    @JsonKey(name: 'batchno') this.batchNo,
+    @JsonKey(name: 'sn') this.serialNumber,
+    @JsonKey(name: 'qty') required this.quantity,
+  });
+
+  factory _$ArrivalCollectSubmitItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalCollectSubmitItemImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'matcode')
+  final String matCode;
+  @override
+  @JsonKey(name: 'batchno')
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNumber;
+  @override
+  @JsonKey(name: 'qty')
+  final double quantity;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectSubmitItem(matCode: $matCode, batchNo: $batchNo, serialNumber: $serialNumber, quantity: $quantity)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalCollectSubmitItemImpl &&
+            (identical(other.matCode, matCode) || other.matCode == matCode) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNumber, serialNumber) ||
+                other.serialNumber == serialNumber) &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, matCode, batchNo, serialNumber, quantity);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalCollectSubmitItemImplCopyWith<_$ArrivalCollectSubmitItemImpl>
+  get copyWith =>
+      __$$ArrivalCollectSubmitItemImplCopyWithImpl<
+        _$ArrivalCollectSubmitItemImpl
+      >(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalCollectSubmitItemImplToJson(this);
+  }
+}
+
+abstract class _ArrivalCollectSubmitItem implements ArrivalCollectSubmitItem {
+  const factory _ArrivalCollectSubmitItem({
+    @JsonKey(name: 'matcode') required final String matCode,
+    @JsonKey(name: 'batchno') final String? batchNo,
+    @JsonKey(name: 'sn') final String? serialNumber,
+    @JsonKey(name: 'qty') required final double quantity,
+  }) = _$ArrivalCollectSubmitItemImpl;
+
+  factory _ArrivalCollectSubmitItem.fromJson(Map<String, dynamic> json) =
+      _$ArrivalCollectSubmitItemImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'matcode')
+  String get matCode;
+  @override
+  @JsonKey(name: 'batchno')
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  String? get serialNumber;
+  @override
+  @JsonKey(name: 'qty')
+  double get quantity;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalCollectSubmitItemImplCopyWith<_$ArrivalCollectSubmitItemImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+ArrivalCollectSubmitFilter _$ArrivalCollectSubmitFilterFromJson(
+  Map<String, dynamic> json,
+) {
+  return _ArrivalCollectSubmitFilter.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalCollectSubmitFilter {
+  @JsonKey(name: 'userCode')
+  String get userCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'arrivalsBillid')
+  String get arrivalsBillId => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalCollectSubmitFilterCopyWith<ArrivalCollectSubmitFilter>
+  get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectSubmitFilterCopyWith<$Res> {
+  factory $ArrivalCollectSubmitFilterCopyWith(
+    ArrivalCollectSubmitFilter value,
+    $Res Function(ArrivalCollectSubmitFilter) then,
+  ) =
+      _$ArrivalCollectSubmitFilterCopyWithImpl<
+        $Res,
+        ArrivalCollectSubmitFilter
+      >;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'userCode') String userCode,
+    @JsonKey(name: 'arrivalsBillid') String arrivalsBillId,
+  });
+}
+
+/// @nodoc
+class _$ArrivalCollectSubmitFilterCopyWithImpl<
+  $Res,
+  $Val extends ArrivalCollectSubmitFilter
+>
+    implements $ArrivalCollectSubmitFilterCopyWith<$Res> {
+  _$ArrivalCollectSubmitFilterCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? userCode = null, Object? arrivalsBillId = null}) {
+    return _then(
+      _value.copyWith(
+            userCode: null == userCode
+                ? _value.userCode
+                : userCode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            arrivalsBillId: null == arrivalsBillId
+                ? _value.arrivalsBillId
+                : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalCollectSubmitFilterImplCopyWith<$Res>
+    implements $ArrivalCollectSubmitFilterCopyWith<$Res> {
+  factory _$$ArrivalCollectSubmitFilterImplCopyWith(
+    _$ArrivalCollectSubmitFilterImpl value,
+    $Res Function(_$ArrivalCollectSubmitFilterImpl) then,
+  ) = __$$ArrivalCollectSubmitFilterImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'userCode') String userCode,
+    @JsonKey(name: 'arrivalsBillid') String arrivalsBillId,
+  });
+}
+
+/// @nodoc
+class __$$ArrivalCollectSubmitFilterImplCopyWithImpl<$Res>
+    extends
+        _$ArrivalCollectSubmitFilterCopyWithImpl<
+          $Res,
+          _$ArrivalCollectSubmitFilterImpl
+        >
+    implements _$$ArrivalCollectSubmitFilterImplCopyWith<$Res> {
+  __$$ArrivalCollectSubmitFilterImplCopyWithImpl(
+    _$ArrivalCollectSubmitFilterImpl _value,
+    $Res Function(_$ArrivalCollectSubmitFilterImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? userCode = null, Object? arrivalsBillId = null}) {
+    return _then(
+      _$ArrivalCollectSubmitFilterImpl(
+        userCode: null == userCode
+            ? _value.userCode
+            : userCode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        arrivalsBillId: null == arrivalsBillId
+            ? _value.arrivalsBillId
+            : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalCollectSubmitFilterImpl implements _ArrivalCollectSubmitFilter {
+  const _$ArrivalCollectSubmitFilterImpl({
+    @JsonKey(name: 'userCode') required this.userCode,
+    @JsonKey(name: 'arrivalsBillid') required this.arrivalsBillId,
+  });
+
+  factory _$ArrivalCollectSubmitFilterImpl.fromJson(
+    Map<String, dynamic> json,
+  ) => _$$ArrivalCollectSubmitFilterImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'userCode')
+  final String userCode;
+  @override
+  @JsonKey(name: 'arrivalsBillid')
+  final String arrivalsBillId;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectSubmitFilter(userCode: $userCode, arrivalsBillId: $arrivalsBillId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalCollectSubmitFilterImpl &&
+            (identical(other.userCode, userCode) ||
+                other.userCode == userCode) &&
+            (identical(other.arrivalsBillId, arrivalsBillId) ||
+                other.arrivalsBillId == arrivalsBillId));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, userCode, arrivalsBillId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalCollectSubmitFilterImplCopyWith<_$ArrivalCollectSubmitFilterImpl>
+  get copyWith =>
+      __$$ArrivalCollectSubmitFilterImplCopyWithImpl<
+        _$ArrivalCollectSubmitFilterImpl
+      >(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalCollectSubmitFilterImplToJson(this);
+  }
+}
+
+abstract class _ArrivalCollectSubmitFilter
+    implements ArrivalCollectSubmitFilter {
+  const factory _ArrivalCollectSubmitFilter({
+    @JsonKey(name: 'userCode') required final String userCode,
+    @JsonKey(name: 'arrivalsBillid') required final String arrivalsBillId,
+  }) = _$ArrivalCollectSubmitFilterImpl;
+
+  factory _ArrivalCollectSubmitFilter.fromJson(Map<String, dynamic> json) =
+      _$ArrivalCollectSubmitFilterImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'userCode')
+  String get userCode;
+  @override
+  @JsonKey(name: 'arrivalsBillid')
+  String get arrivalsBillId;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalCollectSubmitFilterImplCopyWith<_$ArrivalCollectSubmitFilterImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.g.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'arrival_collect_submit_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ArrivalCollectSubmitRequestImpl _$$ArrivalCollectSubmitRequestImplFromJson(
+  Map<String, dynamic> json,
+) => _$ArrivalCollectSubmitRequestImpl(
+  upShelvesInfos:
+      (json['upShelvesInfos'] as List<dynamic>?)
+          ?.map(
+            (e) => ArrivalCollectSubmitItem.fromJson(e as Map<String, dynamic>),
+          )
+          .toList() ??
+      const <ArrivalCollectSubmitItem>[],
+  itemListInfos:
+      (json['itemListInfos'] as List<dynamic>?)
+          ?.map(
+            (e) => ArrivalCollectSubmitItem.fromJson(e as Map<String, dynamic>),
+          )
+          .toList() ??
+      const <ArrivalCollectSubmitItem>[],
+  filter: json['filter'] == null
+      ? null
+      : ArrivalCollectSubmitFilter.fromJson(
+          json['filter'] as Map<String, dynamic>,
+        ),
+);
+
+Map<String, dynamic> _$$ArrivalCollectSubmitRequestImplToJson(
+  _$ArrivalCollectSubmitRequestImpl instance,
+) => <String, dynamic>{
+  'upShelvesInfos': instance.upShelvesInfos,
+  'itemListInfos': instance.itemListInfos,
+  'filter': instance.filter,
+};
+
+_$ArrivalCollectSubmitItemImpl _$$ArrivalCollectSubmitItemImplFromJson(
+  Map<String, dynamic> json,
+) => _$ArrivalCollectSubmitItemImpl(
+  matCode: json['matcode'] as String,
+  batchNo: json['batchno'] as String?,
+  serialNumber: json['sn'] as String?,
+  quantity: (json['qty'] as num).toDouble(),
+);
+
+Map<String, dynamic> _$$ArrivalCollectSubmitItemImplToJson(
+  _$ArrivalCollectSubmitItemImpl instance,
+) => <String, dynamic>{
+  'matcode': instance.matCode,
+  'batchno': instance.batchNo,
+  'sn': instance.serialNumber,
+  'qty': instance.quantity,
+};
+
+_$ArrivalCollectSubmitFilterImpl _$$ArrivalCollectSubmitFilterImplFromJson(
+  Map<String, dynamic> json,
+) => _$ArrivalCollectSubmitFilterImpl(
+  userCode: json['userCode'] as String,
+  arrivalsBillId: json['arrivalsBillid'] as String,
+);
+
+Map<String, dynamic> _$$ArrivalCollectSubmitFilterImplToJson(
+  _$ArrivalCollectSubmitFilterImpl instance,
+) => <String, dynamic>{
+  'userCode': instance.userCode,
+  'arrivalsBillid': instance.arrivalsBillId,
+};

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.dart
@@ -1,0 +1,88 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart';
+
+part 'arrival_collect_task.freezed.dart';
+part 'arrival_collect_task.g.dart';
+
+/// 采集页面的任务行模型。
+@freezed
+class ArrivalCollectTask with _$ArrivalCollectTask {
+  const ArrivalCollectTask._();
+
+  const factory ArrivalCollectTask({
+    /// 物料编码
+    @JsonKey(name: 'matcode') required String materialCode,
+
+    /// 物料名称
+    @JsonKey(name: 'matname') String? materialName,
+
+    /// 到货单号
+    @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
+
+    /// 到货单行ID
+    @JsonKey(name: 'arrivalsBillid') String? arrivalsBillId,
+
+    /// 采购单号
+    @JsonKey(name: 'orderno') String? orderNo,
+
+    /// 计划数量
+    @JsonKey(name: 'qty') required double plannedQuantity,
+
+    /// 已良品数量
+    @JsonKey(name: 'goodqty') required double collectedQuantity,
+
+    /// 初始良品数量（用于删除/恢复时回写）
+    @JsonKey(ignore: true) @Default(0) double baseCollectedQuantity,
+
+    /// 单位
+    @JsonKey(name: 'meins') String? unit,
+
+    /// 批次号
+    @JsonKey(name: 'batchno') String? batchNo,
+
+    /// 序列号
+    String? serialNumber,
+
+    /// 库位编码
+    @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
+
+    /// 物料控制类型（0 无、1 批次、2 序列）
+    @JsonKey(name: 'matcodecontrol') int? materialControlType,
+
+    /// 生产日期
+    @JsonKey(name: 'pdate') String? productionDate,
+
+    /// 有效天数
+    @JsonKey(name: 'vdays') String? validDays,
+  }) = _ArrivalCollectTask;
+
+  factory ArrivalCollectTask.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalCollectTaskFromJson(json);
+
+  factory ArrivalCollectTask.fromDetail(
+    ArrivalSignDetail detail, {
+    String? arrivalsBillId,
+  }) {
+    final goodQty = detail.goodQuantity.toDouble();
+
+    return ArrivalCollectTask(
+      materialCode: detail.materialCode,
+      materialName: detail.materialName,
+      arrivalsBillNo: detail.arrivalsBillNo,
+      arrivalsBillId: arrivalsBillId,
+      orderNo: detail.orderNo,
+      plannedQuantity: detail.quantity.toDouble(),
+      collectedQuantity: goodQty,
+      baseCollectedQuantity: goodQty,
+      unit: detail.unit,
+      batchNo: detail.batchNo,
+      serialNumber: detail.serialNumber,
+      subInventoryCode: detail.subInventoryCode,
+      materialControlType: int.tryParse(detail.controlType ?? ''),
+      productionDate: detail.productionDate,
+      validDays: detail.validDays,
+    );
+  }
+
+  double get remainingQuantity => plannedQuantity - collectedQuantity;
+}

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.freezed.dart
@@ -1,0 +1,594 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_collect_task.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+ArrivalCollectTask _$ArrivalCollectTaskFromJson(Map<String, dynamic> json) {
+  return _ArrivalCollectTask.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalCollectTask {
+  /// 物料编码
+  @JsonKey(name: 'matcode')
+  String get materialCode => throw _privateConstructorUsedError;
+
+  /// 物料名称
+  @JsonKey(name: 'matname')
+  String? get materialName => throw _privateConstructorUsedError;
+
+  /// 到货单号
+  @JsonKey(name: 'arrivalsBillno')
+  String? get arrivalsBillNo => throw _privateConstructorUsedError;
+
+  /// 到货单行ID
+  @JsonKey(name: 'arrivalsBillid')
+  String? get arrivalsBillId => throw _privateConstructorUsedError;
+
+  /// 采购单号
+  @JsonKey(name: 'orderno')
+  String? get orderNo => throw _privateConstructorUsedError;
+
+  /// 计划数量
+  @JsonKey(name: 'qty')
+  double get plannedQuantity => throw _privateConstructorUsedError;
+
+  /// 已良品数量
+  @JsonKey(name: 'goodqty')
+  double get collectedQuantity => throw _privateConstructorUsedError;
+
+  /// 初始良品数量（用于删除/恢复时回写）
+  @JsonKey(ignore: true)
+  double get baseCollectedQuantity => throw _privateConstructorUsedError;
+
+  /// 单位
+  @JsonKey(name: 'meins')
+  String? get unit => throw _privateConstructorUsedError;
+
+  /// 批次号
+  @JsonKey(name: 'batchno')
+  String? get batchNo => throw _privateConstructorUsedError;
+
+  /// 序列号
+  String? get serialNumber => throw _privateConstructorUsedError;
+
+  /// 库位编码
+  @JsonKey(name: 'subinventoryCode')
+  String? get subInventoryCode => throw _privateConstructorUsedError;
+
+  /// 物料控制类型（0 无、1 批次、2 序列）
+  @JsonKey(name: 'matcodecontrol')
+  int? get materialControlType => throw _privateConstructorUsedError;
+
+  /// 生产日期
+  @JsonKey(name: 'pdate')
+  String? get productionDate => throw _privateConstructorUsedError;
+
+  /// 有效天数
+  @JsonKey(name: 'vdays')
+  String? get validDays => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalCollectTaskCopyWith<ArrivalCollectTask> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalCollectTaskCopyWith<$Res> {
+  factory $ArrivalCollectTaskCopyWith(
+    ArrivalCollectTask value,
+    $Res Function(ArrivalCollectTask) then,
+  ) = _$ArrivalCollectTaskCopyWithImpl<$Res, ArrivalCollectTask>;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'matcode') String materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
+    @JsonKey(name: 'arrivalsBillid') String? arrivalsBillId,
+    @JsonKey(name: 'orderno') String? orderNo,
+    @JsonKey(name: 'qty') double plannedQuantity,
+    @JsonKey(name: 'goodqty') double collectedQuantity,
+    @JsonKey(ignore: true) double baseCollectedQuantity,
+    @JsonKey(name: 'meins') String? unit,
+    @JsonKey(name: 'batchno') String? batchNo,
+    String? serialNumber,
+    @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
+    @JsonKey(name: 'matcodecontrol') int? materialControlType,
+    @JsonKey(name: 'pdate') String? productionDate,
+    @JsonKey(name: 'vdays') String? validDays,
+  });
+}
+
+/// @nodoc
+class _$ArrivalCollectTaskCopyWithImpl<$Res, $Val extends ArrivalCollectTask>
+    implements $ArrivalCollectTaskCopyWith<$Res> {
+  _$ArrivalCollectTaskCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? arrivalsBillNo = freezed,
+    Object? arrivalsBillId = freezed,
+    Object? orderNo = freezed,
+    Object? plannedQuantity = null,
+    Object? collectedQuantity = null,
+    Object? baseCollectedQuantity = null,
+    Object? unit = freezed,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? subInventoryCode = freezed,
+    Object? materialControlType = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            materialCode: null == materialCode
+                ? _value.materialCode
+                : materialCode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            materialName: freezed == materialName
+                ? _value.materialName
+                : materialName // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            arrivalsBillNo: freezed == arrivalsBillNo
+                ? _value.arrivalsBillNo
+                : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            arrivalsBillId: freezed == arrivalsBillId
+                ? _value.arrivalsBillId
+                : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            orderNo: freezed == orderNo
+                ? _value.orderNo
+                : orderNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            plannedQuantity: null == plannedQuantity
+                ? _value.plannedQuantity
+                : plannedQuantity // ignore: cast_nullable_to_non_nullable
+                      as double,
+            collectedQuantity: null == collectedQuantity
+                ? _value.collectedQuantity
+                : collectedQuantity // ignore: cast_nullable_to_non_nullable
+                      as double,
+            baseCollectedQuantity: null == baseCollectedQuantity
+                ? _value.baseCollectedQuantity
+                : baseCollectedQuantity // ignore: cast_nullable_to_non_nullable
+                      as double,
+            unit: freezed == unit
+                ? _value.unit
+                : unit // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            batchNo: freezed == batchNo
+                ? _value.batchNo
+                : batchNo // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            serialNumber: freezed == serialNumber
+                ? _value.serialNumber
+                : serialNumber // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            subInventoryCode: freezed == subInventoryCode
+                ? _value.subInventoryCode
+                : subInventoryCode // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            materialControlType: freezed == materialControlType
+                ? _value.materialControlType
+                : materialControlType // ignore: cast_nullable_to_non_nullable
+                      as int?,
+            productionDate: freezed == productionDate
+                ? _value.productionDate
+                : productionDate // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            validDays: freezed == validDays
+                ? _value.validDays
+                : validDays // ignore: cast_nullable_to_non_nullable
+                      as String?,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalCollectTaskImplCopyWith<$Res>
+    implements $ArrivalCollectTaskCopyWith<$Res> {
+  factory _$$ArrivalCollectTaskImplCopyWith(
+    _$ArrivalCollectTaskImpl value,
+    $Res Function(_$ArrivalCollectTaskImpl) then,
+  ) = __$$ArrivalCollectTaskImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'matcode') String materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
+    @JsonKey(name: 'arrivalsBillid') String? arrivalsBillId,
+    @JsonKey(name: 'orderno') String? orderNo,
+    @JsonKey(name: 'qty') double plannedQuantity,
+    @JsonKey(name: 'goodqty') double collectedQuantity,
+    @JsonKey(ignore: true) double baseCollectedQuantity,
+    @JsonKey(name: 'meins') String? unit,
+    @JsonKey(name: 'batchno') String? batchNo,
+    String? serialNumber,
+    @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
+    @JsonKey(name: 'matcodecontrol') int? materialControlType,
+    @JsonKey(name: 'pdate') String? productionDate,
+    @JsonKey(name: 'vdays') String? validDays,
+  });
+}
+
+/// @nodoc
+class __$$ArrivalCollectTaskImplCopyWithImpl<$Res>
+    extends _$ArrivalCollectTaskCopyWithImpl<$Res, _$ArrivalCollectTaskImpl>
+    implements _$$ArrivalCollectTaskImplCopyWith<$Res> {
+  __$$ArrivalCollectTaskImplCopyWithImpl(
+    _$ArrivalCollectTaskImpl _value,
+    $Res Function(_$ArrivalCollectTaskImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? arrivalsBillNo = freezed,
+    Object? arrivalsBillId = freezed,
+    Object? orderNo = freezed,
+    Object? plannedQuantity = null,
+    Object? collectedQuantity = null,
+    Object? baseCollectedQuantity = null,
+    Object? unit = freezed,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? subInventoryCode = freezed,
+    Object? materialControlType = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+  }) {
+    return _then(
+      _$ArrivalCollectTaskImpl(
+        materialCode: null == materialCode
+            ? _value.materialCode
+            : materialCode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        materialName: freezed == materialName
+            ? _value.materialName
+            : materialName // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        arrivalsBillNo: freezed == arrivalsBillNo
+            ? _value.arrivalsBillNo
+            : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        arrivalsBillId: freezed == arrivalsBillId
+            ? _value.arrivalsBillId
+            : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        orderNo: freezed == orderNo
+            ? _value.orderNo
+            : orderNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        plannedQuantity: null == plannedQuantity
+            ? _value.plannedQuantity
+            : plannedQuantity // ignore: cast_nullable_to_non_nullable
+                  as double,
+        collectedQuantity: null == collectedQuantity
+            ? _value.collectedQuantity
+            : collectedQuantity // ignore: cast_nullable_to_non_nullable
+                  as double,
+        baseCollectedQuantity: null == baseCollectedQuantity
+            ? _value.baseCollectedQuantity
+            : baseCollectedQuantity // ignore: cast_nullable_to_non_nullable
+                  as double,
+        unit: freezed == unit
+            ? _value.unit
+            : unit // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        batchNo: freezed == batchNo
+            ? _value.batchNo
+            : batchNo // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        serialNumber: freezed == serialNumber
+            ? _value.serialNumber
+            : serialNumber // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        subInventoryCode: freezed == subInventoryCode
+            ? _value.subInventoryCode
+            : subInventoryCode // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        materialControlType: freezed == materialControlType
+            ? _value.materialControlType
+            : materialControlType // ignore: cast_nullable_to_non_nullable
+                  as int?,
+        productionDate: freezed == productionDate
+            ? _value.productionDate
+            : productionDate // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        validDays: freezed == validDays
+            ? _value.validDays
+            : validDays // ignore: cast_nullable_to_non_nullable
+                  as String?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalCollectTaskImpl extends _ArrivalCollectTask {
+  const _$ArrivalCollectTaskImpl({
+    @JsonKey(name: 'matcode') required this.materialCode,
+    @JsonKey(name: 'matname') this.materialName,
+    @JsonKey(name: 'arrivalsBillno') this.arrivalsBillNo,
+    @JsonKey(name: 'arrivalsBillid') this.arrivalsBillId,
+    @JsonKey(name: 'orderno') this.orderNo,
+    @JsonKey(name: 'qty') required this.plannedQuantity,
+    @JsonKey(name: 'goodqty') required this.collectedQuantity,
+    @JsonKey(ignore: true) this.baseCollectedQuantity = 0,
+    @JsonKey(name: 'meins') this.unit,
+    @JsonKey(name: 'batchno') this.batchNo,
+    this.serialNumber,
+    @JsonKey(name: 'subinventoryCode') this.subInventoryCode,
+    @JsonKey(name: 'matcodecontrol') this.materialControlType,
+    @JsonKey(name: 'pdate') this.productionDate,
+    @JsonKey(name: 'vdays') this.validDays,
+  }) : super._();
+
+  factory _$ArrivalCollectTaskImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalCollectTaskImplFromJson(json);
+
+  /// 物料编码
+  @override
+  @JsonKey(name: 'matcode')
+  final String materialCode;
+
+  /// 物料名称
+  @override
+  @JsonKey(name: 'matname')
+  final String? materialName;
+
+  /// 到货单号
+  @override
+  @JsonKey(name: 'arrivalsBillno')
+  final String? arrivalsBillNo;
+
+  /// 到货单行ID
+  @override
+  @JsonKey(name: 'arrivalsBillid')
+  final String? arrivalsBillId;
+
+  /// 采购单号
+  @override
+  @JsonKey(name: 'orderno')
+  final String? orderNo;
+
+  /// 计划数量
+  @override
+  @JsonKey(name: 'qty')
+  final double plannedQuantity;
+
+  /// 已良品数量
+  @override
+  @JsonKey(name: 'goodqty')
+  final double collectedQuantity;
+
+  /// 初始良品数量（用于删除/恢复时回写）
+  @override
+  @JsonKey(ignore: true)
+  final double baseCollectedQuantity;
+
+  /// 单位
+  @override
+  @JsonKey(name: 'meins')
+  final String? unit;
+
+  /// 批次号
+  @override
+  @JsonKey(name: 'batchno')
+  final String? batchNo;
+
+  /// 序列号
+  @override
+  final String? serialNumber;
+
+  /// 库位编码
+  @override
+  @JsonKey(name: 'subinventoryCode')
+  final String? subInventoryCode;
+
+  /// 物料控制类型（0 无、1 批次、2 序列）
+  @override
+  @JsonKey(name: 'matcodecontrol')
+  final int? materialControlType;
+
+  /// 生产日期
+  @override
+  @JsonKey(name: 'pdate')
+  final String? productionDate;
+
+  /// 有效天数
+  @override
+  @JsonKey(name: 'vdays')
+  final String? validDays;
+
+  @override
+  String toString() {
+    return 'ArrivalCollectTask(materialCode: $materialCode, materialName: $materialName, arrivalsBillNo: $arrivalsBillNo, arrivalsBillId: $arrivalsBillId, orderNo: $orderNo, plannedQuantity: $plannedQuantity, collectedQuantity: $collectedQuantity, baseCollectedQuantity: $baseCollectedQuantity, unit: $unit, batchNo: $batchNo, serialNumber: $serialNumber, subInventoryCode: $subInventoryCode, materialControlType: $materialControlType, productionDate: $productionDate, validDays: $validDays)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalCollectTaskImpl &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.arrivalsBillNo, arrivalsBillNo) ||
+                other.arrivalsBillNo == arrivalsBillNo) &&
+            (identical(other.arrivalsBillId, arrivalsBillId) ||
+                other.arrivalsBillId == arrivalsBillId) &&
+            (identical(other.orderNo, orderNo) || other.orderNo == orderNo) &&
+            (identical(other.plannedQuantity, plannedQuantity) ||
+                other.plannedQuantity == plannedQuantity) &&
+            (identical(other.collectedQuantity, collectedQuantity) ||
+                other.collectedQuantity == collectedQuantity) &&
+            (identical(other.baseCollectedQuantity, baseCollectedQuantity) ||
+                other.baseCollectedQuantity == baseCollectedQuantity) &&
+            (identical(other.unit, unit) || other.unit == unit) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNumber, serialNumber) ||
+                other.serialNumber == serialNumber) &&
+            (identical(other.subInventoryCode, subInventoryCode) ||
+                other.subInventoryCode == subInventoryCode) &&
+            (identical(other.materialControlType, materialControlType) ||
+                other.materialControlType == materialControlType) &&
+            (identical(other.productionDate, productionDate) ||
+                other.productionDate == productionDate) &&
+            (identical(other.validDays, validDays) ||
+                other.validDays == validDays));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    materialCode,
+    materialName,
+    arrivalsBillNo,
+    arrivalsBillId,
+    orderNo,
+    plannedQuantity,
+    collectedQuantity,
+    baseCollectedQuantity,
+    unit,
+    batchNo,
+    serialNumber,
+    subInventoryCode,
+    materialControlType,
+    productionDate,
+    validDays,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalCollectTaskImplCopyWith<_$ArrivalCollectTaskImpl> get copyWith =>
+      __$$ArrivalCollectTaskImplCopyWithImpl<_$ArrivalCollectTaskImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalCollectTaskImplToJson(this);
+  }
+}
+
+abstract class _ArrivalCollectTask extends ArrivalCollectTask {
+  const factory _ArrivalCollectTask({
+    @JsonKey(name: 'matcode') required final String materialCode,
+    @JsonKey(name: 'matname') final String? materialName,
+    @JsonKey(name: 'arrivalsBillno') final String? arrivalsBillNo,
+    @JsonKey(name: 'arrivalsBillid') final String? arrivalsBillId,
+    @JsonKey(name: 'orderno') final String? orderNo,
+    @JsonKey(name: 'qty') required final double plannedQuantity,
+    @JsonKey(name: 'goodqty') required final double collectedQuantity,
+    @JsonKey(ignore: true) final double baseCollectedQuantity,
+    @JsonKey(name: 'meins') final String? unit,
+    @JsonKey(name: 'batchno') final String? batchNo,
+    final String? serialNumber,
+    @JsonKey(name: 'subinventoryCode') final String? subInventoryCode,
+    @JsonKey(name: 'matcodecontrol') final int? materialControlType,
+    @JsonKey(name: 'pdate') final String? productionDate,
+    @JsonKey(name: 'vdays') final String? validDays,
+  }) = _$ArrivalCollectTaskImpl;
+  const _ArrivalCollectTask._() : super._();
+
+  factory _ArrivalCollectTask.fromJson(Map<String, dynamic> json) =
+      _$ArrivalCollectTaskImpl.fromJson;
+
+  @override
+  /// 物料编码
+  @JsonKey(name: 'matcode')
+  String get materialCode;
+  @override
+  /// 物料名称
+  @JsonKey(name: 'matname')
+  String? get materialName;
+  @override
+  /// 到货单号
+  @JsonKey(name: 'arrivalsBillno')
+  String? get arrivalsBillNo;
+  @override
+  /// 到货单行ID
+  @JsonKey(name: 'arrivalsBillid')
+  String? get arrivalsBillId;
+  @override
+  /// 采购单号
+  @JsonKey(name: 'orderno')
+  String? get orderNo;
+  @override
+  /// 计划数量
+  @JsonKey(name: 'qty')
+  double get plannedQuantity;
+  @override
+  /// 已良品数量
+  @JsonKey(name: 'goodqty')
+  double get collectedQuantity;
+  @override
+  /// 初始良品数量（用于删除/恢复时回写）
+  @JsonKey(ignore: true)
+  double get baseCollectedQuantity;
+  @override
+  /// 单位
+  @JsonKey(name: 'meins')
+  String? get unit;
+  @override
+  /// 批次号
+  @JsonKey(name: 'batchno')
+  String? get batchNo;
+  @override
+  /// 序列号
+  String? get serialNumber;
+  @override
+  /// 库位编码
+  @JsonKey(name: 'subinventoryCode')
+  String? get subInventoryCode;
+  @override
+  /// 物料控制类型（0 无、1 批次、2 序列）
+  @JsonKey(name: 'matcodecontrol')
+  int? get materialControlType;
+  @override
+  /// 生产日期
+  @JsonKey(name: 'pdate')
+  String? get productionDate;
+  @override
+  /// 有效天数
+  @JsonKey(name: 'vdays')
+  String? get validDays;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalCollectTaskImplCopyWith<_$ArrivalCollectTaskImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.g.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.g.dart
@@ -1,0 +1,45 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'arrival_collect_task.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ArrivalCollectTaskImpl _$$ArrivalCollectTaskImplFromJson(
+  Map<String, dynamic> json,
+) => _$ArrivalCollectTaskImpl(
+  materialCode: json['matcode'] as String,
+  materialName: json['matname'] as String?,
+  arrivalsBillNo: json['arrivalsBillno'] as String?,
+  arrivalsBillId: json['arrivalsBillid'] as String?,
+  orderNo: json['orderno'] as String?,
+  plannedQuantity: (json['qty'] as num).toDouble(),
+  collectedQuantity: (json['goodqty'] as num).toDouble(),
+  unit: json['meins'] as String?,
+  batchNo: json['batchno'] as String?,
+  serialNumber: json['serialNumber'] as String?,
+  subInventoryCode: json['subinventoryCode'] as String?,
+  materialControlType: (json['matcodecontrol'] as num?)?.toInt(),
+  productionDate: json['pdate'] as String?,
+  validDays: json['vdays'] as String?,
+);
+
+Map<String, dynamic> _$$ArrivalCollectTaskImplToJson(
+  _$ArrivalCollectTaskImpl instance,
+) => <String, dynamic>{
+  'matcode': instance.materialCode,
+  'matname': instance.materialName,
+  'arrivalsBillno': instance.arrivalsBillNo,
+  'arrivalsBillid': instance.arrivalsBillId,
+  'orderno': instance.orderNo,
+  'qty': instance.plannedQuantity,
+  'goodqty': instance.collectedQuantity,
+  'meins': instance.unit,
+  'batchno': instance.batchNo,
+  'serialNumber': instance.serialNumber,
+  'subinventoryCode': instance.subInventoryCode,
+  'matcodecontrol': instance.materialControlType,
+  'pdate': instance.productionDate,
+  'vdays': instance.validDays,
+};

--- a/lib/modules/arrival_sign/task_collect/services/arrival_collect_cache_repository.dart
+++ b/lib/modules/arrival_sign/task_collect/services/arrival_collect_cache_repository.dart
@@ -1,0 +1,40 @@
+import 'package:hive/hive.dart';
+
+import '../models/arrival_collect_cache.dart';
+
+class ArrivalCollectCacheRepository {
+  ArrivalCollectCacheRepository({HiveInterface? hive}) : _hive = hive ?? Hive;
+
+  final HiveInterface _hive;
+
+  static const String _boxName = 'arrival_collect_cache';
+
+  Future<Box<Map>> _openBox() async {
+    if (_hive.isBoxOpen(_boxName)) {
+      return _hive.box<Map>(_boxName);
+    }
+    return _hive.openBox<Map>(_boxName);
+  }
+
+  Future<void> saveCache({
+    required String key,
+    required ArrivalCollectCache cache,
+  }) async {
+    final box = await _openBox();
+    await box.put(key, cache.toJson());
+  }
+
+  Future<ArrivalCollectCache?> loadCache(String key) async {
+    final box = await _openBox();
+    final data = box.get(key);
+    if (data == null) {
+      return null;
+    }
+    return ArrivalCollectCache.fromJson(Map<String, dynamic>.from(data));
+  }
+
+  Future<void> clearCache(String key) async {
+    final box = await _openBox();
+    await box.delete(key);
+  }
+}

--- a/lib/modules/arrival_sign/task_collect/widgets/collect_info_header.dart
+++ b/lib/modules/arrival_sign/task_collect/widgets/collect_info_header.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/modules/arrival_sign/task_collect/bloc/arrival_collect_state.dart';
+
+class CollectInfoHeader extends StatelessWidget {
+  const CollectInfoHeader({super.key, required this.state});
+
+  final ArrivalCollectState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final task = state.selectedTask;
+    if (task == null) {
+      return Container(
+        width: double.infinity,
+        color: Colors.white,
+        padding: const EdgeInsets.all(16),
+        child: const Text('请选择需要采集的物料'),
+      );
+    }
+
+    return Container(
+      width: double.infinity,
+      color: Colors.white,
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '物料：${task.materialCode} ${task.materialName ?? ''}',
+            style: Theme.of(
+              context,
+            ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 12,
+            runSpacing: 8,
+            children: [
+              _infoChip('批次', task.batchNo ?? '-'),
+              _infoChip('序列', task.serialNumber ?? '-'),
+              _infoChip('剩余数量', task.remainingQuantity.toString()),
+              _infoChip('生产日期', task.productionDate ?? '-'),
+              _infoChip('有效期', task.validDays ?? '-'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _infoChip(String label, String value) {
+    return Chip(
+      label: Text('$label：$value'),
+      backgroundColor: const Color(0xFFEFF3F9),
+    );
+  }
+}

--- a/lib/modules/arrival_sign/task_detail/arrival_sign_detail_page.dart
+++ b/lib/modules/arrival_sign/task_detail/arrival_sign_detail_page.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_event.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_state.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/config/arrival_sign_detail_grid_config.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart';
+
+class ArrivalSignDetailPage extends StatefulWidget {
+  const ArrivalSignDetailPage({
+    super.key,
+    required this.arrivalsBillId,
+  });
+
+  final String arrivalsBillId;
+
+  @override
+  State<ArrivalSignDetailPage> createState() => _ArrivalSignDetailPageState();
+}
+
+class _ArrivalSignDetailPageState extends State<ArrivalSignDetailPage> {
+  late final ArrivalSignDetailBloc _bloc;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ArrivalSignDetailBloc>(context);
+    _bloc.add(ArrivalSignDetailEvent.initialized(widget.arrivalsBillId));
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: CustomAppBar(
+        title: '到货任务明细',
+        onBackPressed: () => Navigator.of(context).pop(),
+      ).appBar,
+      body: BlocConsumer<ArrivalSignDetailBloc, ArrivalSignDetailState>(
+        listener: (context, state) {
+          if (state.isLoading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+
+          if (state.errorMessage != null) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.errorMessage!,
+            );
+          }
+        },
+        builder: (context, state) {
+          if (state.details.isEmpty && state.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state.details.isEmpty && state.errorMessage != null) {
+            return Center(child: Text(state.errorMessage!));
+          }
+
+          return Column(
+            children: [
+              _buildScanner(),
+              Expanded(
+                child: state.details.isEmpty
+                    ? const Center(child: Text('当前任务列表没有待处理任务！'))
+                    : CommonDataGrid<ArrivalSignDetail>(
+                        columns: ArrivalSignDetailGridConfig.buildColumns(),
+                        datas: state.details,
+                        currentPage: state.currentPage,
+                        totalPages: state.totalPages,
+                        onLoadData: (pageIndex) async {
+                          _bloc.add(
+                            ArrivalSignDetailEvent.pageChanged(pageIndex),
+                          );
+                        },
+                        allowPager: true,
+                        allowSelect: false,
+                        headerHeight: 44,
+                        rowHeight: 48,
+                      ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '扫描或输入物料编码',
+      clearOnSubmit: true,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: ScannerWidget(
+        controller: _scannerController,
+        config: config,
+        onScanResult: (value) {
+          _bloc.add(ArrivalSignDetailEvent.search(value));
+        },
+        onError: (message) {
+          LoadingDialogManager.instance.showErrorDialog(context, message);
+        },
+      ),
+    );
+  }
+}

--- a/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_bloc.dart
+++ b/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_bloc.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/services/arrival_sign_service.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart';
+
+import 'arrival_sign_detail_event.dart';
+import 'arrival_sign_detail_state.dart';
+
+class ArrivalSignDetailBloc
+    extends Bloc<ArrivalSignDetailEvent, ArrivalSignDetailState> {
+  ArrivalSignDetailBloc({required this.service})
+      : super(const ArrivalSignDetailState()) {
+    on<ArrivalSignDetailEvent>(_onEvent);
+  }
+
+  final ArrivalSignService service;
+  ArrivalSignDetailQuery? _query;
+
+  Future<void> _onEvent(
+    ArrivalSignDetailEvent event,
+    Emitter<ArrivalSignDetailState> emit,
+  ) async {
+    await event.when(
+      initialized: (arrivalsBillId) => _handleInitialized(arrivalsBillId, emit),
+      search: (keyword) => _handleSearch(keyword, emit),
+      refresh: () => _handleRefresh(emit),
+      pageChanged: (pageIndex) => _handlePageChanged(pageIndex, emit),
+    );
+  }
+
+  Future<void> _handleInitialized(
+    String arrivalsBillId,
+    Emitter<ArrivalSignDetailState> emit,
+  ) async {
+    _query = ArrivalSignDetailQuery(arrivalsBillId: arrivalsBillId);
+    await _loadPage(emit, 1);
+  }
+
+  Future<void> _handleSearch(
+    String keyword,
+    Emitter<ArrivalSignDetailState> emit,
+  ) async {
+    if (_query == null) {
+      return;
+    }
+    _query = _query!.copyWith(searchKey: keyword, pageIndex: 1);
+    await _loadPage(emit, 1);
+  }
+
+  Future<void> _handleRefresh(
+    Emitter<ArrivalSignDetailState> emit,
+  ) async {
+    await _loadPage(emit, state.currentPage);
+  }
+
+  Future<void> _handlePageChanged(
+    int pageIndex,
+    Emitter<ArrivalSignDetailState> emit,
+  ) async {
+    await _loadPage(emit, pageIndex);
+  }
+
+  Future<void> _loadPage(
+    Emitter<ArrivalSignDetailState> emit,
+    int pageIndex,
+  ) async {
+    final query = _query;
+    if (query == null) {
+      return;
+    }
+
+    emit(state.copyWith(isLoading: true, errorMessage: null));
+    try {
+      final response = await service.getArrivalSignDetails(
+        query: query.copyWith(pageIndex: pageIndex),
+      );
+      final totalPages = response.total == 0
+          ? 1
+          : (response.total / query.pageSize).ceil();
+      emit(
+        state.copyWith(
+          isLoading: false,
+          details: response.rows,
+          currentPage: pageIndex,
+          totalPages: totalPages,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          isLoading: false,
+          errorMessage: error.toString(),
+        ),
+      );
+    }
+  }
+}

--- a/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_event.dart
+++ b/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_event.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'arrival_sign_detail_event.freezed.dart';
+
+@freezed
+class ArrivalSignDetailEvent with _$ArrivalSignDetailEvent {
+  const factory ArrivalSignDetailEvent.initialized(String arrivalsBillId) =
+      _Initialized;
+  const factory ArrivalSignDetailEvent.search(String keyword) = _Search;
+  const factory ArrivalSignDetailEvent.refresh() = _Refresh;
+  const factory ArrivalSignDetailEvent.pageChanged(int pageIndex) = _PageChanged;
+}

--- a/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_event.freezed.dart
+++ b/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_event.freezed.dart
@@ -1,0 +1,639 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_sign_detail_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ArrivalSignDetailEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String arrivalsBillId) initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(int pageIndex) pageChanged,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String arrivalsBillId)? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(int pageIndex)? pageChanged,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String arrivalsBillId)? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(int pageIndex)? pageChanged,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_PageChanged value) pageChanged,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_PageChanged value)? pageChanged,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_PageChanged value)? pageChanged,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalSignDetailEventCopyWith<$Res> {
+  factory $ArrivalSignDetailEventCopyWith(ArrivalSignDetailEvent value,
+          $Res Function(ArrivalSignDetailEvent) then) =
+      _$ArrivalSignDetailEventCopyWithImpl<$Res, ArrivalSignDetailEvent>;
+}
+
+/// @nodoc
+class _$ArrivalSignDetailEventCopyWithImpl<$Res,
+        $Val extends ArrivalSignDetailEvent>
+    implements $ArrivalSignDetailEventCopyWith<$Res> {
+  _$ArrivalSignDetailEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$InitializedImplCopyWith<$Res> {
+  factory _$$InitializedImplCopyWith(
+          _$InitializedImpl value, $Res Function(_$InitializedImpl) then) =
+      __$$InitializedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String arrivalsBillId});
+}
+
+/// @nodoc
+class __$$InitializedImplCopyWithImpl<$Res>
+    extends _$ArrivalSignDetailEventCopyWithImpl<$Res, _$InitializedImpl>
+    implements _$$InitializedImplCopyWith<$Res> {
+  __$$InitializedImplCopyWithImpl(
+      _$InitializedImpl _value, $Res Function(_$InitializedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? arrivalsBillId = null,
+  }) {
+    return _then(_$InitializedImpl(
+      null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$InitializedImpl implements _Initialized {
+  const _$InitializedImpl(this.arrivalsBillId);
+
+  @override
+  final String arrivalsBillId;
+
+  @override
+  String toString() {
+    return 'ArrivalSignDetailEvent.initialized(arrivalsBillId: $arrivalsBillId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InitializedImpl &&
+            (identical(other.arrivalsBillId, arrivalsBillId) ||
+                other.arrivalsBillId == arrivalsBillId));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, arrivalsBillId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InitializedImplCopyWith<_$InitializedImpl> get copyWith =>
+      __$$InitializedImplCopyWithImpl<_$InitializedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String arrivalsBillId) initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(int pageIndex) pageChanged,
+  }) {
+    return initialized(arrivalsBillId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String arrivalsBillId)? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(int pageIndex)? pageChanged,
+  }) {
+    return initialized?.call(arrivalsBillId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String arrivalsBillId)? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(int pageIndex)? pageChanged,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(arrivalsBillId);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_PageChanged value) pageChanged,
+  }) {
+    return initialized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_PageChanged value)? pageChanged,
+  }) {
+    return initialized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_PageChanged value)? pageChanged,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initialized implements ArrivalSignDetailEvent {
+  const factory _Initialized(final String arrivalsBillId) = _$InitializedImpl;
+
+  String get arrivalsBillId;
+  @JsonKey(ignore: true)
+  _$$InitializedImplCopyWith<_$InitializedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SearchImplCopyWith<$Res> {
+  factory _$$SearchImplCopyWith(
+          _$SearchImpl value, $Res Function(_$SearchImpl) then) =
+      __$$SearchImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String keyword});
+}
+
+/// @nodoc
+class __$$SearchImplCopyWithImpl<$Res>
+    extends _$ArrivalSignDetailEventCopyWithImpl<$Res, _$SearchImpl>
+    implements _$$SearchImplCopyWith<$Res> {
+  __$$SearchImplCopyWithImpl(
+      _$SearchImpl _value, $Res Function(_$SearchImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? keyword = null,
+  }) {
+    return _then(_$SearchImpl(
+      null == keyword
+          ? _value.keyword
+          : keyword // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SearchImpl implements _Search {
+  const _$SearchImpl(this.keyword);
+
+  @override
+  final String keyword;
+
+  @override
+  String toString() {
+    return 'ArrivalSignDetailEvent.search(keyword: $keyword)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SearchImpl &&
+            (identical(other.keyword, keyword) || other.keyword == keyword));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, keyword);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+      __$$SearchImplCopyWithImpl<_$SearchImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String arrivalsBillId) initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(int pageIndex) pageChanged,
+  }) {
+    return search(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String arrivalsBillId)? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(int pageIndex)? pageChanged,
+  }) {
+    return search?.call(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String arrivalsBillId)? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(int pageIndex)? pageChanged,
+    required TResult orElse(),
+  }) {
+    if (search != null) {
+      return search(keyword);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_PageChanged value) pageChanged,
+  }) {
+    return search(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_PageChanged value)? pageChanged,
+  }) {
+    return search?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_PageChanged value)? pageChanged,
+    required TResult orElse(),
+  }) {
+    if (search != null) {
+      return search(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Search implements ArrivalSignDetailEvent {
+  const factory _Search(final String keyword) = _$SearchImpl;
+
+  String get keyword;
+  @JsonKey(ignore: true)
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$RefreshImplCopyWith<$Res> {
+  factory _$$RefreshImplCopyWith(
+          _$RefreshImpl value, $Res Function(_$RefreshImpl) then) =
+      __$$RefreshImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RefreshImplCopyWithImpl<$Res>
+    extends _$ArrivalSignDetailEventCopyWithImpl<$Res, _$RefreshImpl>
+    implements _$$RefreshImplCopyWith<$Res> {
+  __$$RefreshImplCopyWithImpl(
+      _$RefreshImpl _value, $Res Function(_$RefreshImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$RefreshImpl implements _Refresh {
+  const _$RefreshImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalSignDetailEvent.refresh()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$RefreshImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String arrivalsBillId) initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(int pageIndex) pageChanged,
+  }) {
+    return refresh();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String arrivalsBillId)? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(int pageIndex)? pageChanged,
+  }) {
+    return refresh?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String arrivalsBillId)? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(int pageIndex)? pageChanged,
+    required TResult orElse(),
+  }) {
+    if (refresh != null) {
+      return refresh();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_PageChanged value) pageChanged,
+  }) {
+    return refresh(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_PageChanged value)? pageChanged,
+  }) {
+    return refresh?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_PageChanged value)? pageChanged,
+    required TResult orElse(),
+  }) {
+    if (refresh != null) {
+      return refresh(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Refresh implements ArrivalSignDetailEvent {
+  const factory _Refresh() = _$RefreshImpl;
+}
+
+/// @nodoc
+abstract class _$$PageChangedImplCopyWith<$Res> {
+  factory _$$PageChangedImplCopyWith(
+          _$PageChangedImpl value, $Res Function(_$PageChangedImpl) then) =
+      __$$PageChangedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int pageIndex});
+}
+
+/// @nodoc
+class __$$PageChangedImplCopyWithImpl<$Res>
+    extends _$ArrivalSignDetailEventCopyWithImpl<$Res, _$PageChangedImpl>
+    implements _$$PageChangedImplCopyWith<$Res> {
+  __$$PageChangedImplCopyWithImpl(
+      _$PageChangedImpl _value, $Res Function(_$PageChangedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pageIndex = null,
+  }) {
+    return _then(_$PageChangedImpl(
+      null == pageIndex
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PageChangedImpl implements _PageChanged {
+  const _$PageChangedImpl(this.pageIndex);
+
+  @override
+  final int pageIndex;
+
+  @override
+  String toString() {
+    return 'ArrivalSignDetailEvent.pageChanged(pageIndex: $pageIndex)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageChangedImpl &&
+            (identical(other.pageIndex, pageIndex) ||
+                other.pageIndex == pageIndex));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, pageIndex);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      __$$PageChangedImplCopyWithImpl<_$PageChangedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String arrivalsBillId) initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(int pageIndex) pageChanged,
+  }) {
+    return pageChanged(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(String arrivalsBillId)? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(int pageIndex)? pageChanged,
+  }) {
+    return pageChanged?.call(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String arrivalsBillId)? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(int pageIndex)? pageChanged,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(pageIndex);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_PageChanged value) pageChanged,
+  }) {
+    return pageChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_PageChanged value)? pageChanged,
+  }) {
+    return pageChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_PageChanged value)? pageChanged,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _PageChanged implements ArrivalSignDetailEvent {
+  const factory _PageChanged(final int pageIndex) = _$PageChangedImpl;
+
+  int get pageIndex;
+  @JsonKey(ignore: true)
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_state.dart
+++ b/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_state.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart';
+
+part 'arrival_sign_detail_state.freezed.dart';
+
+@freezed
+class ArrivalSignDetailState with _$ArrivalSignDetailState {
+  const factory ArrivalSignDetailState({
+    @Default(false) bool isLoading,
+    @Default(<ArrivalSignDetail>[]) List<ArrivalSignDetail> details,
+    @Default(1) int currentPage,
+    @Default(1) int totalPages,
+    String? errorMessage,
+  }) = _ArrivalSignDetailState;
+}

--- a/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_state.freezed.dart
+++ b/lib/modules/arrival_sign/task_detail/bloc/arrival_sign_detail_state.freezed.dart
@@ -1,0 +1,242 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_sign_detail_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ArrivalSignDetailState {
+  bool get isLoading => throw _privateConstructorUsedError;
+  List<ArrivalSignDetail> get details => throw _privateConstructorUsedError;
+  int get currentPage => throw _privateConstructorUsedError;
+  int get totalPages => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ArrivalSignDetailStateCopyWith<ArrivalSignDetailState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalSignDetailStateCopyWith<$Res> {
+  factory $ArrivalSignDetailStateCopyWith(ArrivalSignDetailState value,
+          $Res Function(ArrivalSignDetailState) then) =
+      _$ArrivalSignDetailStateCopyWithImpl<$Res, ArrivalSignDetailState>;
+  @useResult
+  $Res call(
+      {bool isLoading,
+      List<ArrivalSignDetail> details,
+      int currentPage,
+      int totalPages,
+      String? errorMessage});
+}
+
+/// @nodoc
+class _$ArrivalSignDetailStateCopyWithImpl<$Res,
+        $Val extends ArrivalSignDetailState>
+    implements $ArrivalSignDetailStateCopyWith<$Res> {
+  _$ArrivalSignDetailStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isLoading = null,
+    Object? details = null,
+    Object? currentPage = null,
+    Object? totalPages = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(_value.copyWith(
+      isLoading: null == isLoading
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      details: null == details
+          ? _value.details
+          : details // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalSignDetail>,
+      currentPage: null == currentPage
+          ? _value.currentPage
+          : currentPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      errorMessage: freezed == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalSignDetailStateImplCopyWith<$Res>
+    implements $ArrivalSignDetailStateCopyWith<$Res> {
+  factory _$$ArrivalSignDetailStateImplCopyWith(
+          _$ArrivalSignDetailStateImpl value,
+          $Res Function(_$ArrivalSignDetailStateImpl) then) =
+      __$$ArrivalSignDetailStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {bool isLoading,
+      List<ArrivalSignDetail> details,
+      int currentPage,
+      int totalPages,
+      String? errorMessage});
+}
+
+/// @nodoc
+class __$$ArrivalSignDetailStateImplCopyWithImpl<$Res>
+    extends _$ArrivalSignDetailStateCopyWithImpl<$Res,
+        _$ArrivalSignDetailStateImpl>
+    implements _$$ArrivalSignDetailStateImplCopyWith<$Res> {
+  __$$ArrivalSignDetailStateImplCopyWithImpl(
+      _$ArrivalSignDetailStateImpl _value,
+      $Res Function(_$ArrivalSignDetailStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isLoading = null,
+    Object? details = null,
+    Object? currentPage = null,
+    Object? totalPages = null,
+    Object? errorMessage = freezed,
+  }) {
+    return _then(_$ArrivalSignDetailStateImpl(
+      isLoading: null == isLoading
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      details: null == details
+          ? _value._details
+          : details // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalSignDetail>,
+      currentPage: null == currentPage
+          ? _value.currentPage
+          : currentPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      errorMessage: freezed == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ArrivalSignDetailStateImpl implements _ArrivalSignDetailState {
+  const _$ArrivalSignDetailStateImpl(
+      {this.isLoading = false,
+      final List<ArrivalSignDetail> details = const <ArrivalSignDetail>[],
+      this.currentPage = 1,
+      this.totalPages = 1,
+      this.errorMessage})
+      : _details = details;
+
+  @override
+  @JsonKey()
+  final bool isLoading;
+  final List<ArrivalSignDetail> _details;
+  @override
+  @JsonKey()
+  List<ArrivalSignDetail> get details {
+    if (_details is EqualUnmodifiableListView) return _details;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_details);
+  }
+
+  @override
+  @JsonKey()
+  final int currentPage;
+  @override
+  @JsonKey()
+  final int totalPages;
+  @override
+  final String? errorMessage;
+
+  @override
+  String toString() {
+    return 'ArrivalSignDetailState(isLoading: $isLoading, details: $details, currentPage: $currentPage, totalPages: $totalPages, errorMessage: $errorMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalSignDetailStateImpl &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading) &&
+            const DeepCollectionEquality().equals(other._details, _details) &&
+            (identical(other.currentPage, currentPage) ||
+                other.currentPage == currentPage) &&
+            (identical(other.totalPages, totalPages) ||
+                other.totalPages == totalPages) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      isLoading,
+      const DeepCollectionEquality().hash(_details),
+      currentPage,
+      totalPages,
+      errorMessage);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalSignDetailStateImplCopyWith<_$ArrivalSignDetailStateImpl>
+      get copyWith => __$$ArrivalSignDetailStateImplCopyWithImpl<
+          _$ArrivalSignDetailStateImpl>(this, _$identity);
+}
+
+abstract class _ArrivalSignDetailState implements ArrivalSignDetailState {
+  const factory _ArrivalSignDetailState(
+      {final bool isLoading,
+      final List<ArrivalSignDetail> details,
+      final int currentPage,
+      final int totalPages,
+      final String? errorMessage}) = _$ArrivalSignDetailStateImpl;
+
+  @override
+  bool get isLoading;
+  @override
+  List<ArrivalSignDetail> get details;
+  @override
+  int get currentPage;
+  @override
+  int get totalPages;
+  @override
+  String? get errorMessage;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalSignDetailStateImplCopyWith<_$ArrivalSignDetailStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_detail/config/arrival_sign_detail_grid_config.dart
+++ b/lib/modules/arrival_sign/task_detail/config/arrival_sign_detail_grid_config.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart';
+
+class ArrivalSignDetailGridConfig {
+  static List<GridColumnConfig<ArrivalSignDetail>> buildColumns() {
+    return [
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'materialCode',
+        headerText: '物料编码',
+        width: 140,
+        valueGetter: (row) => row.materialCode,
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'materialName',
+        headerText: '物料名称',
+        width: 200,
+        valueGetter: (row) => row.materialName,
+        maxLines: 2,
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'supplierName',
+        headerText: '供应商',
+        width: 160,
+        valueGetter: (row) => row.supplierName ?? '',
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'quantity',
+        headerText: '数量',
+        width: 100,
+        valueGetter: (row) => row.quantity,
+        textAlign: TextAlign.right,
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'goodQuantity',
+        headerText: '合格数量',
+        width: 110,
+        valueGetter: (row) => row.goodQuantity,
+        textAlign: TextAlign.right,
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'batchNo',
+        headerText: '批次',
+        width: 120,
+        valueGetter: (row) => row.batchNo ?? '',
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'serialNumber',
+        headerText: '序列号',
+        width: 140,
+        valueGetter: (row) => row.serialNumber ?? '',
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'subInventory',
+        headerText: '子库',
+        width: 120,
+        valueGetter: (row) => row.subInventoryCode ?? '',
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'orderNo',
+        headerText: '采购单号',
+        width: 160,
+        valueGetter: (row) => row.orderNo ?? '',
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'arrivalsBillNo',
+        headerText: '到货单号',
+        width: 160,
+        valueGetter: (row) => row.arrivalsBillNo ?? '',
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'productionDate',
+        headerText: '生产日期',
+        width: 140,
+        valueGetter: (row) => row.productionDate ?? '',
+      ),
+      GridColumnConfig<ArrivalSignDetail>(
+        name: 'validDays',
+        headerText: '有效期',
+        width: 120,
+        valueGetter: (row) => row.validDays ?? '',
+      ),
+    ];
+  }
+}

--- a/lib/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart
+++ b/lib/modules/arrival_sign/task_detail/models/arrival_sign_detail.dart
@@ -1,0 +1,84 @@
+// ignore_for_file: invalid_annotation_target
+import 'package:equatable/equatable.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'arrival_sign_detail.freezed.dart';
+part 'arrival_sign_detail.g.dart';
+
+/// 到货任务明细数据
+@freezed
+class ArrivalSignDetail with _$ArrivalSignDetail {
+  const factory ArrivalSignDetail({
+    @JsonKey(name: 'matcode') required String materialCode,
+    @JsonKey(name: 'matname') required String materialName,
+    @JsonKey(name: 'parname') String? supplierName,
+    @JsonKey(name: 'qty') @Default(0) num quantity,
+    @JsonKey(name: 'goodqty') @Default(0) num goodQuantity,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNumber,
+    @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
+    @JsonKey(name: 'posnr') String? position,
+    @JsonKey(name: 'matcodecontrol') String? controlType,
+    @JsonKey(name: 'orderno') String? orderNo,
+    @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
+    @JsonKey(name: 'pdate') String? productionDate,
+    @JsonKey(name: 'vdays') String? validDays,
+  }) = _ArrivalSignDetail;
+
+  factory ArrivalSignDetail.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalSignDetailFromJson(json);
+}
+
+/// 到货任务明细分页数据
+@freezed
+class ArrivalSignDetailPage with _$ArrivalSignDetailPage {
+  const factory ArrivalSignDetailPage({
+    @JsonKey(name: 'total') @Default(0) int total,
+    @JsonKey(name: 'rows')
+    @Default(<ArrivalSignDetail>[])
+    List<ArrivalSignDetail> rows,
+  }) = _ArrivalSignDetailPage;
+
+  factory ArrivalSignDetailPage.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalSignDetailPageFromJson(json);
+}
+
+class ArrivalSignDetailQuery extends Equatable {
+  const ArrivalSignDetailQuery({
+    required this.arrivalsBillId,
+    this.searchKey = '',
+    this.pageIndex = 1,
+    this.pageSize = 100,
+  });
+
+  final String arrivalsBillId;
+  final String searchKey;
+  final int pageIndex;
+  final int pageSize;
+
+  ArrivalSignDetailQuery copyWith({
+    String? arrivalsBillId,
+    String? searchKey,
+    int? pageIndex,
+    int? pageSize,
+  }) {
+    return ArrivalSignDetailQuery(
+      arrivalsBillId: arrivalsBillId ?? this.arrivalsBillId,
+      searchKey: searchKey ?? this.searchKey,
+      pageIndex: pageIndex ?? this.pageIndex,
+      pageSize: pageSize ?? this.pageSize,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'arrivalsBillid': arrivalsBillId,
+      'searchKey': searchKey,
+      'pageIndex': pageIndex,
+      'pageSize': pageSize,
+    };
+  }
+
+  @override
+  List<Object?> get props => [arrivalsBillId, searchKey, pageIndex, pageSize];
+}

--- a/lib/modules/arrival_sign/task_detail/models/arrival_sign_detail.freezed.dart
+++ b/lib/modules/arrival_sign/task_detail/models/arrival_sign_detail.freezed.dart
@@ -1,0 +1,666 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_sign_detail.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ArrivalSignDetail _$ArrivalSignDetailFromJson(Map<String, dynamic> json) {
+  return _ArrivalSignDetail.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalSignDetail {
+  @JsonKey(name: 'matcode')
+  String get materialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matname')
+  String get materialName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'parname')
+  String? get supplierName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'qty')
+  num get quantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'goodqty')
+  num get goodQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'batchno')
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sn')
+  String? get serialNumber => throw _privateConstructorUsedError;
+  @JsonKey(name: 'subinventoryCode')
+  String? get subInventoryCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'posnr')
+  String? get position => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matcodecontrol')
+  String? get controlType => throw _privateConstructorUsedError;
+  @JsonKey(name: 'orderno')
+  String? get orderNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'arrivalsBillno')
+  String? get arrivalsBillNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'pdate')
+  String? get productionDate => throw _privateConstructorUsedError;
+  @JsonKey(name: 'vdays')
+  String? get validDays => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalSignDetailCopyWith<ArrivalSignDetail> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalSignDetailCopyWith<$Res> {
+  factory $ArrivalSignDetailCopyWith(
+          ArrivalSignDetail value, $Res Function(ArrivalSignDetail) then) =
+      _$ArrivalSignDetailCopyWithImpl<$Res, ArrivalSignDetail>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String materialName,
+      @JsonKey(name: 'parname') String? supplierName,
+      @JsonKey(name: 'qty') num quantity,
+      @JsonKey(name: 'goodqty') num goodQuantity,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNumber,
+      @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
+      @JsonKey(name: 'posnr') String? position,
+      @JsonKey(name: 'matcodecontrol') String? controlType,
+      @JsonKey(name: 'orderno') String? orderNo,
+      @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
+      @JsonKey(name: 'pdate') String? productionDate,
+      @JsonKey(name: 'vdays') String? validDays});
+}
+
+/// @nodoc
+class _$ArrivalSignDetailCopyWithImpl<$Res, $Val extends ArrivalSignDetail>
+    implements $ArrivalSignDetailCopyWith<$Res> {
+  _$ArrivalSignDetailCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = null,
+    Object? materialName = null,
+    Object? supplierName = freezed,
+    Object? quantity = null,
+    Object? goodQuantity = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? subInventoryCode = freezed,
+    Object? position = freezed,
+    Object? controlType = freezed,
+    Object? orderNo = freezed,
+    Object? arrivalsBillNo = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+  }) {
+    return _then(_value.copyWith(
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: null == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String,
+      supplierName: freezed == supplierName
+          ? _value.supplierName
+          : supplierName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      quantity: null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as num,
+      goodQuantity: null == goodQuantity
+          ? _value.goodQuantity
+          : goodQuantity // ignore: cast_nullable_to_non_nullable
+              as num,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      subInventoryCode: freezed == subInventoryCode
+          ? _value.subInventoryCode
+          : subInventoryCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      position: freezed == position
+          ? _value.position
+          : position // ignore: cast_nullable_to_non_nullable
+              as String?,
+      controlType: freezed == controlType
+          ? _value.controlType
+          : controlType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      orderNo: freezed == orderNo
+          ? _value.orderNo
+          : orderNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      arrivalsBillNo: freezed == arrivalsBillNo
+          ? _value.arrivalsBillNo
+          : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalSignDetailImplCopyWith<$Res>
+    implements $ArrivalSignDetailCopyWith<$Res> {
+  factory _$$ArrivalSignDetailImplCopyWith(_$ArrivalSignDetailImpl value,
+          $Res Function(_$ArrivalSignDetailImpl) then) =
+      __$$ArrivalSignDetailImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String materialName,
+      @JsonKey(name: 'parname') String? supplierName,
+      @JsonKey(name: 'qty') num quantity,
+      @JsonKey(name: 'goodqty') num goodQuantity,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNumber,
+      @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
+      @JsonKey(name: 'posnr') String? position,
+      @JsonKey(name: 'matcodecontrol') String? controlType,
+      @JsonKey(name: 'orderno') String? orderNo,
+      @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
+      @JsonKey(name: 'pdate') String? productionDate,
+      @JsonKey(name: 'vdays') String? validDays});
+}
+
+/// @nodoc
+class __$$ArrivalSignDetailImplCopyWithImpl<$Res>
+    extends _$ArrivalSignDetailCopyWithImpl<$Res, _$ArrivalSignDetailImpl>
+    implements _$$ArrivalSignDetailImplCopyWith<$Res> {
+  __$$ArrivalSignDetailImplCopyWithImpl(_$ArrivalSignDetailImpl _value,
+      $Res Function(_$ArrivalSignDetailImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = null,
+    Object? materialName = null,
+    Object? supplierName = freezed,
+    Object? quantity = null,
+    Object? goodQuantity = null,
+    Object? batchNo = freezed,
+    Object? serialNumber = freezed,
+    Object? subInventoryCode = freezed,
+    Object? position = freezed,
+    Object? controlType = freezed,
+    Object? orderNo = freezed,
+    Object? arrivalsBillNo = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+  }) {
+    return _then(_$ArrivalSignDetailImpl(
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: null == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String,
+      supplierName: freezed == supplierName
+          ? _value.supplierName
+          : supplierName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      quantity: null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as num,
+      goodQuantity: null == goodQuantity
+          ? _value.goodQuantity
+          : goodQuantity // ignore: cast_nullable_to_non_nullable
+              as num,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      subInventoryCode: freezed == subInventoryCode
+          ? _value.subInventoryCode
+          : subInventoryCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      position: freezed == position
+          ? _value.position
+          : position // ignore: cast_nullable_to_non_nullable
+              as String?,
+      controlType: freezed == controlType
+          ? _value.controlType
+          : controlType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      orderNo: freezed == orderNo
+          ? _value.orderNo
+          : orderNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      arrivalsBillNo: freezed == arrivalsBillNo
+          ? _value.arrivalsBillNo
+          : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalSignDetailImpl implements _ArrivalSignDetail {
+  const _$ArrivalSignDetailImpl(
+      {@JsonKey(name: 'matcode') required this.materialCode,
+      @JsonKey(name: 'matname') required this.materialName,
+      @JsonKey(name: 'parname') this.supplierName,
+      @JsonKey(name: 'qty') this.quantity = 0,
+      @JsonKey(name: 'goodqty') this.goodQuantity = 0,
+      @JsonKey(name: 'batchno') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNumber,
+      @JsonKey(name: 'subinventoryCode') this.subInventoryCode,
+      @JsonKey(name: 'posnr') this.position,
+      @JsonKey(name: 'matcodecontrol') this.controlType,
+      @JsonKey(name: 'orderno') this.orderNo,
+      @JsonKey(name: 'arrivalsBillno') this.arrivalsBillNo,
+      @JsonKey(name: 'pdate') this.productionDate,
+      @JsonKey(name: 'vdays') this.validDays});
+
+  factory _$ArrivalSignDetailImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalSignDetailImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'matcode')
+  final String materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  final String materialName;
+  @override
+  @JsonKey(name: 'parname')
+  final String? supplierName;
+  @override
+  @JsonKey(name: 'qty')
+  final num quantity;
+  @override
+  @JsonKey(name: 'goodqty')
+  final num goodQuantity;
+  @override
+  @JsonKey(name: 'batchno')
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNumber;
+  @override
+  @JsonKey(name: 'subinventoryCode')
+  final String? subInventoryCode;
+  @override
+  @JsonKey(name: 'posnr')
+  final String? position;
+  @override
+  @JsonKey(name: 'matcodecontrol')
+  final String? controlType;
+  @override
+  @JsonKey(name: 'orderno')
+  final String? orderNo;
+  @override
+  @JsonKey(name: 'arrivalsBillno')
+  final String? arrivalsBillNo;
+  @override
+  @JsonKey(name: 'pdate')
+  final String? productionDate;
+  @override
+  @JsonKey(name: 'vdays')
+  final String? validDays;
+
+  @override
+  String toString() {
+    return 'ArrivalSignDetail(materialCode: $materialCode, materialName: $materialName, supplierName: $supplierName, quantity: $quantity, goodQuantity: $goodQuantity, batchNo: $batchNo, serialNumber: $serialNumber, subInventoryCode: $subInventoryCode, position: $position, controlType: $controlType, orderNo: $orderNo, arrivalsBillNo: $arrivalsBillNo, productionDate: $productionDate, validDays: $validDays)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalSignDetailImpl &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.supplierName, supplierName) ||
+                other.supplierName == supplierName) &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity) &&
+            (identical(other.goodQuantity, goodQuantity) ||
+                other.goodQuantity == goodQuantity) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNumber, serialNumber) ||
+                other.serialNumber == serialNumber) &&
+            (identical(other.subInventoryCode, subInventoryCode) ||
+                other.subInventoryCode == subInventoryCode) &&
+            (identical(other.position, position) ||
+                other.position == position) &&
+            (identical(other.controlType, controlType) ||
+                other.controlType == controlType) &&
+            (identical(other.orderNo, orderNo) || other.orderNo == orderNo) &&
+            (identical(other.arrivalsBillNo, arrivalsBillNo) ||
+                other.arrivalsBillNo == arrivalsBillNo) &&
+            (identical(other.productionDate, productionDate) ||
+                other.productionDate == productionDate) &&
+            (identical(other.validDays, validDays) ||
+                other.validDays == validDays));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      materialCode,
+      materialName,
+      supplierName,
+      quantity,
+      goodQuantity,
+      batchNo,
+      serialNumber,
+      subInventoryCode,
+      position,
+      controlType,
+      orderNo,
+      arrivalsBillNo,
+      productionDate,
+      validDays);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalSignDetailImplCopyWith<_$ArrivalSignDetailImpl> get copyWith =>
+      __$$ArrivalSignDetailImplCopyWithImpl<_$ArrivalSignDetailImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalSignDetailImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ArrivalSignDetail implements ArrivalSignDetail {
+  const factory _ArrivalSignDetail(
+          {@JsonKey(name: 'matcode') required final String materialCode,
+          @JsonKey(name: 'matname') required final String materialName,
+          @JsonKey(name: 'parname') final String? supplierName,
+          @JsonKey(name: 'qty') final num quantity,
+          @JsonKey(name: 'goodqty') final num goodQuantity,
+          @JsonKey(name: 'batchno') final String? batchNo,
+          @JsonKey(name: 'sn') final String? serialNumber,
+          @JsonKey(name: 'subinventoryCode') final String? subInventoryCode,
+          @JsonKey(name: 'posnr') final String? position,
+          @JsonKey(name: 'matcodecontrol') final String? controlType,
+          @JsonKey(name: 'orderno') final String? orderNo,
+          @JsonKey(name: 'arrivalsBillno') final String? arrivalsBillNo,
+          @JsonKey(name: 'pdate') final String? productionDate,
+          @JsonKey(name: 'vdays') final String? validDays}) =
+      _$ArrivalSignDetailImpl;
+
+  factory _ArrivalSignDetail.fromJson(Map<String, dynamic> json) =
+      _$ArrivalSignDetailImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'matcode')
+  String get materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  String get materialName;
+  @override
+  @JsonKey(name: 'parname')
+  String? get supplierName;
+  @override
+  @JsonKey(name: 'qty')
+  num get quantity;
+  @override
+  @JsonKey(name: 'goodqty')
+  num get goodQuantity;
+  @override
+  @JsonKey(name: 'batchno')
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  String? get serialNumber;
+  @override
+  @JsonKey(name: 'subinventoryCode')
+  String? get subInventoryCode;
+  @override
+  @JsonKey(name: 'posnr')
+  String? get position;
+  @override
+  @JsonKey(name: 'matcodecontrol')
+  String? get controlType;
+  @override
+  @JsonKey(name: 'orderno')
+  String? get orderNo;
+  @override
+  @JsonKey(name: 'arrivalsBillno')
+  String? get arrivalsBillNo;
+  @override
+  @JsonKey(name: 'pdate')
+  String? get productionDate;
+  @override
+  @JsonKey(name: 'vdays')
+  String? get validDays;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalSignDetailImplCopyWith<_$ArrivalSignDetailImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+ArrivalSignDetailPage _$ArrivalSignDetailPageFromJson(
+    Map<String, dynamic> json) {
+  return _ArrivalSignDetailPage.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalSignDetailPage {
+  @JsonKey(name: 'total')
+  int get total => throw _privateConstructorUsedError;
+  @JsonKey(name: 'rows')
+  List<ArrivalSignDetail> get rows => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalSignDetailPageCopyWith<ArrivalSignDetailPage> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalSignDetailPageCopyWith<$Res> {
+  factory $ArrivalSignDetailPageCopyWith(ArrivalSignDetailPage value,
+          $Res Function(ArrivalSignDetailPage) then) =
+      _$ArrivalSignDetailPageCopyWithImpl<$Res, ArrivalSignDetailPage>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'total') int total,
+      @JsonKey(name: 'rows') List<ArrivalSignDetail> rows});
+}
+
+/// @nodoc
+class _$ArrivalSignDetailPageCopyWithImpl<$Res,
+        $Val extends ArrivalSignDetailPage>
+    implements $ArrivalSignDetailPageCopyWith<$Res> {
+  _$ArrivalSignDetailPageCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? total = null,
+    Object? rows = null,
+  }) {
+    return _then(_value.copyWith(
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      rows: null == rows
+          ? _value.rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalSignDetail>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalSignDetailPageImplCopyWith<$Res>
+    implements $ArrivalSignDetailPageCopyWith<$Res> {
+  factory _$$ArrivalSignDetailPageImplCopyWith(
+          _$ArrivalSignDetailPageImpl value,
+          $Res Function(_$ArrivalSignDetailPageImpl) then) =
+      __$$ArrivalSignDetailPageImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'total') int total,
+      @JsonKey(name: 'rows') List<ArrivalSignDetail> rows});
+}
+
+/// @nodoc
+class __$$ArrivalSignDetailPageImplCopyWithImpl<$Res>
+    extends _$ArrivalSignDetailPageCopyWithImpl<$Res,
+        _$ArrivalSignDetailPageImpl>
+    implements _$$ArrivalSignDetailPageImplCopyWith<$Res> {
+  __$$ArrivalSignDetailPageImplCopyWithImpl(_$ArrivalSignDetailPageImpl _value,
+      $Res Function(_$ArrivalSignDetailPageImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? total = null,
+    Object? rows = null,
+  }) {
+    return _then(_$ArrivalSignDetailPageImpl(
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      rows: null == rows
+          ? _value._rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalSignDetail>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalSignDetailPageImpl implements _ArrivalSignDetailPage {
+  const _$ArrivalSignDetailPageImpl(
+      {@JsonKey(name: 'total') this.total = 0,
+      @JsonKey(name: 'rows')
+      final List<ArrivalSignDetail> rows = const <ArrivalSignDetail>[]})
+      : _rows = rows;
+
+  factory _$ArrivalSignDetailPageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalSignDetailPageImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'total')
+  final int total;
+  final List<ArrivalSignDetail> _rows;
+  @override
+  @JsonKey(name: 'rows')
+  List<ArrivalSignDetail> get rows {
+    if (_rows is EqualUnmodifiableListView) return _rows;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_rows);
+  }
+
+  @override
+  String toString() {
+    return 'ArrivalSignDetailPage(total: $total, rows: $rows)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalSignDetailPageImpl &&
+            (identical(other.total, total) || other.total == total) &&
+            const DeepCollectionEquality().equals(other._rows, _rows));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, total, const DeepCollectionEquality().hash(_rows));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalSignDetailPageImplCopyWith<_$ArrivalSignDetailPageImpl>
+      get copyWith => __$$ArrivalSignDetailPageImplCopyWithImpl<
+          _$ArrivalSignDetailPageImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalSignDetailPageImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ArrivalSignDetailPage implements ArrivalSignDetailPage {
+  const factory _ArrivalSignDetailPage(
+          {@JsonKey(name: 'total') final int total,
+          @JsonKey(name: 'rows') final List<ArrivalSignDetail> rows}) =
+      _$ArrivalSignDetailPageImpl;
+
+  factory _ArrivalSignDetailPage.fromJson(Map<String, dynamic> json) =
+      _$ArrivalSignDetailPageImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'total')
+  int get total;
+  @override
+  @JsonKey(name: 'rows')
+  List<ArrivalSignDetail> get rows;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalSignDetailPageImplCopyWith<_$ArrivalSignDetailPageImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_detail/models/arrival_sign_detail.g.dart
+++ b/lib/modules/arrival_sign/task_detail/models/arrival_sign_detail.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'arrival_sign_detail.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ArrivalSignDetailImpl _$$ArrivalSignDetailImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ArrivalSignDetailImpl(
+      materialCode: json['matcode'] as String,
+      materialName: json['matname'] as String,
+      supplierName: json['parname'] as String?,
+      quantity: json['qty'] as num? ?? 0,
+      goodQuantity: json['goodqty'] as num? ?? 0,
+      batchNo: json['batchno'] as String?,
+      serialNumber: json['sn'] as String?,
+      subInventoryCode: json['subinventoryCode'] as String?,
+      position: json['posnr'] as String?,
+      controlType: json['matcodecontrol'] as String?,
+      orderNo: json['orderno'] as String?,
+      arrivalsBillNo: json['arrivalsBillno'] as String?,
+      productionDate: json['pdate'] as String?,
+      validDays: json['vdays'] as String?,
+    );
+
+Map<String, dynamic> _$$ArrivalSignDetailImplToJson(
+        _$ArrivalSignDetailImpl instance) =>
+    <String, dynamic>{
+      'matcode': instance.materialCode,
+      'matname': instance.materialName,
+      'parname': instance.supplierName,
+      'qty': instance.quantity,
+      'goodqty': instance.goodQuantity,
+      'batchno': instance.batchNo,
+      'sn': instance.serialNumber,
+      'subinventoryCode': instance.subInventoryCode,
+      'posnr': instance.position,
+      'matcodecontrol': instance.controlType,
+      'orderno': instance.orderNo,
+      'arrivalsBillno': instance.arrivalsBillNo,
+      'pdate': instance.productionDate,
+      'vdays': instance.validDays,
+    };
+
+_$ArrivalSignDetailPageImpl _$$ArrivalSignDetailPageImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ArrivalSignDetailPageImpl(
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      rows: (json['rows'] as List<dynamic>?)
+              ?.map(
+                  (e) => ArrivalSignDetail.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <ArrivalSignDetail>[],
+    );
+
+Map<String, dynamic> _$$ArrivalSignDetailPageImplToJson(
+        _$ArrivalSignDetailPageImpl instance) =>
+    <String, dynamic>{
+      'total': instance.total,
+      'rows': instance.rows,
+    };

--- a/lib/modules/arrival_sign/task_list/arrival_sign_task_list_page.dart
+++ b/lib/modules/arrival_sign/task_list/arrival_sign_task_list_page.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/bloc/arrival_sign_list_bloc.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/bloc/arrival_sign_list_event.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/bloc/arrival_sign_list_state.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/config/arrival_sign_task_grid_config.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+
+class ArrivalSignTaskListPage extends StatefulWidget {
+  const ArrivalSignTaskListPage({super.key});
+
+  @override
+  State<ArrivalSignTaskListPage> createState() => _ArrivalSignTaskListPageState();
+}
+
+class _ArrivalSignTaskListPageState extends State<ArrivalSignTaskListPage>
+    with SingleTickerProviderStateMixin {
+  late final ArrivalSignListBloc _bloc;
+  late final CommonDataGridBloc<ArrivalSignTask> _gridBloc;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<ArrivalSignListBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+    _bloc.add(const ArrivalSignListEvent.initialized());
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: CustomAppBar(
+        title: '到货接收',
+        onBackPressed: () => Navigator.of(context).pop(),
+        actions: [
+          IconButton(
+            onPressed: () => Modular.to.pushNamed('/arrival-sign/receive'),
+            icon: const Icon(Icons.add, color: Colors.white, size: 28),
+          ),
+        ],
+      ).appBar,
+      body: BlocListener<ArrivalSignListBloc, ArrivalSignListState>(
+        listener: (context, state) {
+          if (state.isProcessing) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+
+          if (state.successMessage != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(state.successMessage!)),
+            );
+          }
+
+          if (state.errorMessage != null) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.errorMessage!,
+            );
+          }
+        },
+        child: Column(
+          children: [
+            _buildScanInput(),
+            const SizedBox(height: 8),
+            Expanded(child: _buildTable()),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScanInput() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '请扫描到货单号',
+      clearOnSubmit: true,
+    );
+
+    return ScannerWidget(
+      controller: _scannerController,
+      config: config,
+      onScanResult: (value) {
+        _bloc.add(ArrivalSignListEvent.search(value));
+      },
+      onError: (message) {
+        LoadingDialogManager.instance.showErrorDialog(context, message);
+      },
+      suffix: IconButton(
+        icon: SvgPicture.asset('assets/images/icon_filter.svg'),
+        onPressed: () {
+          _bloc.add(const ArrivalSignListEvent.refresh());
+        },
+      ),
+    );
+  }
+
+  Widget _buildTable() {
+    return BlocProvider.value(
+      value: _gridBloc,
+      child: BlocBuilder<CommonDataGridBloc<ArrivalSignTask>,
+          CommonDataGridState<ArrivalSignTask>>(
+        builder: (context, state) {
+          if (state.status == GridStatus.loading && state.data.isEmpty) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state.status == GridStatus.error) {
+            return Center(
+              child: Text(state.errorMessage ?? '加载失败'),
+            );
+          }
+
+          if (state.data.isEmpty) {
+            return const Center(child: Text('暂无数据'));
+          }
+
+          return CommonDataGrid<ArrivalSignTask>(
+            columns: ArrivalSignTaskGridConfig.buildColumns((task, action) {
+              switch (action) {
+                case ArrivalSignTaskAction.collect:
+                  Modular.to.pushNamed('/arrival-sign/collect', arguments: {
+                    'task': task.toJson(),
+                  });
+                  break;
+                case ArrivalSignTaskAction.detail:
+                  Modular.to.pushNamed(
+                    '/arrival-sign/detail',
+                    arguments: {'arrivalsBillId': task.arrivalsBillId},
+                  );
+                  break;
+                case ArrivalSignTaskAction.cancel:
+                  _confirmCancel(task);
+                  break;
+              }
+            }),
+            datas: state.data,
+            currentPage: state.currentPage,
+            totalPages: state.totalPages,
+            onLoadData: (pageIndex) async {
+              _gridBloc.add(LoadDataEvent(pageIndex));
+            },
+            allowPager: true,
+            allowSelect: false,
+            headerHeight: 44,
+            rowHeight: 48,
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _confirmCancel(ArrivalSignTask task) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('确认撤销'),
+          content: Text('确定撤销到货单 \${task.arrivalsBillNo} 吗？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('撤销'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (result == true) {
+      _bloc.add(ArrivalSignListEvent.cancel(task.arrivalsBillId));
+    }
+  }
+}

--- a/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_bloc.dart
+++ b/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_bloc.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/modules/arrival_sign/services/arrival_sign_service.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+import 'arrival_sign_list_event.dart';
+import 'arrival_sign_list_state.dart';
+
+class ArrivalSignListBloc
+    extends Bloc<ArrivalSignListEvent, ArrivalSignListState> {
+  ArrivalSignListBloc({
+    required this.arrivalSignService,
+    required this.userManager,
+  }) : super(const ArrivalSignListState()) {
+    on<ArrivalSignListEvent>(_onEvent);
+  }
+
+  final ArrivalSignService arrivalSignService;
+  final UserManager userManager;
+
+  late ArrivalSignTaskQuery currentQuery = _createDefaultQuery();
+
+  late final CommonDataGridBloc<ArrivalSignTask> gridBloc =
+      CommonDataGridBloc<ArrivalSignTask>(dataLoader: _createLoader());
+
+  DataGridLoader<ArrivalSignTask> _createLoader() {
+    return (pageIndex) async {
+      final query = currentQuery.copyWith(pageIndex: pageIndex);
+      final response = await arrivalSignService.getArrivalSignTasks(
+        query: query,
+      );
+      final totalPages = response.total == 0
+          ? 1
+          : (response.total / query.pageSize).ceil();
+      return DataGridResponseData(
+        totalPages: totalPages,
+        data: response.rows,
+      );
+    };
+  }
+
+  Future<void> _onEvent(
+    ArrivalSignListEvent event,
+    Emitter<ArrivalSignListState> emit,
+  ) async {
+    await event.when(
+      initialized: () => _handleInitialized(emit),
+      search: (keyword) => _handleSearch(keyword, emit),
+      refresh: () => _handleRefresh(emit),
+      cancel: (arrivalsBillId) => _handleCancel(arrivalsBillId, emit),
+    );
+  }
+
+  Future<void> _handleInitialized(Emitter<ArrivalSignListState> emit) async {
+    gridBloc.add(LoadDataEvent(currentQuery.pageIndex));
+  }
+
+  Future<void> _handleSearch(
+    String keyword,
+    Emitter<ArrivalSignListState> emit,
+  ) async {
+    currentQuery = currentQuery.copyWith(
+      searchKey: keyword,
+      pageIndex: 1,
+    );
+    gridBloc.add(const LoadDataEvent(1));
+  }
+
+  Future<void> _handleRefresh(
+    Emitter<ArrivalSignListState> emit,
+  ) async {
+    gridBloc.add(LoadDataEvent(gridBloc.state.currentPage));
+  }
+
+  Future<void> _handleCancel(
+    String arrivalsBillId,
+    Emitter<ArrivalSignListState> emit,
+  ) async {
+    emit(
+      state.copyWith(isProcessing: true, errorMessage: null, successMessage: null),
+    );
+    try {
+      await arrivalSignService.cancelArrivalSign(
+        arrivalsBillId: arrivalsBillId,
+      );
+      emit(state.copyWith(isProcessing: false, successMessage: '撤销成功'));
+      gridBloc.add(const LoadDataEvent(1));
+    } catch (error) {
+      emit(
+        state.copyWith(
+          isProcessing: false,
+          errorMessage: error.toString(),
+        ),
+      );
+    }
+  }
+
+  ArrivalSignTaskQuery _createDefaultQuery() {
+    final user = userManager.userInfo;
+    if (user == null) {
+      return const ArrivalSignTaskQuery(userId: '', roleOrUserId: '');
+    }
+    return ArrivalSignTaskQuery(
+      userId: '${user.userId}',
+      roleOrUserId: '${user.userId}',
+      pageSize: 100,
+    );
+  }
+}

--- a/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_event.dart
+++ b/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_event.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'arrival_sign_list_event.freezed.dart';
+
+@freezed
+class ArrivalSignListEvent with _$ArrivalSignListEvent {
+  const factory ArrivalSignListEvent.initialized() = _Initialized;
+  const factory ArrivalSignListEvent.search(String keyword) = _Search;
+  const factory ArrivalSignListEvent.refresh() = _Refresh;
+  const factory ArrivalSignListEvent.cancel(String arrivalsBillId) = _Cancel;
+}

--- a/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_event.freezed.dart
+++ b/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_event.freezed.dart
@@ -1,0 +1,607 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_sign_list_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ArrivalSignListEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) cancel,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? cancel,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? cancel,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Cancel value) cancel,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Cancel value)? cancel,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Cancel value)? cancel,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalSignListEventCopyWith<$Res> {
+  factory $ArrivalSignListEventCopyWith(ArrivalSignListEvent value,
+          $Res Function(ArrivalSignListEvent) then) =
+      _$ArrivalSignListEventCopyWithImpl<$Res, ArrivalSignListEvent>;
+}
+
+/// @nodoc
+class _$ArrivalSignListEventCopyWithImpl<$Res,
+        $Val extends ArrivalSignListEvent>
+    implements $ArrivalSignListEventCopyWith<$Res> {
+  _$ArrivalSignListEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$InitializedImplCopyWith<$Res> {
+  factory _$$InitializedImplCopyWith(
+          _$InitializedImpl value, $Res Function(_$InitializedImpl) then) =
+      __$$InitializedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InitializedImplCopyWithImpl<$Res>
+    extends _$ArrivalSignListEventCopyWithImpl<$Res, _$InitializedImpl>
+    implements _$$InitializedImplCopyWith<$Res> {
+  __$$InitializedImplCopyWithImpl(
+      _$InitializedImpl _value, $Res Function(_$InitializedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$InitializedImpl implements _Initialized {
+  const _$InitializedImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalSignListEvent.initialized()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitializedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) cancel,
+  }) {
+    return initialized();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? cancel,
+  }) {
+    return initialized?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? cancel,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Cancel value) cancel,
+  }) {
+    return initialized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Cancel value)? cancel,
+  }) {
+    return initialized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Cancel value)? cancel,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initialized implements ArrivalSignListEvent {
+  const factory _Initialized() = _$InitializedImpl;
+}
+
+/// @nodoc
+abstract class _$$SearchImplCopyWith<$Res> {
+  factory _$$SearchImplCopyWith(
+          _$SearchImpl value, $Res Function(_$SearchImpl) then) =
+      __$$SearchImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String keyword});
+}
+
+/// @nodoc
+class __$$SearchImplCopyWithImpl<$Res>
+    extends _$ArrivalSignListEventCopyWithImpl<$Res, _$SearchImpl>
+    implements _$$SearchImplCopyWith<$Res> {
+  __$$SearchImplCopyWithImpl(
+      _$SearchImpl _value, $Res Function(_$SearchImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? keyword = null,
+  }) {
+    return _then(_$SearchImpl(
+      null == keyword
+          ? _value.keyword
+          : keyword // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SearchImpl implements _Search {
+  const _$SearchImpl(this.keyword);
+
+  @override
+  final String keyword;
+
+  @override
+  String toString() {
+    return 'ArrivalSignListEvent.search(keyword: $keyword)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SearchImpl &&
+            (identical(other.keyword, keyword) || other.keyword == keyword));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, keyword);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+      __$$SearchImplCopyWithImpl<_$SearchImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) cancel,
+  }) {
+    return search(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? cancel,
+  }) {
+    return search?.call(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? cancel,
+    required TResult orElse(),
+  }) {
+    if (search != null) {
+      return search(keyword);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Cancel value) cancel,
+  }) {
+    return search(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Cancel value)? cancel,
+  }) {
+    return search?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Cancel value)? cancel,
+    required TResult orElse(),
+  }) {
+    if (search != null) {
+      return search(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Search implements ArrivalSignListEvent {
+  const factory _Search(final String keyword) = _$SearchImpl;
+
+  String get keyword;
+  @JsonKey(ignore: true)
+  _$$SearchImplCopyWith<_$SearchImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$RefreshImplCopyWith<$Res> {
+  factory _$$RefreshImplCopyWith(
+          _$RefreshImpl value, $Res Function(_$RefreshImpl) then) =
+      __$$RefreshImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RefreshImplCopyWithImpl<$Res>
+    extends _$ArrivalSignListEventCopyWithImpl<$Res, _$RefreshImpl>
+    implements _$$RefreshImplCopyWith<$Res> {
+  __$$RefreshImplCopyWithImpl(
+      _$RefreshImpl _value, $Res Function(_$RefreshImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$RefreshImpl implements _Refresh {
+  const _$RefreshImpl();
+
+  @override
+  String toString() {
+    return 'ArrivalSignListEvent.refresh()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$RefreshImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) cancel,
+  }) {
+    return refresh();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? cancel,
+  }) {
+    return refresh?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? cancel,
+    required TResult orElse(),
+  }) {
+    if (refresh != null) {
+      return refresh();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Cancel value) cancel,
+  }) {
+    return refresh(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Cancel value)? cancel,
+  }) {
+    return refresh?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Cancel value)? cancel,
+    required TResult orElse(),
+  }) {
+    if (refresh != null) {
+      return refresh(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Refresh implements ArrivalSignListEvent {
+  const factory _Refresh() = _$RefreshImpl;
+}
+
+/// @nodoc
+abstract class _$$CancelImplCopyWith<$Res> {
+  factory _$$CancelImplCopyWith(
+          _$CancelImpl value, $Res Function(_$CancelImpl) then) =
+      __$$CancelImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String arrivalsBillId});
+}
+
+/// @nodoc
+class __$$CancelImplCopyWithImpl<$Res>
+    extends _$ArrivalSignListEventCopyWithImpl<$Res, _$CancelImpl>
+    implements _$$CancelImplCopyWith<$Res> {
+  __$$CancelImplCopyWithImpl(
+      _$CancelImpl _value, $Res Function(_$CancelImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? arrivalsBillId = null,
+  }) {
+    return _then(_$CancelImpl(
+      null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$CancelImpl implements _Cancel {
+  const _$CancelImpl(this.arrivalsBillId);
+
+  @override
+  final String arrivalsBillId;
+
+  @override
+  String toString() {
+    return 'ArrivalSignListEvent.cancel(arrivalsBillId: $arrivalsBillId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CancelImpl &&
+            (identical(other.arrivalsBillId, arrivalsBillId) ||
+                other.arrivalsBillId == arrivalsBillId));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, arrivalsBillId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CancelImplCopyWith<_$CancelImpl> get copyWith =>
+      __$$CancelImplCopyWithImpl<_$CancelImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String keyword) search,
+    required TResult Function() refresh,
+    required TResult Function(String arrivalsBillId) cancel,
+  }) {
+    return cancel(arrivalsBillId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String keyword)? search,
+    TResult? Function()? refresh,
+    TResult? Function(String arrivalsBillId)? cancel,
+  }) {
+    return cancel?.call(arrivalsBillId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String keyword)? search,
+    TResult Function()? refresh,
+    TResult Function(String arrivalsBillId)? cancel,
+    required TResult orElse(),
+  }) {
+    if (cancel != null) {
+      return cancel(arrivalsBillId);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_Search value) search,
+    required TResult Function(_Refresh value) refresh,
+    required TResult Function(_Cancel value) cancel,
+  }) {
+    return cancel(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_Search value)? search,
+    TResult? Function(_Refresh value)? refresh,
+    TResult? Function(_Cancel value)? cancel,
+  }) {
+    return cancel?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_Search value)? search,
+    TResult Function(_Refresh value)? refresh,
+    TResult Function(_Cancel value)? cancel,
+    required TResult orElse(),
+  }) {
+    if (cancel != null) {
+      return cancel(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Cancel implements ArrivalSignListEvent {
+  const factory _Cancel(final String arrivalsBillId) = _$CancelImpl;
+
+  String get arrivalsBillId;
+  @JsonKey(ignore: true)
+  _$$CancelImplCopyWith<_$CancelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_state.dart
+++ b/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_state.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'arrival_sign_list_state.freezed.dart';
+
+@freezed
+class ArrivalSignListState with _$ArrivalSignListState {
+  const factory ArrivalSignListState({
+    @Default(false) bool isProcessing,
+    String? errorMessage,
+    String? successMessage,
+  }) = _ArrivalSignListState;
+}

--- a/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_state.freezed.dart
+++ b/lib/modules/arrival_sign/task_list/bloc/arrival_sign_list_state.freezed.dart
@@ -1,0 +1,176 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_sign_list_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$ArrivalSignListState {
+  bool get isProcessing => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+  String? get successMessage => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $ArrivalSignListStateCopyWith<ArrivalSignListState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalSignListStateCopyWith<$Res> {
+  factory $ArrivalSignListStateCopyWith(ArrivalSignListState value,
+          $Res Function(ArrivalSignListState) then) =
+      _$ArrivalSignListStateCopyWithImpl<$Res, ArrivalSignListState>;
+  @useResult
+  $Res call({bool isProcessing, String? errorMessage, String? successMessage});
+}
+
+/// @nodoc
+class _$ArrivalSignListStateCopyWithImpl<$Res,
+        $Val extends ArrivalSignListState>
+    implements $ArrivalSignListStateCopyWith<$Res> {
+  _$ArrivalSignListStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isProcessing = null,
+    Object? errorMessage = freezed,
+    Object? successMessage = freezed,
+  }) {
+    return _then(_value.copyWith(
+      isProcessing: null == isProcessing
+          ? _value.isProcessing
+          : isProcessing // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      successMessage: freezed == successMessage
+          ? _value.successMessage
+          : successMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalSignListStateImplCopyWith<$Res>
+    implements $ArrivalSignListStateCopyWith<$Res> {
+  factory _$$ArrivalSignListStateImplCopyWith(_$ArrivalSignListStateImpl value,
+          $Res Function(_$ArrivalSignListStateImpl) then) =
+      __$$ArrivalSignListStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({bool isProcessing, String? errorMessage, String? successMessage});
+}
+
+/// @nodoc
+class __$$ArrivalSignListStateImplCopyWithImpl<$Res>
+    extends _$ArrivalSignListStateCopyWithImpl<$Res, _$ArrivalSignListStateImpl>
+    implements _$$ArrivalSignListStateImplCopyWith<$Res> {
+  __$$ArrivalSignListStateImplCopyWithImpl(_$ArrivalSignListStateImpl _value,
+      $Res Function(_$ArrivalSignListStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? isProcessing = null,
+    Object? errorMessage = freezed,
+    Object? successMessage = freezed,
+  }) {
+    return _then(_$ArrivalSignListStateImpl(
+      isProcessing: null == isProcessing
+          ? _value.isProcessing
+          : isProcessing // ignore: cast_nullable_to_non_nullable
+              as bool,
+      errorMessage: freezed == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      successMessage: freezed == successMessage
+          ? _value.successMessage
+          : successMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ArrivalSignListStateImpl implements _ArrivalSignListState {
+  const _$ArrivalSignListStateImpl(
+      {this.isProcessing = false, this.errorMessage, this.successMessage});
+
+  @override
+  @JsonKey()
+  final bool isProcessing;
+  @override
+  final String? errorMessage;
+  @override
+  final String? successMessage;
+
+  @override
+  String toString() {
+    return 'ArrivalSignListState(isProcessing: $isProcessing, errorMessage: $errorMessage, successMessage: $successMessage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalSignListStateImpl &&
+            (identical(other.isProcessing, isProcessing) ||
+                other.isProcessing == isProcessing) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage) &&
+            (identical(other.successMessage, successMessage) ||
+                other.successMessage == successMessage));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, isProcessing, errorMessage, successMessage);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalSignListStateImplCopyWith<_$ArrivalSignListStateImpl>
+      get copyWith =>
+          __$$ArrivalSignListStateImplCopyWithImpl<_$ArrivalSignListStateImpl>(
+              this, _$identity);
+}
+
+abstract class _ArrivalSignListState implements ArrivalSignListState {
+  const factory _ArrivalSignListState(
+      {final bool isProcessing,
+      final String? errorMessage,
+      final String? successMessage}) = _$ArrivalSignListStateImpl;
+
+  @override
+  bool get isProcessing;
+  @override
+  String? get errorMessage;
+  @override
+  String? get successMessage;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalSignListStateImplCopyWith<_$ArrivalSignListStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_list/config/arrival_sign_task_grid_config.dart
+++ b/lib/modules/arrival_sign/task_list/config/arrival_sign_task_grid_config.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/modules/arrival_sign/task_list/models/arrival_sign_task.dart';
+
+typedef ArrivalSignTaskOperation = void Function(
+  ArrivalSignTask task,
+  ArrivalSignTaskAction action,
+);
+
+enum ArrivalSignTaskAction { collect, detail, cancel }
+
+class ArrivalSignTaskGridConfig {
+  static List<GridColumnConfig<ArrivalSignTask>> buildColumns(
+    ArrivalSignTaskOperation onAction,
+  ) {
+    return [
+      GridColumnConfig<ArrivalSignTask>(
+        name: 'actions',
+        headerText: '操作',
+        width: 220,
+        valueGetter: (task) => null,
+        cellBuilder: (task, columnName, cellValue) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SizedBox(
+                height: 30,
+                child: ElevatedButton(
+                  onPressed: () => onAction(task, ArrivalSignTaskAction.collect),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF007AFF),
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                  ),
+                  child: const Text('采集'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              SizedBox(
+                height: 30,
+                child: OutlinedButton(
+                  onPressed: () => onAction(task, ArrivalSignTaskAction.detail),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: const Color(0xFF1E88E5),
+                    side: const BorderSide(color: Color(0xFF1E88E5)),
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                  ),
+                  child: const Text('明细'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              SizedBox(
+                height: 30,
+                child: OutlinedButton(
+                  onPressed: () => onAction(task, ArrivalSignTaskAction.cancel),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: const Color(0xFFD84315),
+                    side: const BorderSide(color: Color(0xFFD84315)),
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                  ),
+                  child: const Text('撤销'),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+      GridColumnConfig<ArrivalSignTask>(
+        name: 'arrivalsBillNo',
+        headerText: '到货单号',
+        width: 160,
+        valueGetter: (task) => task.arrivalsBillNo,
+      ),
+      GridColumnConfig<ArrivalSignTask>(
+        name: 'orderNo',
+        headerText: '采购单号',
+        width: 150,
+        valueGetter: (task) => task.orderNo,
+      ),
+      GridColumnConfig<ArrivalSignTask>(
+        name: 'poNumber',
+        headerText: '采购订单',
+        width: 150,
+        valueGetter: (task) => task.poNumber,
+      ),
+      GridColumnConfig<ArrivalSignTask>(
+        name: 'createDate',
+        headerText: '到货日期',
+        width: 140,
+        valueGetter: (task) => task.createDate,
+      ),
+      GridColumnConfig<ArrivalSignTask>(
+        name: 'plant',
+        headerText: '工厂',
+        width: 100,
+        valueGetter: (task) => task.plant,
+      ),
+      GridColumnConfig<ArrivalSignTask>(
+        name: 'supplierName',
+        headerText: '供应商',
+        width: 160,
+        valueGetter: (task) => task.supplierName,
+      ),
+      GridColumnConfig<ArrivalSignTask>(
+        name: 'arrivalsBillId',
+        headerText: '到货单ID',
+        width: 140,
+        valueGetter: (task) => task.arrivalsBillId,
+      ),
+    ];
+  }
+}

--- a/lib/modules/arrival_sign/task_list/models/arrival_sign_task.dart
+++ b/lib/modules/arrival_sign/task_list/models/arrival_sign_task.dart
@@ -1,0 +1,100 @@
+// ignore_for_file: invalid_annotation_target
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:equatable/equatable.dart';
+
+part 'arrival_sign_task.freezed.dart';
+part 'arrival_sign_task.g.dart';
+
+/// 到货签收任务列表数据模型
+@freezed
+class ArrivalSignTask with _$ArrivalSignTask {
+  const factory ArrivalSignTask({
+    @JsonKey(name: 'arrivalsBillid') required String arrivalsBillId,
+    @JsonKey(name: 'arrivalsBillno') required String arrivalsBillNo,
+    @JsonKey(name: 'orderno') required String orderNo,
+    @JsonKey(name: 'poNumber') required String poNumber,
+    @JsonKey(name: 'createdate') required String createDate,
+    @JsonKey(name: 'werks') required String plant,
+    @JsonKey(name: 'parname') required String supplierName,
+    @JsonKey(name: 'status') String? status,
+  }) = _ArrivalSignTask;
+
+  factory ArrivalSignTask.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalSignTaskFromJson(json);
+}
+
+/// 到货签收任务分页数据
+@freezed
+class ArrivalSignTaskPage with _$ArrivalSignTaskPage {
+  const factory ArrivalSignTaskPage({
+    @JsonKey(name: 'total') @Default(0) int total,
+    @JsonKey(name: 'rows') @Default(<ArrivalSignTask>[]) List<ArrivalSignTask> rows,
+  }) = _ArrivalSignTaskPage;
+
+  factory ArrivalSignTaskPage.fromJson(Map<String, dynamic> json) =>
+      _$ArrivalSignTaskPageFromJson(json);
+}
+
+/// 到货签收任务列表查询参数
+class ArrivalSignTaskQuery extends Equatable {
+  const ArrivalSignTaskQuery({
+    required this.userId,
+    required this.roleOrUserId,
+    this.searchKey = '',
+    this.pageIndex = 1,
+    this.pageSize = 100,
+    this.sortType = '',
+    this.sortColumn = '',
+  });
+
+  final String userId;
+  final String roleOrUserId;
+  final String searchKey;
+  final int pageIndex;
+  final int pageSize;
+  final String sortType;
+  final String sortColumn;
+
+  ArrivalSignTaskQuery copyWith({
+    String? userId,
+    String? roleOrUserId,
+    String? searchKey,
+    int? pageIndex,
+    int? pageSize,
+    String? sortType,
+    String? sortColumn,
+  }) {
+    return ArrivalSignTaskQuery(
+      userId: userId ?? this.userId,
+      roleOrUserId: roleOrUserId ?? this.roleOrUserId,
+      searchKey: searchKey ?? this.searchKey,
+      pageIndex: pageIndex ?? this.pageIndex,
+      pageSize: pageSize ?? this.pageSize,
+      sortType: sortType ?? this.sortType,
+      sortColumn: sortColumn ?? this.sortColumn,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'userId': userId,
+      'roleoRuserId': roleOrUserId,
+      'searchKey': searchKey,
+      'pageIndex': pageIndex,
+      'pageSize': pageSize,
+      'sortType': sortType,
+      'sortColumn': sortColumn,
+    };
+  }
+
+  @override
+  List<Object?> get props => [
+        userId,
+        roleOrUserId,
+        searchKey,
+        pageIndex,
+        pageSize,
+        sortType,
+        sortColumn,
+      ];
+}

--- a/lib/modules/arrival_sign/task_list/models/arrival_sign_task.freezed.dart
+++ b/lib/modules/arrival_sign/task_list/models/arrival_sign_task.freezed.dart
@@ -1,0 +1,502 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'arrival_sign_task.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ArrivalSignTask _$ArrivalSignTaskFromJson(Map<String, dynamic> json) {
+  return _ArrivalSignTask.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalSignTask {
+  @JsonKey(name: 'arrivalsBillid')
+  String get arrivalsBillId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'arrivalsBillno')
+  String get arrivalsBillNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'orderno')
+  String get orderNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'poNumber')
+  String get poNumber => throw _privateConstructorUsedError;
+  @JsonKey(name: 'createdate')
+  String get createDate => throw _privateConstructorUsedError;
+  @JsonKey(name: 'werks')
+  String get plant => throw _privateConstructorUsedError;
+  @JsonKey(name: 'parname')
+  String get supplierName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'status')
+  String? get status => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalSignTaskCopyWith<ArrivalSignTask> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalSignTaskCopyWith<$Res> {
+  factory $ArrivalSignTaskCopyWith(
+          ArrivalSignTask value, $Res Function(ArrivalSignTask) then) =
+      _$ArrivalSignTaskCopyWithImpl<$Res, ArrivalSignTask>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'arrivalsBillid') String arrivalsBillId,
+      @JsonKey(name: 'arrivalsBillno') String arrivalsBillNo,
+      @JsonKey(name: 'orderno') String orderNo,
+      @JsonKey(name: 'poNumber') String poNumber,
+      @JsonKey(name: 'createdate') String createDate,
+      @JsonKey(name: 'werks') String plant,
+      @JsonKey(name: 'parname') String supplierName,
+      @JsonKey(name: 'status') String? status});
+}
+
+/// @nodoc
+class _$ArrivalSignTaskCopyWithImpl<$Res, $Val extends ArrivalSignTask>
+    implements $ArrivalSignTaskCopyWith<$Res> {
+  _$ArrivalSignTaskCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? arrivalsBillId = null,
+    Object? arrivalsBillNo = null,
+    Object? orderNo = null,
+    Object? poNumber = null,
+    Object? createDate = null,
+    Object? plant = null,
+    Object? supplierName = null,
+    Object? status = freezed,
+  }) {
+    return _then(_value.copyWith(
+      arrivalsBillId: null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+      arrivalsBillNo: null == arrivalsBillNo
+          ? _value.arrivalsBillNo
+          : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      orderNo: null == orderNo
+          ? _value.orderNo
+          : orderNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      poNumber: null == poNumber
+          ? _value.poNumber
+          : poNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      createDate: null == createDate
+          ? _value.createDate
+          : createDate // ignore: cast_nullable_to_non_nullable
+              as String,
+      plant: null == plant
+          ? _value.plant
+          : plant // ignore: cast_nullable_to_non_nullable
+              as String,
+      supplierName: null == supplierName
+          ? _value.supplierName
+          : supplierName // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: freezed == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalSignTaskImplCopyWith<$Res>
+    implements $ArrivalSignTaskCopyWith<$Res> {
+  factory _$$ArrivalSignTaskImplCopyWith(_$ArrivalSignTaskImpl value,
+          $Res Function(_$ArrivalSignTaskImpl) then) =
+      __$$ArrivalSignTaskImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'arrivalsBillid') String arrivalsBillId,
+      @JsonKey(name: 'arrivalsBillno') String arrivalsBillNo,
+      @JsonKey(name: 'orderno') String orderNo,
+      @JsonKey(name: 'poNumber') String poNumber,
+      @JsonKey(name: 'createdate') String createDate,
+      @JsonKey(name: 'werks') String plant,
+      @JsonKey(name: 'parname') String supplierName,
+      @JsonKey(name: 'status') String? status});
+}
+
+/// @nodoc
+class __$$ArrivalSignTaskImplCopyWithImpl<$Res>
+    extends _$ArrivalSignTaskCopyWithImpl<$Res, _$ArrivalSignTaskImpl>
+    implements _$$ArrivalSignTaskImplCopyWith<$Res> {
+  __$$ArrivalSignTaskImplCopyWithImpl(
+      _$ArrivalSignTaskImpl _value, $Res Function(_$ArrivalSignTaskImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? arrivalsBillId = null,
+    Object? arrivalsBillNo = null,
+    Object? orderNo = null,
+    Object? poNumber = null,
+    Object? createDate = null,
+    Object? plant = null,
+    Object? supplierName = null,
+    Object? status = freezed,
+  }) {
+    return _then(_$ArrivalSignTaskImpl(
+      arrivalsBillId: null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+      arrivalsBillNo: null == arrivalsBillNo
+          ? _value.arrivalsBillNo
+          : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      orderNo: null == orderNo
+          ? _value.orderNo
+          : orderNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      poNumber: null == poNumber
+          ? _value.poNumber
+          : poNumber // ignore: cast_nullable_to_non_nullable
+              as String,
+      createDate: null == createDate
+          ? _value.createDate
+          : createDate // ignore: cast_nullable_to_non_nullable
+              as String,
+      plant: null == plant
+          ? _value.plant
+          : plant // ignore: cast_nullable_to_non_nullable
+              as String,
+      supplierName: null == supplierName
+          ? _value.supplierName
+          : supplierName // ignore: cast_nullable_to_non_nullable
+              as String,
+      status: freezed == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalSignTaskImpl implements _ArrivalSignTask {
+  const _$ArrivalSignTaskImpl(
+      {@JsonKey(name: 'arrivalsBillid') required this.arrivalsBillId,
+      @JsonKey(name: 'arrivalsBillno') required this.arrivalsBillNo,
+      @JsonKey(name: 'orderno') required this.orderNo,
+      @JsonKey(name: 'poNumber') required this.poNumber,
+      @JsonKey(name: 'createdate') required this.createDate,
+      @JsonKey(name: 'werks') required this.plant,
+      @JsonKey(name: 'parname') required this.supplierName,
+      @JsonKey(name: 'status') this.status});
+
+  factory _$ArrivalSignTaskImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalSignTaskImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'arrivalsBillid')
+  final String arrivalsBillId;
+  @override
+  @JsonKey(name: 'arrivalsBillno')
+  final String arrivalsBillNo;
+  @override
+  @JsonKey(name: 'orderno')
+  final String orderNo;
+  @override
+  @JsonKey(name: 'poNumber')
+  final String poNumber;
+  @override
+  @JsonKey(name: 'createdate')
+  final String createDate;
+  @override
+  @JsonKey(name: 'werks')
+  final String plant;
+  @override
+  @JsonKey(name: 'parname')
+  final String supplierName;
+  @override
+  @JsonKey(name: 'status')
+  final String? status;
+
+  @override
+  String toString() {
+    return 'ArrivalSignTask(arrivalsBillId: $arrivalsBillId, arrivalsBillNo: $arrivalsBillNo, orderNo: $orderNo, poNumber: $poNumber, createDate: $createDate, plant: $plant, supplierName: $supplierName, status: $status)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalSignTaskImpl &&
+            (identical(other.arrivalsBillId, arrivalsBillId) ||
+                other.arrivalsBillId == arrivalsBillId) &&
+            (identical(other.arrivalsBillNo, arrivalsBillNo) ||
+                other.arrivalsBillNo == arrivalsBillNo) &&
+            (identical(other.orderNo, orderNo) || other.orderNo == orderNo) &&
+            (identical(other.poNumber, poNumber) ||
+                other.poNumber == poNumber) &&
+            (identical(other.createDate, createDate) ||
+                other.createDate == createDate) &&
+            (identical(other.plant, plant) || other.plant == plant) &&
+            (identical(other.supplierName, supplierName) ||
+                other.supplierName == supplierName) &&
+            (identical(other.status, status) || other.status == status));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, arrivalsBillId, arrivalsBillNo,
+      orderNo, poNumber, createDate, plant, supplierName, status);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalSignTaskImplCopyWith<_$ArrivalSignTaskImpl> get copyWith =>
+      __$$ArrivalSignTaskImplCopyWithImpl<_$ArrivalSignTaskImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalSignTaskImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ArrivalSignTask implements ArrivalSignTask {
+  const factory _ArrivalSignTask(
+      {@JsonKey(name: 'arrivalsBillid') required final String arrivalsBillId,
+      @JsonKey(name: 'arrivalsBillno') required final String arrivalsBillNo,
+      @JsonKey(name: 'orderno') required final String orderNo,
+      @JsonKey(name: 'poNumber') required final String poNumber,
+      @JsonKey(name: 'createdate') required final String createDate,
+      @JsonKey(name: 'werks') required final String plant,
+      @JsonKey(name: 'parname') required final String supplierName,
+      @JsonKey(name: 'status') final String? status}) = _$ArrivalSignTaskImpl;
+
+  factory _ArrivalSignTask.fromJson(Map<String, dynamic> json) =
+      _$ArrivalSignTaskImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'arrivalsBillid')
+  String get arrivalsBillId;
+  @override
+  @JsonKey(name: 'arrivalsBillno')
+  String get arrivalsBillNo;
+  @override
+  @JsonKey(name: 'orderno')
+  String get orderNo;
+  @override
+  @JsonKey(name: 'poNumber')
+  String get poNumber;
+  @override
+  @JsonKey(name: 'createdate')
+  String get createDate;
+  @override
+  @JsonKey(name: 'werks')
+  String get plant;
+  @override
+  @JsonKey(name: 'parname')
+  String get supplierName;
+  @override
+  @JsonKey(name: 'status')
+  String? get status;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalSignTaskImplCopyWith<_$ArrivalSignTaskImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+ArrivalSignTaskPage _$ArrivalSignTaskPageFromJson(Map<String, dynamic> json) {
+  return _ArrivalSignTaskPage.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ArrivalSignTaskPage {
+  @JsonKey(name: 'total')
+  int get total => throw _privateConstructorUsedError;
+  @JsonKey(name: 'rows')
+  List<ArrivalSignTask> get rows => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $ArrivalSignTaskPageCopyWith<ArrivalSignTaskPage> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ArrivalSignTaskPageCopyWith<$Res> {
+  factory $ArrivalSignTaskPageCopyWith(
+          ArrivalSignTaskPage value, $Res Function(ArrivalSignTaskPage) then) =
+      _$ArrivalSignTaskPageCopyWithImpl<$Res, ArrivalSignTaskPage>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'total') int total,
+      @JsonKey(name: 'rows') List<ArrivalSignTask> rows});
+}
+
+/// @nodoc
+class _$ArrivalSignTaskPageCopyWithImpl<$Res, $Val extends ArrivalSignTaskPage>
+    implements $ArrivalSignTaskPageCopyWith<$Res> {
+  _$ArrivalSignTaskPageCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? total = null,
+    Object? rows = null,
+  }) {
+    return _then(_value.copyWith(
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      rows: null == rows
+          ? _value.rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalSignTask>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ArrivalSignTaskPageImplCopyWith<$Res>
+    implements $ArrivalSignTaskPageCopyWith<$Res> {
+  factory _$$ArrivalSignTaskPageImplCopyWith(_$ArrivalSignTaskPageImpl value,
+          $Res Function(_$ArrivalSignTaskPageImpl) then) =
+      __$$ArrivalSignTaskPageImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'total') int total,
+      @JsonKey(name: 'rows') List<ArrivalSignTask> rows});
+}
+
+/// @nodoc
+class __$$ArrivalSignTaskPageImplCopyWithImpl<$Res>
+    extends _$ArrivalSignTaskPageCopyWithImpl<$Res, _$ArrivalSignTaskPageImpl>
+    implements _$$ArrivalSignTaskPageImplCopyWith<$Res> {
+  __$$ArrivalSignTaskPageImplCopyWithImpl(_$ArrivalSignTaskPageImpl _value,
+      $Res Function(_$ArrivalSignTaskPageImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? total = null,
+    Object? rows = null,
+  }) {
+    return _then(_$ArrivalSignTaskPageImpl(
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      rows: null == rows
+          ? _value._rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalSignTask>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ArrivalSignTaskPageImpl implements _ArrivalSignTaskPage {
+  const _$ArrivalSignTaskPageImpl(
+      {@JsonKey(name: 'total') this.total = 0,
+      @JsonKey(name: 'rows')
+      final List<ArrivalSignTask> rows = const <ArrivalSignTask>[]})
+      : _rows = rows;
+
+  factory _$ArrivalSignTaskPageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ArrivalSignTaskPageImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'total')
+  final int total;
+  final List<ArrivalSignTask> _rows;
+  @override
+  @JsonKey(name: 'rows')
+  List<ArrivalSignTask> get rows {
+    if (_rows is EqualUnmodifiableListView) return _rows;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_rows);
+  }
+
+  @override
+  String toString() {
+    return 'ArrivalSignTaskPage(total: $total, rows: $rows)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ArrivalSignTaskPageImpl &&
+            (identical(other.total, total) || other.total == total) &&
+            const DeepCollectionEquality().equals(other._rows, _rows));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, total, const DeepCollectionEquality().hash(_rows));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ArrivalSignTaskPageImplCopyWith<_$ArrivalSignTaskPageImpl> get copyWith =>
+      __$$ArrivalSignTaskPageImplCopyWithImpl<_$ArrivalSignTaskPageImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ArrivalSignTaskPageImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ArrivalSignTaskPage implements ArrivalSignTaskPage {
+  const factory _ArrivalSignTaskPage(
+          {@JsonKey(name: 'total') final int total,
+          @JsonKey(name: 'rows') final List<ArrivalSignTask> rows}) =
+      _$ArrivalSignTaskPageImpl;
+
+  factory _ArrivalSignTaskPage.fromJson(Map<String, dynamic> json) =
+      _$ArrivalSignTaskPageImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'total')
+  int get total;
+  @override
+  @JsonKey(name: 'rows')
+  List<ArrivalSignTask> get rows;
+  @override
+  @JsonKey(ignore: true)
+  _$$ArrivalSignTaskPageImplCopyWith<_$ArrivalSignTaskPageImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/arrival_sign/task_list/models/arrival_sign_task.g.dart
+++ b/lib/modules/arrival_sign/task_list/models/arrival_sign_task.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'arrival_sign_task.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ArrivalSignTaskImpl _$$ArrivalSignTaskImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ArrivalSignTaskImpl(
+      arrivalsBillId: json['arrivalsBillid'] as String,
+      arrivalsBillNo: json['arrivalsBillno'] as String,
+      orderNo: json['orderno'] as String,
+      poNumber: json['poNumber'] as String,
+      createDate: json['createdate'] as String,
+      plant: json['werks'] as String,
+      supplierName: json['parname'] as String,
+      status: json['status'] as String?,
+    );
+
+Map<String, dynamic> _$$ArrivalSignTaskImplToJson(
+        _$ArrivalSignTaskImpl instance) =>
+    <String, dynamic>{
+      'arrivalsBillid': instance.arrivalsBillId,
+      'arrivalsBillno': instance.arrivalsBillNo,
+      'orderno': instance.orderNo,
+      'poNumber': instance.poNumber,
+      'createdate': instance.createDate,
+      'werks': instance.plant,
+      'parname': instance.supplierName,
+      'status': instance.status,
+    };
+
+_$ArrivalSignTaskPageImpl _$$ArrivalSignTaskPageImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ArrivalSignTaskPageImpl(
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      rows: (json['rows'] as List<dynamic>?)
+              ?.map((e) => ArrivalSignTask.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <ArrivalSignTask>[],
+    );
+
+Map<String, dynamic> _$$ArrivalSignTaskPageImplToJson(
+        _$ArrivalSignTaskPageImpl instance) =>
+    <String, dynamic>{
+      'total': instance.total,
+      'rows': instance.rows,
+    };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
     description:
       name: _fe_analyzer_shared
       sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "67.0.0"
   analyzer:
@@ -14,7 +14,7 @@ packages:
     description:
       name: analyzer
       sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.4.1"
   ansicolor:
@@ -22,7 +22,7 @@ packages:
     description:
       name: ansicolor
       sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
   archive:
@@ -30,7 +30,7 @@ packages:
     description:
       name: archive
       sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.7"
   args:
@@ -38,7 +38,7 @@ packages:
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
   async:
@@ -46,7 +46,7 @@ packages:
     description:
       name: async
       sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
   auto_injector:
@@ -54,7 +54,7 @@ packages:
     description:
       name: auto_injector
       sha256: "1fc2624898e92485122eb2b1698dd42511d7ff6574f84a3a8606fc4549a1e8f8"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   bloc:
@@ -62,7 +62,7 @@ packages:
     description:
       name: bloc
       sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
   boolean_selector:
@@ -70,7 +70,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   build:
@@ -78,7 +78,7 @@ packages:
     description:
       name: build
       sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   build_config:
@@ -86,7 +86,7 @@ packages:
     description:
       name: build_config
       sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   build_daemon:
@@ -94,7 +94,7 @@ packages:
     description:
       name: build_daemon
       sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
   build_resolvers:
@@ -102,7 +102,7 @@ packages:
     description:
       name: build_resolvers
       sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   build_runner:
@@ -110,7 +110,7 @@ packages:
     description:
       name: build_runner
       sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.13"
   build_runner_core:
@@ -118,7 +118,7 @@ packages:
     description:
       name: build_runner_core
       sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.3.2"
   built_collection:
@@ -126,7 +126,7 @@ packages:
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -134,7 +134,7 @@ packages:
     description:
       name: built_value
       sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.12.0"
   characters:
@@ -142,7 +142,7 @@ packages:
     description:
       name: characters
       sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   checked_yaml:
@@ -150,7 +150,7 @@ packages:
     description:
       name: checked_yaml
       sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
   clock:
@@ -158,7 +158,7 @@ packages:
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   code_builder:
@@ -166,7 +166,7 @@ packages:
     description:
       name: code_builder
       sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
   collection:
@@ -174,7 +174,7 @@ packages:
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
   convert:
@@ -182,7 +182,7 @@ packages:
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   crypto:
@@ -190,7 +190,7 @@ packages:
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
   csslib:
@@ -198,7 +198,7 @@ packages:
     description:
       name: csslib
       sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   cupertino_icons:
@@ -206,7 +206,7 @@ packages:
     description:
       name: cupertino_icons
       sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
   dart_style:
@@ -214,7 +214,7 @@ packages:
     description:
       name: dart_style
       sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
   dio:
@@ -222,7 +222,7 @@ packages:
     description:
       name: dio
       sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.9.0"
   dio_web_adapter:
@@ -230,7 +230,7 @@ packages:
     description:
       name: dio_web_adapter
       sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   equatable:
@@ -238,7 +238,7 @@ packages:
     description:
       name: equatable
       sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.7"
   fake_async:
@@ -246,7 +246,7 @@ packages:
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   ffi:
@@ -254,7 +254,7 @@ packages:
     description:
       name: ffi
       sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   file:
@@ -262,7 +262,7 @@ packages:
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
   fixnum:
@@ -270,7 +270,7 @@ packages:
     description:
       name: fixnum
       sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   flutter:
@@ -283,7 +283,7 @@ packages:
     description:
       name: flutter_bloc
       sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.6"
   flutter_hooks:
@@ -291,7 +291,7 @@ packages:
     description:
       name: flutter_hooks
       sha256: cde36b12f7188c85286fba9b38cc5a902e7279f36dd676967106c041dc9dde70
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.20.5"
   flutter_lints:
@@ -299,7 +299,7 @@ packages:
     description:
       name: flutter_lints
       sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
   flutter_modular:
@@ -307,7 +307,7 @@ packages:
     description:
       name: flutter_modular
       sha256: "33a63d9fe61429d12b3dfa04795ed890f17d179d3d38e988ba7969651fcd5586"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.4.1"
   flutter_native_splash:
@@ -315,7 +315,7 @@ packages:
     description:
       name: flutter_native_splash
       sha256: "8321a6d11a8d13977fa780c89de8d257cce3d841eecfb7a4cadffcc4f12d82dc"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.6"
   flutter_secure_storage:
@@ -323,7 +323,7 @@ packages:
     description:
       name: flutter_secure_storage
       sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "9.2.4"
   flutter_secure_storage_linux:
@@ -331,7 +331,7 @@ packages:
     description:
       name: flutter_secure_storage_linux
       sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
   flutter_secure_storage_macos:
@@ -339,7 +339,7 @@ packages:
     description:
       name: flutter_secure_storage_macos
       sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
   flutter_secure_storage_platform_interface:
@@ -347,7 +347,7 @@ packages:
     description:
       name: flutter_secure_storage_platform_interface
       sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   flutter_secure_storage_web:
@@ -355,7 +355,7 @@ packages:
     description:
       name: flutter_secure_storage_web
       sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   flutter_secure_storage_windows:
@@ -363,7 +363,7 @@ packages:
     description:
       name: flutter_secure_storage_windows
       sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
   flutter_svg:
@@ -371,7 +371,7 @@ packages:
     description:
       name: flutter_svg
       sha256: b9c2ad5872518a27507ab432d1fb97e8813b05f0fc693f9d40fad06d073e0678
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   flutter_test:
@@ -389,7 +389,7 @@ packages:
     description:
       name: freezed
       sha256: a434911f643466d78462625df76fd9eb13e57348ff43fe1f77bbe909522c67a1
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.2"
   freezed_annotation:
@@ -397,7 +397,7 @@ packages:
     description:
       name: freezed_annotation
       sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
   frontend_server_client:
@@ -405,7 +405,7 @@ packages:
     description:
       name: frontend_server_client
       sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   glob:
@@ -413,23 +413,23 @@ packages:
     description:
       name: glob
       sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   google_fonts:
     dependency: "direct main"
     description:
       name: google_fonts
-      sha256: ebc94ed30fd13cefd397cb1658b593f21571f014b7d1197eeb41fb95f05d899a
-      url: "https://pub.flutter-io.cn"
+      sha256: "517b20870220c48752eafa0ba1a797a092fb22df0d89535fd9991e86ee2cdd9c"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.2"
   graphs:
     dependency: transitive
     description:
       name: graphs
       sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   hive:
@@ -437,7 +437,7 @@ packages:
     description:
       name: hive
       sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   hive_flutter:
@@ -445,7 +445,7 @@ packages:
     description:
       name: hive_flutter
       sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   hive_generator:
@@ -453,7 +453,7 @@ packages:
     description:
       name: hive_generator
       sha256: "06cb8f58ace74de61f63500564931f9505368f45f98958bd7a6c35ba24159db4"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   html:
@@ -461,7 +461,7 @@ packages:
     description:
       name: html
       sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.15.6"
   http:
@@ -469,7 +469,7 @@ packages:
     description:
       name: http
       sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   http_multi_server:
@@ -477,7 +477,7 @@ packages:
     description:
       name: http_multi_server
       sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
   http_parser:
@@ -485,7 +485,7 @@ packages:
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
   image:
@@ -493,7 +493,7 @@ packages:
     description:
       name: image
       sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
   intl:
@@ -501,7 +501,7 @@ packages:
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.20.2"
   io:
@@ -509,7 +509,7 @@ packages:
     description:
       name: io
       sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   js:
@@ -517,7 +517,7 @@ packages:
     description:
       name: js
       sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
   json_annotation:
@@ -525,7 +525,7 @@ packages:
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
   json_serializable:
@@ -533,7 +533,7 @@ packages:
     description:
       name: json_serializable
       sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.8.0"
   leak_tracker:
@@ -541,7 +541,7 @@ packages:
     description:
       name: leak_tracker
       sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "11.0.2"
   leak_tracker_flutter_testing:
@@ -549,7 +549,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.10"
   leak_tracker_testing:
@@ -557,7 +557,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   lints:
@@ -565,7 +565,7 @@ packages:
     description:
       name: lints
       sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   logging:
@@ -573,7 +573,7 @@ packages:
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   matcher:
@@ -581,7 +581,7 @@ packages:
     description:
       name: matcher
       sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.17"
   material_color_utilities:
@@ -589,7 +589,7 @@ packages:
     description:
       name: material_color_utilities
       sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
   meta:
@@ -597,7 +597,7 @@ packages:
     description:
       name: meta
       sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
   mime:
@@ -605,7 +605,7 @@ packages:
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   modular_core:
@@ -613,7 +613,7 @@ packages:
     description:
       name: modular_core
       sha256: "1db0420a0dfb8a2c6dca846e7cbaa4ffeb778e247916dbcb27fb25aa566e5436"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
   nested:
@@ -621,7 +621,7 @@ packages:
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   package_config:
@@ -629,7 +629,7 @@ packages:
     description:
       name: package_config
       sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   path:
@@ -637,7 +637,7 @@ packages:
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   path_parsing:
@@ -645,7 +645,7 @@ packages:
     description:
       name: path_parsing
       sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   path_provider:
@@ -653,23 +653,23 @@ packages:
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
-      url: "https://pub.flutter-io.cn"
+      sha256: e122c5ea805bb6773bb12ce667611265980940145be920cd09a4b0ec0285cb16
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.18"
+    version: "2.2.20"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
       sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.2"
   path_provider_linux:
@@ -677,7 +677,7 @@ packages:
     description:
       name: path_provider_linux
       sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
@@ -685,7 +685,7 @@ packages:
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   path_provider_windows:
@@ -693,7 +693,7 @@ packages:
     description:
       name: path_provider_windows
       sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   petitparser:
@@ -701,7 +701,7 @@ packages:
     description:
       name: petitparser
       sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
   platform:
@@ -709,7 +709,7 @@ packages:
     description:
       name: platform
       sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
@@ -717,7 +717,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
   pool:
@@ -725,7 +725,7 @@ packages:
     description:
       name: pool
       sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
   posix:
@@ -733,7 +733,7 @@ packages:
     description:
       name: posix
       sha256: "6323a5b0fa688b6a010df4905a56b00181479e6d10534cecfecede2aa55add61"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
   provider:
@@ -741,7 +741,7 @@ packages:
     description:
       name: provider
       sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
   pub_semver:
@@ -749,7 +749,7 @@ packages:
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   pubspec_parse:
@@ -757,7 +757,7 @@ packages:
     description:
       name: pubspec_parse
       sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   result_dart:
@@ -765,7 +765,7 @@ packages:
     description:
       name: result_dart
       sha256: "0666b21fbdf697b3bdd9986348a380aa204b3ebe7c146d8e4cdaa7ce735e6054"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   shared_preferences:
@@ -773,23 +773,23 @@ packages:
     description:
       name: shared_preferences
       sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.3"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: a2608114b1ffdcbc9c120eb71a0e207c71da56202852d4aab8a5e30a82269e74
-      url: "https://pub.flutter-io.cn"
+      sha256: "34266009473bf71d748912da4bf62d439185226c03e01e2d9687bc65bbfcb713"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.4.12"
+    version: "2.4.15"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
       sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.5.4"
   shared_preferences_linux:
@@ -797,7 +797,7 @@ packages:
     description:
       name: shared_preferences_linux
       sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   shared_preferences_platform_interface:
@@ -805,7 +805,7 @@ packages:
     description:
       name: shared_preferences_platform_interface
       sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   shared_preferences_web:
@@ -813,7 +813,7 @@ packages:
     description:
       name: shared_preferences_web
       sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.3"
   shared_preferences_windows:
@@ -821,7 +821,7 @@ packages:
     description:
       name: shared_preferences_windows
       sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   shelf:
@@ -829,7 +829,7 @@ packages:
     description:
       name: shelf
       sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
   shelf_web_socket:
@@ -837,7 +837,7 @@ packages:
     description:
       name: shelf_web_socket
       sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   sky_engine:
@@ -850,7 +850,7 @@ packages:
     description:
       name: source_gen
       sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   source_helper:
@@ -858,7 +858,7 @@ packages:
     description:
       name: source_helper
       sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.5"
   source_span:
@@ -866,7 +866,7 @@ packages:
     description:
       name: source_span
       sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
   sprintf:
@@ -874,7 +874,7 @@ packages:
     description:
       name: sprintf
       sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
   stack_trace:
@@ -882,7 +882,7 @@ packages:
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
   stream_channel:
@@ -890,7 +890,7 @@ packages:
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   stream_transform:
@@ -898,7 +898,7 @@ packages:
     description:
       name: stream_transform
       sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   string_scanner:
@@ -906,31 +906,31 @@ packages:
     description:
       name: string_scanner
       sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
   syncfusion_flutter_core:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_core
-      sha256: e8e351522b7c3442609e04f1613f29b7917147bb3de41dbd3c1ec4169cf1888d
-      url: "https://pub.flutter-io.cn"
+      sha256: adcd41bc5c4de1e7aa831fe3f2ca2d22465de29f166a9de685133b70d21e4541
+      url: "https://pub.dev"
     source: hosted
-    version: "31.1.20"
+    version: "31.2.2"
   syncfusion_flutter_datagrid:
     dependency: "direct main"
     description:
       name: syncfusion_flutter_datagrid
-      sha256: "5699d6ef698bb29b19267fdbf22b9dbd4a4dbedcd853c7cfced75a31272757bf"
-      url: "https://pub.flutter-io.cn"
+      sha256: "3b62d1fdee9583c60909e1a67b7cf4b8624c0944156e7df6e2e97b6c5426aded"
+      url: "https://pub.dev"
     source: hosted
-    version: "31.1.20"
+    version: "31.2.2"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
   test_api:
@@ -938,7 +938,7 @@ packages:
     description:
       name: test_api
       sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
   timing:
@@ -946,7 +946,7 @@ packages:
     description:
       name: timing
       sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   typed_data:
@@ -954,7 +954,7 @@ packages:
     description:
       name: typed_data
       sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   universal_io:
@@ -962,7 +962,7 @@ packages:
     description:
       name: universal_io
       sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.2"
   uuid:
@@ -970,7 +970,7 @@ packages:
     description:
       name: uuid
       sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "4.5.1"
   vector_graphics:
@@ -978,7 +978,7 @@ packages:
     description:
       name: vector_graphics
       sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.19"
   vector_graphics_codec:
@@ -986,7 +986,7 @@ packages:
     description:
       name: vector_graphics_codec
       sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.13"
   vector_graphics_compiler:
@@ -994,7 +994,7 @@ packages:
     description:
       name: vector_graphics_compiler
       sha256: d354a7ec6931e6047785f4db12a1f61ec3d43b207fc0790f863818543f8ff0dc
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.19"
   vector_math:
@@ -1002,7 +1002,7 @@ packages:
     description:
       name: vector_math
       sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   vm_service:
@@ -1010,23 +1010,23 @@ packages:
     description:
       name: vm_service
       sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
-      url: "https://pub.flutter-io.cn"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   web:
     dependency: transitive
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   web_socket:
@@ -1034,7 +1034,7 @@ packages:
     description:
       name: web_socket
       sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
@@ -1042,23 +1042,23 @@ packages:
     description:
       name: web_socket_channel
       sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
-      url: "https://pub.flutter-io.cn"
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
     source: hosted
-    version: "5.14.0"
+    version: "5.15.0"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   xml:
@@ -1066,7 +1066,7 @@ packages:
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
   yaml:
@@ -1074,7 +1074,7 @@ packages:
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
 sdks:


### PR DESCRIPTION
## Summary
- add the arrival sign collect page with scanning, tabbed grids, and manual quantity input backed by persistent cache
- introduce collect-specific bloc, Freezed models, and service APIs for QR lookup and commit submission
- register collect/result routes and mark the arrival sign refactor TODOs for the completed list and collect flows

## Testing
- `./flutter/bin/flutter pub run build_runner build --delete-conflicting-outputs`

------
https://chatgpt.com/codex/tasks/task_e_68f07e2c3ca48330aef7c2aa601d387a