### PR TITLE
feat: add ASWH inventory pallet detail view and command confirmation

### DIFF
--- a/docs/aswh_inventory_refactor/aswh_inventory_checkorder_todo.md
+++ b/docs/aswh_inventory_refactor/aswh_inventory_checkorder_todo.md
@@ -1,0 +1,33 @@
+# 立库盘点指令结果页（task_collect/aswhInventoryCheckorder.nvue）重构 TODO
+
+## 背景概述
+- 页面展示盘点相关指令执行情况，与在线拣选指令页结构类似，同样基于 `getWmsToWcsByTaskID` 查询，并通过底部按钮提供撤销与刷新功能。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventoryCheckorder.nvue†L1-L95】
+- 与采集页的更多菜单联动，用于查看盘点任务已下发指令的状态。
+
+## 实施目标
+- 根据业务需要决定与 `在线拣选指令页` 的差异（例如过滤条件/展示字段），可共用同一 Flutter 页面，通过参数控制标题与操作类型。
+- 提供刷新、撤销功能，并展示 WCS 返回的详细信息。
+
+## TODO 清单
+- [x] **需求澄清**：
+  - [x] 与业务确认 `Checkorder` 页与 `WmsToWcs` 页的差异点（是否仅标题不同或过滤不同）。
+  - [x] 如差异较小，考虑共享组件，通过 `CommandCategory` 参数驱动。
+- [x] **路由策略**：
+  - [x] 若独立页面，注册 `/aswh-inventory/commands/checkorder` 并传递任务参数与类别。
+  - [x] 若复用通用指令页，定义可选参数控制标题 `立库盘点采集结果`。
+- [x] **数据模型与服务**：
+  - [x] 重用 `InventoryWcsCommand` 模型，必要时扩展字段。
+  - [x] 服务层添加对应过滤逻辑（如任务类型、命令类型）。
+- [x] **BLoC 扩展**：
+  - [x] 在指令 BLoC 中加入 `CommandCategory` 字段，加载时应用不同过滤；撤销事件根据类别调用不同接口。
+  - [x] 确保刷新按钮（底部第三个）触发重新加载。
+- [x] **UI 调整**：
+  - [x] 根据类别设置 AppBar 标题。
+  - [x] 底部按钮与在线拣选页一致，可复用组件。
+- [ ] **测试**：
+  - [ ] 单测覆盖多类别加载、撤销；
+  - [ ] Widget 测试验证标题、按钮行为符合类别要求。
+
+## 依赖与参考
+- API：`getWmsToWcsByTaskID`。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventoryCheckorder.nvue†L83-L93】
+- Flutter 参考：共用 `aswh_inventory_wms_to_wcs_todo.md` 中的服务与 UI 设计。

--- a/docs/aswh_inventory_refactor/aswh_inventory_collect_detail_todo.md
+++ b/docs/aswh_inventory_refactor/aswh_inventory_collect_detail_todo.md
@@ -1,0 +1,38 @@
+# 立库盘点采集结果页（task_collect/aswhInventorytaskCollectDetail.nvue）重构 TODO
+
+## 背景概述
+- 页面从本地缓存 `up_stocks`、`up_inTaskItemList` 恢复采集结果列表，展示托盘、物料、批次、序列等信息，并支持勾选后批量删除。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventorytaskCollectDetail.nvue†L31-L200】
+- 依赖底部导航触发删除操作，删除时更新缓存并同步任务采集数量。
+- Flutter 中需替换为仓储层 + BLoC 状态管理，实现一致的删除、缓存更新与页面跳转。
+
+## 实施目标
+- 将采集结果列表抽象为独立页面/对话框，与采集主流程共享模型与缓存。
+- 支持多选删除、数量回滚、缓存更新，提供一致的用户反馈。
+- 使用 Freezed 定义 `InventoryCollectedItem` 模型和 BLoC 状态，确保序列化与复制便利。
+
+## TODO 清单
+- [x] **路由与导航**：
+  - [x] 注册 `/aswh-inventory/collect/result`（或对话框形式），从采集页导航并传入当前缓存快照。
+  - [x] 完成返回时将更新后的采集结果回传给采集页。
+- [x] **数据模型**：
+  - [x] 使用 `InventoryCollectedItem`（继承自采集记录模型）追加 `stockId`、`invTaskItemId`、`sourceQty` 等字段。
+  - [x] 定义 `InventoryCollectDetailState`（`items`、`selectedIds`、`status`、`message`）。
+- [x] **服务/仓储集成**：
+  - [x] 利用 `InventoryCollectCacheRepository` 加载/保存结果列表，替换 `uni.getStorageSync`、`uni.setStorage` 逻辑。
+  - [x] 删除后同步更新任务明细缓存（减少 `collectdataqty`）。
+- [x] **BLoC 设计**：
+  - [x] 事件：`DetailPageStarted`、`SelectionChanged`、`SelectAllToggled`、`DeleteRequested`、`DeletionConfirmed`。
+  - [x] 状态：包含 `isAllSelected`、`pendingDeletion` 标识，删除成功后发出 `itemsUpdated`。
+  - [x] 删除流程：触发确认弹窗→调用缓存仓储→回传成功消息。
+- [x] **UI 实现**：
+  - [x] 使用 `CommonDataGrid` 或 `DataTable` 展示列信息，并支持复选框选择。
+  - [x] 底部操作条仅保留“删除”按钮，风格参考出库采集结果页。
+  - [x] 删除成功后展示 `SnackBar`/`Toast` 并自动返回。
+- [ ] **测试计划**：
+  - [ ] BLoC 单测覆盖：初始化加载、单选/全选、删除成功/取消。
+  - [ ] 仓储单测验证缓存更新逻辑与数量回滚。
+  - [ ] Widget 测试验证复选框交互与删除提示。
+
+## 依赖与参考
+- 原始逻辑：`aswhInventorytaskCollectDetail.nvue` 删除流程。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventorytaskCollectDetail.nvue†L143-L198】
+- Flutter 参考：`lib/modules/outbound/collection_task/pages/outbound_collection_result_page.dart`（如存在）或同类结果页实现。

--- a/docs/aswh_inventory_refactor/aswh_inventory_collect_todo.md
+++ b/docs/aswh_inventory_refactor/aswh_inventory_collect_todo.md
@@ -1,0 +1,67 @@
+# 立库盘点采集页（task_collect/aswhInventorytaskaskItem.nvue）重构 TODO
+
+## 背景概述
+- 页面包含扫码输入、托盘/库位/物料信息展示、任务列表与采集结果双 Tab、托盘数量确认弹框、底部工具栏（拣选位置、采集结果、提交、更多）及气泡菜单等复杂交互。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventorytaskaskItem.nvue†L1-L144】【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventorytaskaskItem.nvue†L229-L358】
+- 调用接口涉及任务明细查询、托盘校验、WCS 指令、差异提交等十余个 API，需要在 Flutter 中集中封装服务层。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventorytaskaskItem.nvue†L146-L165】
+- 当前逻辑依赖大量全局变量与本地缓存（`uni.$on('scancodedate')`、`uni.setStorageSync`），重构时需引入 BLoC + 仓储缓存方案。
+- Flutter 参考：
+  - `lib/modules/outbound/collection_task` 的扫码工作流、任务切换、离线缓存实现。【F:lib/modules/outbound/collection_task/bloc/collection_bloc.dart†L27-L215】【F:lib/modules/outbound/collection_task/widgets/collection_layout.dart†L18-L210】
+  - `lib/modules/goods_up/collection_task` 中的托盘/库位校验逻辑与 UI 结构。
+
+## 实施目标
+- 构建 `lib/modules/aswh_inventory/collection_task`，拆分页面、部件、BLoC、服务、仓储。
+- 完成托盘→库位→物料→数量四步采集流程，支持批次/序列校验、库存校对、托盘数量确认。
+- 管理任务列表与采集中列表、WCS 指令弹窗、更多操作（查询指令、单个托盘、回库、全部托盘）。
+- 使用 Freezed 定义各类数据对象（任务明细、采集记录、托盘状态、指令提交参数等）。
+
+## TODO 清单
+- [x] **目录与路由**：
+  - [x] 在模块中创建 `collection_task` 子目录（`bloc/`, `models/`, `services/`, `widgets/`）。
+  - [x] 注册路由 `/aswh-inventory/collect/:taskId`，接收任务 JSON 参数。
+- [x] **数据模型（Freezed）**：
+  - [x] `InventoryTaskItem`：托盘、库位、数量、盘点类型、任务号等字段。
+  - [x] `InventoryCollectingRecord`：托盘、库位、物料、批次、序列、数量、时间戳。
+  - [x] `InventoryCollectCommand`：WCS 指令提交参数（托盘号、指令类型、数量、操作人等）。
+  - [x] `InventoryCollectStateSnapshot`：缓存的采集状态，便于离线恢复。
+  - [x] `InventoryPalletInfo`、`InventoryMatControl`、`InventorySiteInfo` 等辅助模型。
+- [x] **服务层实现**：
+  - [x] 创建 `AswhInventoryCollectService`，封装以下 API：`getInventoryTaskItem`、`commitInventoryInfos`、`getStoreSiteByRoom`、`getMtlRepertoryByStoresiteNo`、`CommitInvDownWmsToWcs`、`CommitInvResetWmsToWcs`、`GetMatControl`、`GetRoomMatControl` 等。
+  - [x] 提供统一的错误包装与重试支持（参考 `CollectionService`）。
+  - [x] 处理托盘数量确认和 WCS 指令提交的 API 调用链。
+- [x] **本地缓存策略**：
+  - [x] 使用 `Hive` 或本地数据库存储采集缓存，替换 `uni.setStorageSync('up_stocks')` 等逻辑。
+  - [x] 定义 `InventoryCollectCacheRepository`，支持保存/恢复任务项与采集结果。
+- [x] **BLoC 设计**：
+  - [x] 事件分层：`CollectionStarted`（初始化）、`ScanCaptured`、`TrayConfirmed`、`SiteValidated`、`MaterialDecoded`、`QuantityEntered`、`TaskItemSelected`、`SwitchTabRequested`、`SubmitRequested`、`CommandActionTriggered`、`PopupClosed` 等。
+  - [x] 状态结构包含：`currentStep`、`activeTask`、`collectingItems`、`collectedItems`、`selectedIds`、`popup`、`commandMenu`、`message`、`isLoading`。
+  - [x] 处理扫码分支：托盘码、库位码、物料码分别解析并驱动状态流。
+  - [x] 支持多托盘采集与差异判断，合并/更新 `collectingItems`。
+- [x] **业务规则实现**：
+  - [x] 校验批次规则（映射 `booCheck`）。
+  - [x] 校验供应商规则（映射 `booCheckAagentCode`）。
+  - [x] 校验有效期等剩余逻辑。
+  - [x] 托盘/库位匹配、ERP 库位一致性判断（`siteFlag`、`erpStoreSite`）。
+  - [x] 数量校验（空托盘、整盘、盘盈盘亏等）。
+  - [x] “更多”菜单包含：
+    - [x] 查询指令 → 跳转指令页并传递任务参数。
+    - [x] 单个托盘/全部托盘 → 调用 WCS 接口并展示弹框确认。
+    - [x] 回库 → 调用回库接口，更新列表。
+- [x] **UI 组件拆分**：
+  - [x] 顶部信息区组件（托盘、库位、库存、拣选位置、物料信息）。
+  - [x] Tab 面板：`TaskListTab`、`CollectingTab`，分别绑定 BLoC 状态。
+  - [x] 底部工具栏组件，支持主按钮与更多菜单。
+  - [x] 托盘数量确认弹窗组件。
+  - [x] 集成扫码监听与输入框焦点控制。
+- [x] **交互细节**：
+  - [x] 初始化时加载任务列表与拣选位选项（`getInOutdt`）。
+  - [x] `SwitchTab` 时同步选中项、更新选择状态。
+  - [x] 列表选择支持全选/单选，对应 BLoC 中的集合操作。
+  - [x] 提交成功后清理缓存并刷新任务列表。
+- [ ] **测试计划**：
+  - [ ] BLoC 单测覆盖扫码流程（托盘→库位→物料→数量）、提交成功/失败、指令操作。
+  - [ ] Service 单测使用 Mock 校验多接口组合调用。
+  - [ ] Widget 测试验证 Tab 切换、弹窗展示、更多菜单交互。
+
+## 依赖与参考
+- API：详见 `GlodWind-Wms-App/api/system/goodsDown.js` 中盘点相关接口。【F:GlodWind-Wms-App/api/system/goodsDown.js†L224-L380】
+- Flutter 参考模块：`lib/modules/outbound/collection_task`、`lib/modules/goods_up/collection_task`。

--- a/docs/aswh_inventory_refactor/aswh_inventory_pallet_item_todo.md
+++ b/docs/aswh_inventory_refactor/aswh_inventory_pallet_item_todo.md
@@ -1,0 +1,37 @@
+# 托盘明细页（task_collect/aswhInventoryPalletItem.nvue）重构 TODO
+
+## 背景概述
+- 页面基于 `getPalletItemByTaskID` 查询单个托盘下的物料明细，使用折叠面板展示托盘、物料、批次、序列、数量等信息，顶部提供搜索栏以关键字过滤。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventoryPalletItem.nvue†L1-L127】
+- 当前仅实现简单 toast 搜索，无实际过滤逻辑，需要在 Flutter 中补齐。
+- 页面引用多个混入/组件（浮动球、抽屉、列表），Flutter 版本需简化并与统一设计系统对齐。
+
+## 实施目标
+- 构建可复用的托盘明细组件/页面，供采集页跳转查看。
+- 支持列表过滤、折叠卡片展示、数据加载指示和错误处理。
+- 使用 Freezed 定义 `InventoryPalletItem` 数据模型。
+
+- [x] **路由与入口**：
+  - [x] 注册 `/aswh-inventory/pallet/:trayNo`，从采集页“更多→单个托盘”跳转。
+  - [x] 接收 `trayNo` 参数并在返回时告知采集页是否继续下发指令。
+- [x] **数据模型与服务**：
+  - [x] 定义 `InventoryPalletItem`（palletNo、matCode、matName、itemBatch、itemSn、itemQty、proofNo 等）。
+  - [x] 在 `AswhInventoryCommandService` 或独立 `AswhInventoryPalletService` 中实现 `getPalletItemByTaskID` 调用。
+- [x] **BLoC/状态管理**：
+  - [x] 事件：`PalletDetailStarted`、`KeywordChanged`、`RefreshRequested`。
+  - [x] 状态：`items`、`filteredItems`、`status`（loading/success/failure）、`keyword`、`message`。
+  - [x] 搜索事件实时过滤 `filteredItems`，空关键词恢复原列表。
+- [x] **UI 实现**：
+  - [x] 顶部搜索栏（可使用 `SearchBar` 组件），支持输入与扫码。
+  - [x] 列表项采用 `ExpansionPanelList`/`Card` 展示明细，兼容移动端滚动。
+  - [x] 底部提示“已经到底了”可替换为 `ListFooter` 组件。
+  - [x] 错误/空状态提示（`EmptyView`）。
+- [x] **交互增强**：
+  - [x] 支持下拉刷新与加载动画。
+  - [x] 如需浮动操作按钮，结合设计规范决定是否保留，避免额外复杂性。
+- [ ] **测试计划**：
+  - [ ] BLoC 单测覆盖：加载成功、失败、关键词过滤。
+  - [ ] Widget 测试：展开/收起面板、空状态展示。
+
+## 依赖与参考
+- API：`getPalletItemByTaskID`。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventoryPalletItem.nvue†L74-L77】
+- Flutter 参考：可借鉴 `lib/modules/outbound/task_details/widgets/outbound_task_detail_panel.dart` 等折叠面板实现。

--- a/docs/aswh_inventory_refactor/aswh_inventory_receive_todo.md
+++ b/docs/aswh_inventory_refactor/aswh_inventory_receive_todo.md
@@ -1,0 +1,40 @@
+# 立库盘点接收页（task_receive/aswhInventorytaskReceive.nvue）重构 TODO
+
+## 背景概述
+- UniApp 接收页支持扫码/输入单号，列表展示待接收任务，仅提供“接收”操作，调用 `getInventoryTask`、`commitInventoryTask` 并在接收后刷新列表。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_receive/aswhInventorytaskReceive.nvue†L1-L158】
+- 返回逻辑通过 `reLaunch` 跳回任务列表，同时移除扫码监听，需要在 Flutter 中协调导航栈与扫码订阅。
+- Flutter 参考：`lib/modules/outbound/task_receive` 模块实现接收流程，可借鉴 BLoC 状态机、对话框与 UI 布局。【F:lib/modules/outbound/task_receive/outbound_task_receive_page.dart†L18-L165】
+
+## 实施目标
+- 在 `lib/modules/aswh_inventory/task_receive` 下重构接收页，实现扫码输入、分页与批量接收。
+- 共享任务列表的模型与服务，保持接口复用。
+- 完成 Freezed 状态建模，覆盖加载、提交、完成、错误四种状态。
+
+## TODO 清单
+- [x] **结构与路由**：
+  - [x] 在 `AswhInventoryModule` 中注册接收页路由 `/aswh-inventory/receive`。
+  - [x] 确保接收页可从任务列表 `AppBar` 右侧入口跳转并支持 `Navigator.pop` 返回。
+- [x] **BLoC 设计**：
+  - [x] 创建 `AswhInventoryReceiveBloc`，继承 `Bloc<AswhInventoryReceiveEvent, AswhInventoryReceiveState>`。
+  - [x] 事件类：`AswhInventoryReceiveStarted`、`AswhInventoryReceiveSearchSubmitted`、`AswhInventoryReceiveScanCaptured`、`AswhInventoryReceiveConfirmed`、`AswhInventoryReceivePageChanged`。
+  - [x] 状态字段：`status`、`filter`、`tasks`、`selectedTask`、`message`、`pagination`。
+  - [x] 接收操作需弹出确认对话框，并在成功后更新列表、清空扫码输入。
+- [x] **UI 实现**：
+  - [x] 顶部 `AppBar` + 扫码输入框（复用任务列表组件）。
+  - [x] 数据表格使用 `CommonDataGrid`，仅包含“接收”按钮列。
+  - [x] 分页组件保持与列表页一致。
+  - [x] 接收成功后通过 `SnackBar` 或 `Toast` 反馈结果。
+- [x] **服务调用**：
+  - [x] 复用 `AswhInventoryTaskService` 的 `getInventoryTask` 和 `commitInventoryTask`，并支持 userId 参数覆盖（接收页默认 `userId = 'ALL'`）。
+  - [x] 处理并发点击或重复扫码，通过 BLoC 状态防抖。
+- [x] **扫码监听**：
+  - [x] 集成全局扫码流（参考 `OutboundTaskReceivePage` 中的 `GlobalScanListener`）。
+  - [x] 实现自动聚焦逻辑：捕获扫码后填充输入并触发查询。
+  - [x] 页面销毁时取消订阅，防止内存泄漏。
+- [ ] **测试**：
+  - [ ] BLoC 单测覆盖：加载失败、接收成功、接收失败、分页切换。
+  - [ ] Widget 测试验证扫码输入自动查询与接收按钮对话框。
+
+## 依赖与参考
+- API：`/system/terminal/getInventoryTask`、`/system/terminal/commitInventoryTask`。【F:GlodWind-Wms-App/api/system/goodsDown.js†L224-L268】
+- Flutter 参考模块：`lib/modules/outbound/task_receive`、`lib/modules/goods_up/task_receive`（如存在）。

--- a/docs/aswh_inventory_refactor/aswh_inventory_task_list_todo.md
+++ b/docs/aswh_inventory_refactor/aswh_inventory_task_list_todo.md
@@ -1,0 +1,45 @@
+# 立库盘点任务列表页（aswhInventoryTask.nvue）重构 TODO
+
+## 背景概述
+- UniApp 页面提供盘点任务列表、扫码查询、分页以及“采集/撤销”操作按钮，并在导航栏右侧跳转至接收页。【F:GlodWind-Wms-App/pages/aswhInventorytask/aswhInventoryTask.nvue†L1-L158】
+- 当前接口调用 `getInventoryTask` 获取任务，`commitInventoryTask` 执行撤销操作，需要迁移至 Flutter 服务层。
+- Flutter 参考：`lib/modules/outbound/task_list`、`lib/modules/goods_up/task_list` 中的数据网格与 BLoC 结构，可复用 `CommonDataGrid` + `BlocConsumer` 模式构建列表与分页。【F:lib/modules/outbound/task_list/outbound_task_list_page.dart†L21-L177】【F:lib/modules/goods_up/task_list/goods_up_task_list_page.dart†L18-L162】
+
+## 实施目标
+- 建立 `lib/modules/aswh_inventory/task_list` 目录，包含页面、BLoC、模型、仓储服务。
+- 支持扫码器监听、分页查询、撤销任务、跳转采集/接收页的完整工作流。
+- 使用 Freezed 定义任务查询参数与任务行数据模型，配合 `json_serializable`。
+
+## TODO 清单
+- [x] **项目结构初始化**：
+  - [x] 新建 `AswhInventoryModule` 并注册任务列表路由（参考 `OutboundModule`）。
+  - [x] 在 `app_module.dart` 中声明依赖注入，绑定列表页所需的 BLoC 与服务。
+- [x] **数据模型（Freezed）**：
+  - [x] 定义 `InventoryTaskFilter`（字段：sortType、sortColumn、searchKey、userId、roleOrUserId、roomTag、pageIndex、pageSize 等）。
+  - [x] 定义 `InventoryTaskSummary`（字段：taskComment、storeroomNo、storeroomName、checkTaskNo、状态等）。
+  - [x] 提供 `fromJson/toJson`、`copyWith`，并与 API 参数命名保持一致。
+- [x] **服务层实现**：
+  - [x] 创建 `AswhInventoryTaskService`，封装 `getInventoryTask`、`commitInventoryTask`。
+  - [x] 整合公共 `DioClient`，补充分页与错误处理逻辑，复用出库模块的响应包装格式。
+- [x] **BLoC 设计**：
+  - [x] 事件：`TaskListStarted`、`FilterSubmitted`、`ScanContentReceived`、`TaskCancelRequested`、`PageChanged`。
+  - [x] 状态：`TaskListState` 包含 `status`、`filter`、`tasks`、`pagination`、`message`。
+  - [x] 在取消任务成功后刷新列表并提示 UI。
+- [x] **UI 构建**：
+  - [x] 页面结构：`AppScaffold` + `AppBar`（左返回、右跳转接收）、扫码输入框、`CommonDataGrid`、`PaginationBar`。
+  - [x] “采集”按钮触发导航到采集页，并携带完整任务 JSON。
+  - [x] “撤销”按钮触发确认对话框（复用 `ConfirmDialog` 组件）。
+  - [x] 集成扫码组件（参考 `lib/modules/outbound/collection_task/widgets/scanner_overlay.dart`）。
+- [x] **导航集成**：
+  - [x] 成功加载任务后允许通过按钮跳转至 `/aswh-inventory/collect/:taskId` 与 `/aswh-inventory/receive`。
+  - [x] 保持返回首页逻辑与 UniApp 相同（必要时使用 `Navigator.popUntil`）。
+- [ ] **测试与验收**：
+  - [ ] 编写 BLoC 单元测试覆盖加载成功、加载失败、撤销成功/失败分支。
+  - [ ] Widget 测试验证分页点击、按钮行为与扫码输入调用事件。
+  - [ ] 手动测试包含扫码触发、任务为空提示、撤销后刷新。
+
+## 依赖与参考
+- API 文档：`/system/terminal/getInventoryTask`、`/system/terminal/commitInventoryTask`。【F:GlodWind-Wms-App/api/system/goodsDown.js†L224-L268】
+- Flutter 参考：
+  - 任务列表页：`OutboundTaskListPage`、`GoodsUpTaskListPage`。
+  - 公共组件：`CommonDataGrid`、`ScannerListener`、`AppDialog`。

--- a/docs/aswh_inventory_refactor/aswh_inventory_wms_to_wcs_todo.md
+++ b/docs/aswh_inventory_refactor/aswh_inventory_wms_to_wcs_todo.md
@@ -1,0 +1,37 @@
+# 在线拣选指令页（task_collect/aswhInventoryWmsToWcs.nvue）重构 TODO
+
+## 背景概述
+- 页面展示 WMS→WCS 指令列表，列包含托盘、起始/目标地址、堆垛机、状态、重量/高度等级、任务/凭证信息等；底部提供“撤销回指令”“撤销出库指令”“刷新”操作。【F:GlodWind-Wms-App/pages/aswhInventorytask/task_collect/aswhInventoryWmsToWcs.nvue†L1-L87】
+- 数据来源 `getWmsToWcsByTaskID`（来自 `api/system/aswhUp`），根据任务号、任务 ID 与任务类型过滤。
+- 需要与采集页的“更多→查询指令”操作联动。
+
+## 实施目标
+- 构建 `lib/modules/aswh_inventory/command_list` 页面，复用 `CommonDataGrid` 展示指令记录。
+- 提供 WCS 指令撤销与刷新操作，支持实时反馈。
+- 使用 Freezed 定义 `InventoryWcsCommand` 数据模型。
+
+## TODO 清单
+- [x] **路由与参数**：
+  - [x] 注册 `/aswh-inventory/commands`，接受 `taskComment`、`taskId`、`taskType` 参数。
+  - [x] 在采集页的“更多→查询指令”中导航到该页面，并支持返回。
+- [x] **数据模型**：
+  - [x] 定义 `InventoryWcsCommand`（字段：palNo、startAddr、destAddr、stackerNo、sendTime、state、weightGrade、highGrade、taskNo、proofNo、taskType、changeType、ioType、wcsErrMessage、taskId、proofId、interfaceId）。
+  - [x] 建立 `InventoryCommandAction` 枚举区分回指令、出库指令撤销。
+- [x] **服务层**：
+  - [x] 创建 `AswhInventoryCommandService` 封装 `getWmsToWcsByTaskID`、`commitInvDownWmsToWcs`（或对应撤销接口）。
+  - [x] 支持状态刷新、错误提示、重试。
+- [x] **BLoC 设计**：
+  - [x] 事件：`CommandPageStarted`、`CommandRefreshRequested`、`CommandRevokeRequested`（携带类型）。
+  - [x] 状态：`commands`、`status`、`message`、`pendingAction`。
+  - [x] 撤销成功后刷新列表并显示提示。
+- [x] **UI 实现**：
+  - [x] 使用 `AppScaffold` + `CommonDataGrid` 渲染列。
+  - [x] 底部操作栏映射到三个按钮（撤销回指令、撤销出库指令、刷新）。
+  - [x] 撤销操作前弹出确认对话框。
+- [ ] **测试计划**：
+  - [ ] BLoC 单测覆盖：初始化加载、刷新、撤销成功/失败。
+  - [ ] Widget 测试验证按钮交互与加载状态。
+
+## 依赖与参考
+- API：`getWmsToWcsByTaskID` 及相关撤销接口（位于 `api/system/aswhUp.js`、`api/system/goodsDown.js`）。
+- Flutter 参考：`lib/modules/outbound/exception_collection/command_list`（若存在）或同类指令列表实现。

--- a/lib/app_module.dart
+++ b/lib/app_module.dart
@@ -9,6 +9,7 @@ import 'package:wms_app/services/api_service.dart';
 import 'modules/outbound/outbound_module.dart';
 import 'modules/goods_up/goods_up_module.dart';
 import 'modules/arrival_sign/arrival_sign_module.dart';
+import 'modules/aswh_inventory/aswh_inventory_module.dart';
 
 /// 应用主模块
 class AppModule extends Module {
@@ -48,5 +49,8 @@ class AppModule extends Module {
 
     // 到货签收模块
     r.module('/arrival-sign', module: ArrivalSignModule());
+
+    // 立库盘点模块
+    r.module('/aswh-inventory', module: AswhInventoryModule());
   }
 }

--- a/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_event.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_event.freezed.dart
@@ -12,8 +12,7 @@ part of 'arrival_collect_event.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$ArrivalCollectEvent {
@@ -31,8 +30,9 @@ mixin _$ArrivalCollectEvent {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
-  }) => throw _privateConstructorUsedError;
+        resultPageClosed,
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(ArrivalSignTask task)? initialized,
@@ -47,8 +47,9 @@ mixin _$ArrivalCollectEvent {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
-  }) => throw _privateConstructorUsedError;
+        resultPageClosed,
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(ArrivalSignTask task)? initialized,
@@ -64,7 +65,8 @@ mixin _$ArrivalCollectEvent {
     TResult Function()? persistCache,
     TResult Function(List<ArrivalCollectProgress> progresses)? resultPageClosed,
     required TResult orElse(),
-  }) => throw _privateConstructorUsedError;
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult map<TResult extends Object?>({
     required TResult Function(_Initialized value) initialized,
@@ -74,13 +76,14 @@ mixin _$ArrivalCollectEvent {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
     required TResult Function(_PersistCache value) persistCache,
     required TResult Function(_ResultPageClosed value) resultPageClosed,
-  }) => throw _privateConstructorUsedError;
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(_Initialized value)? initialized,
@@ -95,7 +98,8 @@ mixin _$ArrivalCollectEvent {
     TResult? Function(_RestoreFromCache value)? restoreFromCache,
     TResult? Function(_PersistCache value)? persistCache,
     TResult? Function(_ResultPageClosed value)? resultPageClosed,
-  }) => throw _privateConstructorUsedError;
+  }) =>
+      throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeMap<TResult extends Object?>({
     TResult Function(_Initialized value)? initialized,
@@ -111,15 +115,15 @@ mixin _$ArrivalCollectEvent {
     TResult Function(_PersistCache value)? persistCache,
     TResult Function(_ResultPageClosed value)? resultPageClosed,
     required TResult orElse(),
-  }) => throw _privateConstructorUsedError;
+  }) =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $ArrivalCollectEventCopyWith<$Res> {
   factory $ArrivalCollectEventCopyWith(
-    ArrivalCollectEvent value,
-    $Res Function(ArrivalCollectEvent) then,
-  ) = _$ArrivalCollectEventCopyWithImpl<$Res, ArrivalCollectEvent>;
+          ArrivalCollectEvent value, $Res Function(ArrivalCollectEvent) then) =
+      _$ArrivalCollectEventCopyWithImpl<$Res, ArrivalCollectEvent>;
 }
 
 /// @nodoc
@@ -136,9 +140,8 @@ class _$ArrivalCollectEventCopyWithImpl<$Res, $Val extends ArrivalCollectEvent>
 /// @nodoc
 abstract class _$$InitializedImplCopyWith<$Res> {
   factory _$$InitializedImplCopyWith(
-    _$InitializedImpl value,
-    $Res Function(_$InitializedImpl) then,
-  ) = __$$InitializedImplCopyWithImpl<$Res>;
+          _$InitializedImpl value, $Res Function(_$InitializedImpl) then) =
+      __$$InitializedImplCopyWithImpl<$Res>;
   @useResult
   $Res call({ArrivalSignTask task});
 
@@ -150,21 +153,20 @@ class __$$InitializedImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$InitializedImpl>
     implements _$$InitializedImplCopyWith<$Res> {
   __$$InitializedImplCopyWithImpl(
-    _$InitializedImpl _value,
-    $Res Function(_$InitializedImpl) _then,
-  ) : super(_value, _then);
+      _$InitializedImpl _value, $Res Function(_$InitializedImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? task = null}) {
-    return _then(
-      _$InitializedImpl(
-        null == task
-            ? _value.task
-            : task // ignore: cast_nullable_to_non_nullable
-                  as ArrivalSignTask,
-      ),
-    );
+  $Res call({
+    Object? task = null,
+  }) {
+    return _then(_$InitializedImpl(
+      null == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as ArrivalSignTask,
+    ));
   }
 
   @override
@@ -221,7 +223,7 @@ class _$InitializedImpl implements _Initialized {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return initialized(task);
   }
@@ -241,7 +243,7 @@ class _$InitializedImpl implements _Initialized {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return initialized?.call(task);
   }
@@ -279,7 +281,7 @@ class _$InitializedImpl implements _Initialized {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -343,10 +345,9 @@ abstract class _Initialized implements ArrivalCollectEvent {
 
 /// @nodoc
 abstract class _$$RefreshDetailsImplCopyWith<$Res> {
-  factory _$$RefreshDetailsImplCopyWith(
-    _$RefreshDetailsImpl value,
-    $Res Function(_$RefreshDetailsImpl) then,
-  ) = __$$RefreshDetailsImplCopyWithImpl<$Res>;
+  factory _$$RefreshDetailsImplCopyWith(_$RefreshDetailsImpl value,
+          $Res Function(_$RefreshDetailsImpl) then) =
+      __$$RefreshDetailsImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -354,9 +355,8 @@ class __$$RefreshDetailsImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$RefreshDetailsImpl>
     implements _$$RefreshDetailsImplCopyWith<$Res> {
   __$$RefreshDetailsImplCopyWithImpl(
-    _$RefreshDetailsImpl _value,
-    $Res Function(_$RefreshDetailsImpl) _then,
-  ) : super(_value, _then);
+      _$RefreshDetailsImpl _value, $Res Function(_$RefreshDetailsImpl) _then)
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -393,7 +393,7 @@ class _$RefreshDetailsImpl implements _RefreshDetails {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return refreshDetails();
   }
@@ -413,7 +413,7 @@ class _$RefreshDetailsImpl implements _RefreshDetails {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return refreshDetails?.call();
   }
@@ -451,7 +451,7 @@ class _$RefreshDetailsImpl implements _RefreshDetails {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -511,9 +511,8 @@ abstract class _RefreshDetails implements ArrivalCollectEvent {
 /// @nodoc
 abstract class _$$SelectTaskImplCopyWith<$Res> {
   factory _$$SelectTaskImplCopyWith(
-    _$SelectTaskImpl value,
-    $Res Function(_$SelectTaskImpl) then,
-  ) = __$$SelectTaskImplCopyWithImpl<$Res>;
+          _$SelectTaskImpl value, $Res Function(_$SelectTaskImpl) then) =
+      __$$SelectTaskImplCopyWithImpl<$Res>;
   @useResult
   $Res call({ArrivalCollectTask task});
 
@@ -525,21 +524,20 @@ class __$$SelectTaskImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$SelectTaskImpl>
     implements _$$SelectTaskImplCopyWith<$Res> {
   __$$SelectTaskImplCopyWithImpl(
-    _$SelectTaskImpl _value,
-    $Res Function(_$SelectTaskImpl) _then,
-  ) : super(_value, _then);
+      _$SelectTaskImpl _value, $Res Function(_$SelectTaskImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? task = null}) {
-    return _then(
-      _$SelectTaskImpl(
-        null == task
-            ? _value.task
-            : task // ignore: cast_nullable_to_non_nullable
-                  as ArrivalCollectTask,
-      ),
-    );
+  $Res call({
+    Object? task = null,
+  }) {
+    return _then(_$SelectTaskImpl(
+      null == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectTask,
+    ));
   }
 
   @override
@@ -596,7 +594,7 @@ class _$SelectTaskImpl implements _SelectTask {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return selectTask(task);
   }
@@ -616,7 +614,7 @@ class _$SelectTaskImpl implements _SelectTask {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return selectTask?.call(task);
   }
@@ -654,7 +652,7 @@ class _$SelectTaskImpl implements _SelectTask {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -719,9 +717,8 @@ abstract class _SelectTask implements ArrivalCollectEvent {
 /// @nodoc
 abstract class _$$ScanSubmittedImplCopyWith<$Res> {
   factory _$$ScanSubmittedImplCopyWith(
-    _$ScanSubmittedImpl value,
-    $Res Function(_$ScanSubmittedImpl) then,
-  ) = __$$ScanSubmittedImplCopyWithImpl<$Res>;
+          _$ScanSubmittedImpl value, $Res Function(_$ScanSubmittedImpl) then) =
+      __$$ScanSubmittedImplCopyWithImpl<$Res>;
   @useResult
   $Res call({String value});
 }
@@ -731,21 +728,20 @@ class __$$ScanSubmittedImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$ScanSubmittedImpl>
     implements _$$ScanSubmittedImplCopyWith<$Res> {
   __$$ScanSubmittedImplCopyWithImpl(
-    _$ScanSubmittedImpl _value,
-    $Res Function(_$ScanSubmittedImpl) _then,
-  ) : super(_value, _then);
+      _$ScanSubmittedImpl _value, $Res Function(_$ScanSubmittedImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? value = null}) {
-    return _then(
-      _$ScanSubmittedImpl(
-        null == value
-            ? _value.value
-            : value // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
+  $Res call({
+    Object? value = null,
+  }) {
+    return _then(_$ScanSubmittedImpl(
+      null == value
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
   }
 }
 
@@ -794,7 +790,7 @@ class _$ScanSubmittedImpl implements _ScanSubmitted {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return scanSubmitted(value);
   }
@@ -814,7 +810,7 @@ class _$ScanSubmittedImpl implements _ScanSubmitted {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return scanSubmitted?.call(value);
   }
@@ -852,7 +848,7 @@ class _$ScanSubmittedImpl implements _ScanSubmitted {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -916,10 +912,9 @@ abstract class _ScanSubmitted implements ArrivalCollectEvent {
 
 /// @nodoc
 abstract class _$$QuantitySubmittedImplCopyWith<$Res> {
-  factory _$$QuantitySubmittedImplCopyWith(
-    _$QuantitySubmittedImpl value,
-    $Res Function(_$QuantitySubmittedImpl) then,
-  ) = __$$QuantitySubmittedImplCopyWithImpl<$Res>;
+  factory _$$QuantitySubmittedImplCopyWith(_$QuantitySubmittedImpl value,
+          $Res Function(_$QuantitySubmittedImpl) then) =
+      __$$QuantitySubmittedImplCopyWithImpl<$Res>;
   @useResult
   $Res call({double quantity});
 }
@@ -928,22 +923,21 @@ abstract class _$$QuantitySubmittedImplCopyWith<$Res> {
 class __$$QuantitySubmittedImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$QuantitySubmittedImpl>
     implements _$$QuantitySubmittedImplCopyWith<$Res> {
-  __$$QuantitySubmittedImplCopyWithImpl(
-    _$QuantitySubmittedImpl _value,
-    $Res Function(_$QuantitySubmittedImpl) _then,
-  ) : super(_value, _then);
+  __$$QuantitySubmittedImplCopyWithImpl(_$QuantitySubmittedImpl _value,
+      $Res Function(_$QuantitySubmittedImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? quantity = null}) {
-    return _then(
-      _$QuantitySubmittedImpl(
-        null == quantity
-            ? _value.quantity
-            : quantity // ignore: cast_nullable_to_non_nullable
-                  as double,
-      ),
-    );
+  $Res call({
+    Object? quantity = null,
+  }) {
+    return _then(_$QuantitySubmittedImpl(
+      null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
   }
 }
 
@@ -977,9 +971,7 @@ class _$QuantitySubmittedImpl implements _QuantitySubmitted {
   @pragma('vm:prefer-inline')
   _$$QuantitySubmittedImplCopyWith<_$QuantitySubmittedImpl> get copyWith =>
       __$$QuantitySubmittedImplCopyWithImpl<_$QuantitySubmittedImpl>(
-        this,
-        _$identity,
-      );
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -996,7 +988,7 @@ class _$QuantitySubmittedImpl implements _QuantitySubmitted {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return quantitySubmitted(quantity);
   }
@@ -1016,7 +1008,7 @@ class _$QuantitySubmittedImpl implements _QuantitySubmitted {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return quantitySubmitted?.call(quantity);
   }
@@ -1054,7 +1046,7 @@ class _$QuantitySubmittedImpl implements _QuantitySubmitted {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -1120,9 +1112,8 @@ abstract class _QuantitySubmitted implements ArrivalCollectEvent {
 /// @nodoc
 abstract class _$$SwitchTabImplCopyWith<$Res> {
   factory _$$SwitchTabImplCopyWith(
-    _$SwitchTabImpl value,
-    $Res Function(_$SwitchTabImpl) then,
-  ) = __$$SwitchTabImplCopyWithImpl<$Res>;
+          _$SwitchTabImpl value, $Res Function(_$SwitchTabImpl) then) =
+      __$$SwitchTabImplCopyWithImpl<$Res>;
   @useResult
   $Res call({int index});
 }
@@ -1132,21 +1123,20 @@ class __$$SwitchTabImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$SwitchTabImpl>
     implements _$$SwitchTabImplCopyWith<$Res> {
   __$$SwitchTabImplCopyWithImpl(
-    _$SwitchTabImpl _value,
-    $Res Function(_$SwitchTabImpl) _then,
-  ) : super(_value, _then);
+      _$SwitchTabImpl _value, $Res Function(_$SwitchTabImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? index = null}) {
-    return _then(
-      _$SwitchTabImpl(
-        null == index
-            ? _value.index
-            : index // ignore: cast_nullable_to_non_nullable
-                  as int,
-      ),
-    );
+  $Res call({
+    Object? index = null,
+  }) {
+    return _then(_$SwitchTabImpl(
+      null == index
+          ? _value.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
   }
 }
 
@@ -1195,7 +1185,7 @@ class _$SwitchTabImpl implements _SwitchTab {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return switchTab(index);
   }
@@ -1215,7 +1205,7 @@ class _$SwitchTabImpl implements _SwitchTab {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return switchTab?.call(index);
   }
@@ -1253,7 +1243,7 @@ class _$SwitchTabImpl implements _SwitchTab {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -1318,34 +1308,34 @@ abstract class _SwitchTab implements ArrivalCollectEvent {
 /// @nodoc
 abstract class _$$ToggleCollectSelectionImplCopyWith<$Res> {
   factory _$$ToggleCollectSelectionImplCopyWith(
-    _$ToggleCollectSelectionImpl value,
-    $Res Function(_$ToggleCollectSelectionImpl) then,
-  ) = __$$ToggleCollectSelectionImplCopyWithImpl<$Res>;
+          _$ToggleCollectSelectionImpl value,
+          $Res Function(_$ToggleCollectSelectionImpl) then) =
+      __$$ToggleCollectSelectionImplCopyWithImpl<$Res>;
   @useResult
   $Res call({String id});
 }
 
 /// @nodoc
 class __$$ToggleCollectSelectionImplCopyWithImpl<$Res>
-    extends
-        _$ArrivalCollectEventCopyWithImpl<$Res, _$ToggleCollectSelectionImpl>
+    extends _$ArrivalCollectEventCopyWithImpl<$Res,
+        _$ToggleCollectSelectionImpl>
     implements _$$ToggleCollectSelectionImplCopyWith<$Res> {
   __$$ToggleCollectSelectionImplCopyWithImpl(
-    _$ToggleCollectSelectionImpl _value,
-    $Res Function(_$ToggleCollectSelectionImpl) _then,
-  ) : super(_value, _then);
+      _$ToggleCollectSelectionImpl _value,
+      $Res Function(_$ToggleCollectSelectionImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? id = null}) {
-    return _then(
-      _$ToggleCollectSelectionImpl(
-        null == id
-            ? _value.id
-            : id // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
+  $Res call({
+    Object? id = null,
+  }) {
+    return _then(_$ToggleCollectSelectionImpl(
+      null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
   }
 }
 
@@ -1377,11 +1367,8 @@ class _$ToggleCollectSelectionImpl implements _ToggleCollectSelection {
   @override
   @pragma('vm:prefer-inline')
   _$$ToggleCollectSelectionImplCopyWith<_$ToggleCollectSelectionImpl>
-  get copyWith =>
-      __$$ToggleCollectSelectionImplCopyWithImpl<_$ToggleCollectSelectionImpl>(
-        this,
-        _$identity,
-      );
+      get copyWith => __$$ToggleCollectSelectionImplCopyWithImpl<
+          _$ToggleCollectSelectionImpl>(this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -1398,7 +1385,7 @@ class _$ToggleCollectSelectionImpl implements _ToggleCollectSelection {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return toggleCollectSelection(id);
   }
@@ -1418,7 +1405,7 @@ class _$ToggleCollectSelectionImpl implements _ToggleCollectSelection {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return toggleCollectSelection?.call(id);
   }
@@ -1456,7 +1443,7 @@ class _$ToggleCollectSelectionImpl implements _ToggleCollectSelection {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -1516,15 +1503,14 @@ abstract class _ToggleCollectSelection implements ArrivalCollectEvent {
   String get id;
   @JsonKey(ignore: true)
   _$$ToggleCollectSelectionImplCopyWith<_$ToggleCollectSelectionImpl>
-  get copyWith => throw _privateConstructorUsedError;
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class _$$DeleteSelectedImplCopyWith<$Res> {
-  factory _$$DeleteSelectedImplCopyWith(
-    _$DeleteSelectedImpl value,
-    $Res Function(_$DeleteSelectedImpl) then,
-  ) = __$$DeleteSelectedImplCopyWithImpl<$Res>;
+  factory _$$DeleteSelectedImplCopyWith(_$DeleteSelectedImpl value,
+          $Res Function(_$DeleteSelectedImpl) then) =
+      __$$DeleteSelectedImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -1532,9 +1518,8 @@ class __$$DeleteSelectedImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$DeleteSelectedImpl>
     implements _$$DeleteSelectedImplCopyWith<$Res> {
   __$$DeleteSelectedImplCopyWithImpl(
-    _$DeleteSelectedImpl _value,
-    $Res Function(_$DeleteSelectedImpl) _then,
-  ) : super(_value, _then);
+      _$DeleteSelectedImpl _value, $Res Function(_$DeleteSelectedImpl) _then)
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -1571,7 +1556,7 @@ class _$DeleteSelectedImpl implements _DeleteSelected {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return deleteSelected();
   }
@@ -1591,7 +1576,7 @@ class _$DeleteSelectedImpl implements _DeleteSelected {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return deleteSelected?.call();
   }
@@ -1629,7 +1614,7 @@ class _$DeleteSelectedImpl implements _DeleteSelected {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -1689,9 +1674,8 @@ abstract class _DeleteSelected implements ArrivalCollectEvent {
 /// @nodoc
 abstract class _$$SubmitImplCopyWith<$Res> {
   factory _$$SubmitImplCopyWith(
-    _$SubmitImpl value,
-    $Res Function(_$SubmitImpl) then,
-  ) = __$$SubmitImplCopyWithImpl<$Res>;
+          _$SubmitImpl value, $Res Function(_$SubmitImpl) then) =
+      __$$SubmitImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -1699,9 +1683,8 @@ class __$$SubmitImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$SubmitImpl>
     implements _$$SubmitImplCopyWith<$Res> {
   __$$SubmitImplCopyWithImpl(
-    _$SubmitImpl _value,
-    $Res Function(_$SubmitImpl) _then,
-  ) : super(_value, _then);
+      _$SubmitImpl _value, $Res Function(_$SubmitImpl) _then)
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -1738,7 +1721,7 @@ class _$SubmitImpl implements _Submit {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return submit();
   }
@@ -1758,7 +1741,7 @@ class _$SubmitImpl implements _Submit {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return submit?.call();
   }
@@ -1796,7 +1779,7 @@ class _$SubmitImpl implements _Submit {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -1855,20 +1838,18 @@ abstract class _Submit implements ArrivalCollectEvent {
 
 /// @nodoc
 abstract class _$$RestoreFromCacheImplCopyWith<$Res> {
-  factory _$$RestoreFromCacheImplCopyWith(
-    _$RestoreFromCacheImpl value,
-    $Res Function(_$RestoreFromCacheImpl) then,
-  ) = __$$RestoreFromCacheImplCopyWithImpl<$Res>;
+  factory _$$RestoreFromCacheImplCopyWith(_$RestoreFromCacheImpl value,
+          $Res Function(_$RestoreFromCacheImpl) then) =
+      __$$RestoreFromCacheImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
 class __$$RestoreFromCacheImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$RestoreFromCacheImpl>
     implements _$$RestoreFromCacheImplCopyWith<$Res> {
-  __$$RestoreFromCacheImplCopyWithImpl(
-    _$RestoreFromCacheImpl _value,
-    $Res Function(_$RestoreFromCacheImpl) _then,
-  ) : super(_value, _then);
+  __$$RestoreFromCacheImplCopyWithImpl(_$RestoreFromCacheImpl _value,
+      $Res Function(_$RestoreFromCacheImpl) _then)
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -1905,7 +1886,7 @@ class _$RestoreFromCacheImpl implements _RestoreFromCache {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return restoreFromCache();
   }
@@ -1925,7 +1906,7 @@ class _$RestoreFromCacheImpl implements _RestoreFromCache {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return restoreFromCache?.call();
   }
@@ -1963,7 +1944,7 @@ class _$RestoreFromCacheImpl implements _RestoreFromCache {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -2023,9 +2004,8 @@ abstract class _RestoreFromCache implements ArrivalCollectEvent {
 /// @nodoc
 abstract class _$$PersistCacheImplCopyWith<$Res> {
   factory _$$PersistCacheImplCopyWith(
-    _$PersistCacheImpl value,
-    $Res Function(_$PersistCacheImpl) then,
-  ) = __$$PersistCacheImplCopyWithImpl<$Res>;
+          _$PersistCacheImpl value, $Res Function(_$PersistCacheImpl) then) =
+      __$$PersistCacheImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
@@ -2033,9 +2013,8 @@ class __$$PersistCacheImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$PersistCacheImpl>
     implements _$$PersistCacheImplCopyWith<$Res> {
   __$$PersistCacheImplCopyWithImpl(
-    _$PersistCacheImpl _value,
-    $Res Function(_$PersistCacheImpl) _then,
-  ) : super(_value, _then);
+      _$PersistCacheImpl _value, $Res Function(_$PersistCacheImpl) _then)
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -2072,7 +2051,7 @@ class _$PersistCacheImpl implements _PersistCache {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return persistCache();
   }
@@ -2092,7 +2071,7 @@ class _$PersistCacheImpl implements _PersistCache {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return persistCache?.call();
   }
@@ -2130,7 +2109,7 @@ class _$PersistCacheImpl implements _PersistCache {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -2189,10 +2168,9 @@ abstract class _PersistCache implements ArrivalCollectEvent {
 
 /// @nodoc
 abstract class _$$ResultPageClosedImplCopyWith<$Res> {
-  factory _$$ResultPageClosedImplCopyWith(
-    _$ResultPageClosedImpl value,
-    $Res Function(_$ResultPageClosedImpl) then,
-  ) = __$$ResultPageClosedImplCopyWithImpl<$Res>;
+  factory _$$ResultPageClosedImplCopyWith(_$ResultPageClosedImpl value,
+          $Res Function(_$ResultPageClosedImpl) then) =
+      __$$ResultPageClosedImplCopyWithImpl<$Res>;
   @useResult
   $Res call({List<ArrivalCollectProgress> progresses});
 }
@@ -2201,22 +2179,21 @@ abstract class _$$ResultPageClosedImplCopyWith<$Res> {
 class __$$ResultPageClosedImplCopyWithImpl<$Res>
     extends _$ArrivalCollectEventCopyWithImpl<$Res, _$ResultPageClosedImpl>
     implements _$$ResultPageClosedImplCopyWith<$Res> {
-  __$$ResultPageClosedImplCopyWithImpl(
-    _$ResultPageClosedImpl _value,
-    $Res Function(_$ResultPageClosedImpl) _then,
-  ) : super(_value, _then);
+  __$$ResultPageClosedImplCopyWithImpl(_$ResultPageClosedImpl _value,
+      $Res Function(_$ResultPageClosedImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? progresses = null}) {
-    return _then(
-      _$ResultPageClosedImpl(
-        null == progresses
-            ? _value._progresses
-            : progresses // ignore: cast_nullable_to_non_nullable
-                  as List<ArrivalCollectProgress>,
-      ),
-    );
+  $Res call({
+    Object? progresses = null,
+  }) {
+    return _then(_$ResultPageClosedImpl(
+      null == progresses
+          ? _value._progresses
+          : progresses // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectProgress>,
+    ));
   }
 }
 
@@ -2224,7 +2201,7 @@ class __$$ResultPageClosedImplCopyWithImpl<$Res>
 
 class _$ResultPageClosedImpl implements _ResultPageClosed {
   const _$ResultPageClosedImpl(final List<ArrivalCollectProgress> progresses)
-    : _progresses = progresses;
+      : _progresses = progresses;
 
   final List<ArrivalCollectProgress> _progresses;
   @override
@@ -2244,26 +2221,20 @@ class _$ResultPageClosedImpl implements _ResultPageClosed {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ResultPageClosedImpl &&
-            const DeepCollectionEquality().equals(
-              other._progresses,
-              _progresses,
-            ));
+            const DeepCollectionEquality()
+                .equals(other._progresses, _progresses));
   }
 
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(_progresses),
-  );
+      runtimeType, const DeepCollectionEquality().hash(_progresses));
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ResultPageClosedImplCopyWith<_$ResultPageClosedImpl> get copyWith =>
       __$$ResultPageClosedImplCopyWithImpl<_$ResultPageClosedImpl>(
-        this,
-        _$identity,
-      );
+          this, _$identity);
 
   @override
   @optionalTypeArgs
@@ -2280,7 +2251,7 @@ class _$ResultPageClosedImpl implements _ResultPageClosed {
     required TResult Function() restoreFromCache,
     required TResult Function() persistCache,
     required TResult Function(List<ArrivalCollectProgress> progresses)
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return resultPageClosed(progresses);
   }
@@ -2300,7 +2271,7 @@ class _$ResultPageClosedImpl implements _ResultPageClosed {
     TResult? Function()? restoreFromCache,
     TResult? Function()? persistCache,
     TResult? Function(List<ArrivalCollectProgress> progresses)?
-    resultPageClosed,
+        resultPageClosed,
   }) {
     return resultPageClosed?.call(progresses);
   }
@@ -2338,7 +2309,7 @@ class _$ResultPageClosedImpl implements _ResultPageClosed {
     required TResult Function(_QuantitySubmitted value) quantitySubmitted,
     required TResult Function(_SwitchTab value) switchTab,
     required TResult Function(_ToggleCollectSelection value)
-    toggleCollectSelection,
+        toggleCollectSelection,
     required TResult Function(_DeleteSelected value) deleteSelected,
     required TResult Function(_Submit value) submit,
     required TResult Function(_RestoreFromCache value) restoreFromCache,
@@ -2393,8 +2364,7 @@ class _$ResultPageClosedImpl implements _ResultPageClosed {
 
 abstract class _ResultPageClosed implements ArrivalCollectEvent {
   const factory _ResultPageClosed(
-    final List<ArrivalCollectProgress> progresses,
-  ) = _$ResultPageClosedImpl;
+      final List<ArrivalCollectProgress> progresses) = _$ResultPageClosedImpl;
 
   List<ArrivalCollectProgress> get progresses;
   @JsonKey(ignore: true)

--- a/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_state.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/bloc/arrival_collect_state.freezed.dart
@@ -12,8 +12,7 @@ part of 'arrival_collect_state.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$ArrivalCollectState {
@@ -39,24 +38,22 @@ mixin _$ArrivalCollectState {
 /// @nodoc
 abstract class $ArrivalCollectStateCopyWith<$Res> {
   factory $ArrivalCollectStateCopyWith(
-    ArrivalCollectState value,
-    $Res Function(ArrivalCollectState) then,
-  ) = _$ArrivalCollectStateCopyWithImpl<$Res, ArrivalCollectState>;
+          ArrivalCollectState value, $Res Function(ArrivalCollectState) then) =
+      _$ArrivalCollectStateCopyWithImpl<$Res, ArrivalCollectState>;
   @useResult
-  $Res call({
-    ArrivalSignTask? headerTask,
-    bool isLoading,
-    bool isSubmitting,
-    List<ArrivalCollectTask> taskItems,
-    ArrivalCollectTask? selectedTask,
-    List<ArrivalCollectProgress> progresses,
-    ArrivalCollectScanStep currentStep,
-    Set<String> selectedProgressIds,
-    int activeTabIndex,
-    String? successMessage,
-    String? errorMessage,
-    ArrivalCollectCache? cache,
-  });
+  $Res call(
+      {ArrivalSignTask? headerTask,
+      bool isLoading,
+      bool isSubmitting,
+      List<ArrivalCollectTask> taskItems,
+      ArrivalCollectTask? selectedTask,
+      List<ArrivalCollectProgress> progresses,
+      ArrivalCollectScanStep currentStep,
+      Set<String> selectedProgressIds,
+      int activeTabIndex,
+      String? successMessage,
+      String? errorMessage,
+      ArrivalCollectCache? cache});
 
   $ArrivalSignTaskCopyWith<$Res>? get headerTask;
   $ArrivalCollectTaskCopyWith<$Res>? get selectedTask;
@@ -89,59 +86,56 @@ class _$ArrivalCollectStateCopyWithImpl<$Res, $Val extends ArrivalCollectState>
     Object? errorMessage = freezed,
     Object? cache = freezed,
   }) {
-    return _then(
-      _value.copyWith(
-            headerTask: freezed == headerTask
-                ? _value.headerTask
-                : headerTask // ignore: cast_nullable_to_non_nullable
-                      as ArrivalSignTask?,
-            isLoading: null == isLoading
-                ? _value.isLoading
-                : isLoading // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            isSubmitting: null == isSubmitting
-                ? _value.isSubmitting
-                : isSubmitting // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            taskItems: null == taskItems
-                ? _value.taskItems
-                : taskItems // ignore: cast_nullable_to_non_nullable
-                      as List<ArrivalCollectTask>,
-            selectedTask: freezed == selectedTask
-                ? _value.selectedTask
-                : selectedTask // ignore: cast_nullable_to_non_nullable
-                      as ArrivalCollectTask?,
-            progresses: null == progresses
-                ? _value.progresses
-                : progresses // ignore: cast_nullable_to_non_nullable
-                      as List<ArrivalCollectProgress>,
-            currentStep: null == currentStep
-                ? _value.currentStep
-                : currentStep // ignore: cast_nullable_to_non_nullable
-                      as ArrivalCollectScanStep,
-            selectedProgressIds: null == selectedProgressIds
-                ? _value.selectedProgressIds
-                : selectedProgressIds // ignore: cast_nullable_to_non_nullable
-                      as Set<String>,
-            activeTabIndex: null == activeTabIndex
-                ? _value.activeTabIndex
-                : activeTabIndex // ignore: cast_nullable_to_non_nullable
-                      as int,
-            successMessage: freezed == successMessage
-                ? _value.successMessage
-                : successMessage // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            errorMessage: freezed == errorMessage
-                ? _value.errorMessage
-                : errorMessage // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            cache: freezed == cache
-                ? _value.cache
-                : cache // ignore: cast_nullable_to_non_nullable
-                      as ArrivalCollectCache?,
-          )
-          as $Val,
-    );
+    return _then(_value.copyWith(
+      headerTask: freezed == headerTask
+          ? _value.headerTask
+          : headerTask // ignore: cast_nullable_to_non_nullable
+              as ArrivalSignTask?,
+      isLoading: null == isLoading
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSubmitting: null == isSubmitting
+          ? _value.isSubmitting
+          : isSubmitting // ignore: cast_nullable_to_non_nullable
+              as bool,
+      taskItems: null == taskItems
+          ? _value.taskItems
+          : taskItems // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectTask>,
+      selectedTask: freezed == selectedTask
+          ? _value.selectedTask
+          : selectedTask // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectTask?,
+      progresses: null == progresses
+          ? _value.progresses
+          : progresses // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectProgress>,
+      currentStep: null == currentStep
+          ? _value.currentStep
+          : currentStep // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectScanStep,
+      selectedProgressIds: null == selectedProgressIds
+          ? _value.selectedProgressIds
+          : selectedProgressIds // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+      activeTabIndex: null == activeTabIndex
+          ? _value.activeTabIndex
+          : activeTabIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+      successMessage: freezed == successMessage
+          ? _value.successMessage
+          : successMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      errorMessage: freezed == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      cache: freezed == cache
+          ? _value.cache
+          : cache // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectCache?,
+    ) as $Val);
   }
 
   @override
@@ -184,26 +178,24 @@ class _$ArrivalCollectStateCopyWithImpl<$Res, $Val extends ArrivalCollectState>
 /// @nodoc
 abstract class _$$ArrivalCollectStateImplCopyWith<$Res>
     implements $ArrivalCollectStateCopyWith<$Res> {
-  factory _$$ArrivalCollectStateImplCopyWith(
-    _$ArrivalCollectStateImpl value,
-    $Res Function(_$ArrivalCollectStateImpl) then,
-  ) = __$$ArrivalCollectStateImplCopyWithImpl<$Res>;
+  factory _$$ArrivalCollectStateImplCopyWith(_$ArrivalCollectStateImpl value,
+          $Res Function(_$ArrivalCollectStateImpl) then) =
+      __$$ArrivalCollectStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    ArrivalSignTask? headerTask,
-    bool isLoading,
-    bool isSubmitting,
-    List<ArrivalCollectTask> taskItems,
-    ArrivalCollectTask? selectedTask,
-    List<ArrivalCollectProgress> progresses,
-    ArrivalCollectScanStep currentStep,
-    Set<String> selectedProgressIds,
-    int activeTabIndex,
-    String? successMessage,
-    String? errorMessage,
-    ArrivalCollectCache? cache,
-  });
+  $Res call(
+      {ArrivalSignTask? headerTask,
+      bool isLoading,
+      bool isSubmitting,
+      List<ArrivalCollectTask> taskItems,
+      ArrivalCollectTask? selectedTask,
+      List<ArrivalCollectProgress> progresses,
+      ArrivalCollectScanStep currentStep,
+      Set<String> selectedProgressIds,
+      int activeTabIndex,
+      String? successMessage,
+      String? errorMessage,
+      ArrivalCollectCache? cache});
 
   @override
   $ArrivalSignTaskCopyWith<$Res>? get headerTask;
@@ -217,10 +209,9 @@ abstract class _$$ArrivalCollectStateImplCopyWith<$Res>
 class __$$ArrivalCollectStateImplCopyWithImpl<$Res>
     extends _$ArrivalCollectStateCopyWithImpl<$Res, _$ArrivalCollectStateImpl>
     implements _$$ArrivalCollectStateImplCopyWith<$Res> {
-  __$$ArrivalCollectStateImplCopyWithImpl(
-    _$ArrivalCollectStateImpl _value,
-    $Res Function(_$ArrivalCollectStateImpl) _then,
-  ) : super(_value, _then);
+  __$$ArrivalCollectStateImplCopyWithImpl(_$ArrivalCollectStateImpl _value,
+      $Res Function(_$ArrivalCollectStateImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -238,81 +229,79 @@ class __$$ArrivalCollectStateImplCopyWithImpl<$Res>
     Object? errorMessage = freezed,
     Object? cache = freezed,
   }) {
-    return _then(
-      _$ArrivalCollectStateImpl(
-        headerTask: freezed == headerTask
-            ? _value.headerTask
-            : headerTask // ignore: cast_nullable_to_non_nullable
-                  as ArrivalSignTask?,
-        isLoading: null == isLoading
-            ? _value.isLoading
-            : isLoading // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        isSubmitting: null == isSubmitting
-            ? _value.isSubmitting
-            : isSubmitting // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        taskItems: null == taskItems
-            ? _value._taskItems
-            : taskItems // ignore: cast_nullable_to_non_nullable
-                  as List<ArrivalCollectTask>,
-        selectedTask: freezed == selectedTask
-            ? _value.selectedTask
-            : selectedTask // ignore: cast_nullable_to_non_nullable
-                  as ArrivalCollectTask?,
-        progresses: null == progresses
-            ? _value._progresses
-            : progresses // ignore: cast_nullable_to_non_nullable
-                  as List<ArrivalCollectProgress>,
-        currentStep: null == currentStep
-            ? _value.currentStep
-            : currentStep // ignore: cast_nullable_to_non_nullable
-                  as ArrivalCollectScanStep,
-        selectedProgressIds: null == selectedProgressIds
-            ? _value._selectedProgressIds
-            : selectedProgressIds // ignore: cast_nullable_to_non_nullable
-                  as Set<String>,
-        activeTabIndex: null == activeTabIndex
-            ? _value.activeTabIndex
-            : activeTabIndex // ignore: cast_nullable_to_non_nullable
-                  as int,
-        successMessage: freezed == successMessage
-            ? _value.successMessage
-            : successMessage // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        errorMessage: freezed == errorMessage
-            ? _value.errorMessage
-            : errorMessage // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        cache: freezed == cache
-            ? _value.cache
-            : cache // ignore: cast_nullable_to_non_nullable
-                  as ArrivalCollectCache?,
-      ),
-    );
+    return _then(_$ArrivalCollectStateImpl(
+      headerTask: freezed == headerTask
+          ? _value.headerTask
+          : headerTask // ignore: cast_nullable_to_non_nullable
+              as ArrivalSignTask?,
+      isLoading: null == isLoading
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isSubmitting: null == isSubmitting
+          ? _value.isSubmitting
+          : isSubmitting // ignore: cast_nullable_to_non_nullable
+              as bool,
+      taskItems: null == taskItems
+          ? _value._taskItems
+          : taskItems // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectTask>,
+      selectedTask: freezed == selectedTask
+          ? _value.selectedTask
+          : selectedTask // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectTask?,
+      progresses: null == progresses
+          ? _value._progresses
+          : progresses // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectProgress>,
+      currentStep: null == currentStep
+          ? _value.currentStep
+          : currentStep // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectScanStep,
+      selectedProgressIds: null == selectedProgressIds
+          ? _value._selectedProgressIds
+          : selectedProgressIds // ignore: cast_nullable_to_non_nullable
+              as Set<String>,
+      activeTabIndex: null == activeTabIndex
+          ? _value.activeTabIndex
+          : activeTabIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+      successMessage: freezed == successMessage
+          ? _value.successMessage
+          : successMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      errorMessage: freezed == errorMessage
+          ? _value.errorMessage
+          : errorMessage // ignore: cast_nullable_to_non_nullable
+              as String?,
+      cache: freezed == cache
+          ? _value.cache
+          : cache // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectCache?,
+    ));
   }
 }
 
 /// @nodoc
 
 class _$ArrivalCollectStateImpl implements _ArrivalCollectState {
-  const _$ArrivalCollectStateImpl({
-    this.headerTask,
-    this.isLoading = false,
-    this.isSubmitting = false,
-    final List<ArrivalCollectTask> taskItems = const <ArrivalCollectTask>[],
-    this.selectedTask,
-    final List<ArrivalCollectProgress> progresses =
-        const <ArrivalCollectProgress>[],
-    this.currentStep = ArrivalCollectScanStep.materialQRCode,
-    final Set<String> selectedProgressIds = const <String>{},
-    this.activeTabIndex = 0,
-    this.successMessage,
-    this.errorMessage,
-    this.cache,
-  }) : _taskItems = taskItems,
-       _progresses = progresses,
-       _selectedProgressIds = selectedProgressIds;
+  const _$ArrivalCollectStateImpl(
+      {this.headerTask,
+      this.isLoading = false,
+      this.isSubmitting = false,
+      final List<ArrivalCollectTask> taskItems = const <ArrivalCollectTask>[],
+      this.selectedTask,
+      final List<ArrivalCollectProgress> progresses =
+          const <ArrivalCollectProgress>[],
+      this.currentStep = ArrivalCollectScanStep.materialQRCode,
+      final Set<String> selectedProgressIds = const <String>{},
+      this.activeTabIndex = 0,
+      this.successMessage,
+      this.errorMessage,
+      this.cache})
+      : _taskItems = taskItems,
+        _progresses = progresses,
+        _selectedProgressIds = selectedProgressIds;
 
   @override
   final ArrivalSignTask? headerTask;
@@ -381,22 +370,16 @@ class _$ArrivalCollectStateImpl implements _ArrivalCollectState {
                 other.isLoading == isLoading) &&
             (identical(other.isSubmitting, isSubmitting) ||
                 other.isSubmitting == isSubmitting) &&
-            const DeepCollectionEquality().equals(
-              other._taskItems,
-              _taskItems,
-            ) &&
+            const DeepCollectionEquality()
+                .equals(other._taskItems, _taskItems) &&
             (identical(other.selectedTask, selectedTask) ||
                 other.selectedTask == selectedTask) &&
-            const DeepCollectionEquality().equals(
-              other._progresses,
-              _progresses,
-            ) &&
+            const DeepCollectionEquality()
+                .equals(other._progresses, _progresses) &&
             (identical(other.currentStep, currentStep) ||
                 other.currentStep == currentStep) &&
-            const DeepCollectionEquality().equals(
-              other._selectedProgressIds,
-              _selectedProgressIds,
-            ) &&
+            const DeepCollectionEquality()
+                .equals(other._selectedProgressIds, _selectedProgressIds) &&
             (identical(other.activeTabIndex, activeTabIndex) ||
                 other.activeTabIndex == activeTabIndex) &&
             (identical(other.successMessage, successMessage) ||
@@ -408,46 +391,42 @@ class _$ArrivalCollectStateImpl implements _ArrivalCollectState {
 
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    headerTask,
-    isLoading,
-    isSubmitting,
-    const DeepCollectionEquality().hash(_taskItems),
-    selectedTask,
-    const DeepCollectionEquality().hash(_progresses),
-    currentStep,
-    const DeepCollectionEquality().hash(_selectedProgressIds),
-    activeTabIndex,
-    successMessage,
-    errorMessage,
-    cache,
-  );
+      runtimeType,
+      headerTask,
+      isLoading,
+      isSubmitting,
+      const DeepCollectionEquality().hash(_taskItems),
+      selectedTask,
+      const DeepCollectionEquality().hash(_progresses),
+      currentStep,
+      const DeepCollectionEquality().hash(_selectedProgressIds),
+      activeTabIndex,
+      successMessage,
+      errorMessage,
+      cache);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ArrivalCollectStateImplCopyWith<_$ArrivalCollectStateImpl> get copyWith =>
       __$$ArrivalCollectStateImplCopyWithImpl<_$ArrivalCollectStateImpl>(
-        this,
-        _$identity,
-      );
+          this, _$identity);
 }
 
 abstract class _ArrivalCollectState implements ArrivalCollectState {
-  const factory _ArrivalCollectState({
-    final ArrivalSignTask? headerTask,
-    final bool isLoading,
-    final bool isSubmitting,
-    final List<ArrivalCollectTask> taskItems,
-    final ArrivalCollectTask? selectedTask,
-    final List<ArrivalCollectProgress> progresses,
-    final ArrivalCollectScanStep currentStep,
-    final Set<String> selectedProgressIds,
-    final int activeTabIndex,
-    final String? successMessage,
-    final String? errorMessage,
-    final ArrivalCollectCache? cache,
-  }) = _$ArrivalCollectStateImpl;
+  const factory _ArrivalCollectState(
+      {final ArrivalSignTask? headerTask,
+      final bool isLoading,
+      final bool isSubmitting,
+      final List<ArrivalCollectTask> taskItems,
+      final ArrivalCollectTask? selectedTask,
+      final List<ArrivalCollectProgress> progresses,
+      final ArrivalCollectScanStep currentStep,
+      final Set<String> selectedProgressIds,
+      final int activeTabIndex,
+      final String? successMessage,
+      final String? errorMessage,
+      final ArrivalCollectCache? cache}) = _$ArrivalCollectStateImpl;
 
   @override
   ArrivalSignTask? get headerTask;

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.freezed.dart
@@ -12,8 +12,7 @@ part of 'arrival_collect_cache.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 ArrivalCollectCache _$ArrivalCollectCacheFromJson(Map<String, dynamic> json) {
   return _ArrivalCollectCache.fromJson(json);
@@ -35,15 +34,13 @@ mixin _$ArrivalCollectCache {
 /// @nodoc
 abstract class $ArrivalCollectCacheCopyWith<$Res> {
   factory $ArrivalCollectCacheCopyWith(
-    ArrivalCollectCache value,
-    $Res Function(ArrivalCollectCache) then,
-  ) = _$ArrivalCollectCacheCopyWithImpl<$Res, ArrivalCollectCache>;
+          ArrivalCollectCache value, $Res Function(ArrivalCollectCache) then) =
+      _$ArrivalCollectCacheCopyWithImpl<$Res, ArrivalCollectCache>;
   @useResult
-  $Res call({
-    List<ArrivalCollectProgress> progresses,
-    bool hasPendingSubmit,
-    String? arrivalsBillId,
-  });
+  $Res call(
+      {List<ArrivalCollectProgress> progresses,
+      bool hasPendingSubmit,
+      String? arrivalsBillId});
 }
 
 /// @nodoc
@@ -63,50 +60,44 @@ class _$ArrivalCollectCacheCopyWithImpl<$Res, $Val extends ArrivalCollectCache>
     Object? hasPendingSubmit = null,
     Object? arrivalsBillId = freezed,
   }) {
-    return _then(
-      _value.copyWith(
-            progresses: null == progresses
-                ? _value.progresses
-                : progresses // ignore: cast_nullable_to_non_nullable
-                      as List<ArrivalCollectProgress>,
-            hasPendingSubmit: null == hasPendingSubmit
-                ? _value.hasPendingSubmit
-                : hasPendingSubmit // ignore: cast_nullable_to_non_nullable
-                      as bool,
-            arrivalsBillId: freezed == arrivalsBillId
-                ? _value.arrivalsBillId
-                : arrivalsBillId // ignore: cast_nullable_to_non_nullable
-                      as String?,
-          )
-          as $Val,
-    );
+    return _then(_value.copyWith(
+      progresses: null == progresses
+          ? _value.progresses
+          : progresses // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectProgress>,
+      hasPendingSubmit: null == hasPendingSubmit
+          ? _value.hasPendingSubmit
+          : hasPendingSubmit // ignore: cast_nullable_to_non_nullable
+              as bool,
+      arrivalsBillId: freezed == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
   }
 }
 
 /// @nodoc
 abstract class _$$ArrivalCollectCacheImplCopyWith<$Res>
     implements $ArrivalCollectCacheCopyWith<$Res> {
-  factory _$$ArrivalCollectCacheImplCopyWith(
-    _$ArrivalCollectCacheImpl value,
-    $Res Function(_$ArrivalCollectCacheImpl) then,
-  ) = __$$ArrivalCollectCacheImplCopyWithImpl<$Res>;
+  factory _$$ArrivalCollectCacheImplCopyWith(_$ArrivalCollectCacheImpl value,
+          $Res Function(_$ArrivalCollectCacheImpl) then) =
+      __$$ArrivalCollectCacheImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    List<ArrivalCollectProgress> progresses,
-    bool hasPendingSubmit,
-    String? arrivalsBillId,
-  });
+  $Res call(
+      {List<ArrivalCollectProgress> progresses,
+      bool hasPendingSubmit,
+      String? arrivalsBillId});
 }
 
 /// @nodoc
 class __$$ArrivalCollectCacheImplCopyWithImpl<$Res>
     extends _$ArrivalCollectCacheCopyWithImpl<$Res, _$ArrivalCollectCacheImpl>
     implements _$$ArrivalCollectCacheImplCopyWith<$Res> {
-  __$$ArrivalCollectCacheImplCopyWithImpl(
-    _$ArrivalCollectCacheImpl _value,
-    $Res Function(_$ArrivalCollectCacheImpl) _then,
-  ) : super(_value, _then);
+  __$$ArrivalCollectCacheImplCopyWithImpl(_$ArrivalCollectCacheImpl _value,
+      $Res Function(_$ArrivalCollectCacheImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -115,22 +106,20 @@ class __$$ArrivalCollectCacheImplCopyWithImpl<$Res>
     Object? hasPendingSubmit = null,
     Object? arrivalsBillId = freezed,
   }) {
-    return _then(
-      _$ArrivalCollectCacheImpl(
-        progresses: null == progresses
-            ? _value._progresses
-            : progresses // ignore: cast_nullable_to_non_nullable
-                  as List<ArrivalCollectProgress>,
-        hasPendingSubmit: null == hasPendingSubmit
-            ? _value.hasPendingSubmit
-            : hasPendingSubmit // ignore: cast_nullable_to_non_nullable
-                  as bool,
-        arrivalsBillId: freezed == arrivalsBillId
-            ? _value.arrivalsBillId
-            : arrivalsBillId // ignore: cast_nullable_to_non_nullable
-                  as String?,
-      ),
-    );
+    return _then(_$ArrivalCollectCacheImpl(
+      progresses: null == progresses
+          ? _value._progresses
+          : progresses // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectProgress>,
+      hasPendingSubmit: null == hasPendingSubmit
+          ? _value.hasPendingSubmit
+          : hasPendingSubmit // ignore: cast_nullable_to_non_nullable
+              as bool,
+      arrivalsBillId: freezed == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
   }
 }
 
@@ -138,12 +127,12 @@ class __$$ArrivalCollectCacheImplCopyWithImpl<$Res>
 
 @JsonSerializable(explicitToJson: true)
 class _$ArrivalCollectCacheImpl implements _ArrivalCollectCache {
-  const _$ArrivalCollectCacheImpl({
-    final List<ArrivalCollectProgress> progresses =
-        const <ArrivalCollectProgress>[],
-    this.hasPendingSubmit = false,
-    this.arrivalsBillId,
-  }) : _progresses = progresses;
+  const _$ArrivalCollectCacheImpl(
+      {final List<ArrivalCollectProgress> progresses =
+          const <ArrivalCollectProgress>[],
+      this.hasPendingSubmit = false,
+      this.arrivalsBillId})
+      : _progresses = progresses;
 
   factory _$ArrivalCollectCacheImpl.fromJson(Map<String, dynamic> json) =>
       _$$ArrivalCollectCacheImplFromJson(json);
@@ -173,10 +162,8 @@ class _$ArrivalCollectCacheImpl implements _ArrivalCollectCache {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ArrivalCollectCacheImpl &&
-            const DeepCollectionEquality().equals(
-              other._progresses,
-              _progresses,
-            ) &&
+            const DeepCollectionEquality()
+                .equals(other._progresses, _progresses) &&
             (identical(other.hasPendingSubmit, hasPendingSubmit) ||
                 other.hasPendingSubmit == hasPendingSubmit) &&
             (identical(other.arrivalsBillId, arrivalsBillId) ||
@@ -186,33 +173,31 @@ class _$ArrivalCollectCacheImpl implements _ArrivalCollectCache {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(_progresses),
-    hasPendingSubmit,
-    arrivalsBillId,
-  );
+      runtimeType,
+      const DeepCollectionEquality().hash(_progresses),
+      hasPendingSubmit,
+      arrivalsBillId);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ArrivalCollectCacheImplCopyWith<_$ArrivalCollectCacheImpl> get copyWith =>
       __$$ArrivalCollectCacheImplCopyWithImpl<_$ArrivalCollectCacheImpl>(
-        this,
-        _$identity,
-      );
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ArrivalCollectCacheImplToJson(this);
+    return _$$ArrivalCollectCacheImplToJson(
+      this,
+    );
   }
 }
 
 abstract class _ArrivalCollectCache implements ArrivalCollectCache {
-  const factory _ArrivalCollectCache({
-    final List<ArrivalCollectProgress> progresses,
-    final bool hasPendingSubmit,
-    final String? arrivalsBillId,
-  }) = _$ArrivalCollectCacheImpl;
+  const factory _ArrivalCollectCache(
+      {final List<ArrivalCollectProgress> progresses,
+      final bool hasPendingSubmit,
+      final String? arrivalsBillId}) = _$ArrivalCollectCacheImpl;
 
   factory _ArrivalCollectCache.fromJson(Map<String, dynamic> json) =
       _$ArrivalCollectCacheImpl.fromJson;

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.g.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_cache.g.dart
@@ -7,23 +7,21 @@ part of 'arrival_collect_cache.dart';
 // **************************************************************************
 
 _$ArrivalCollectCacheImpl _$$ArrivalCollectCacheImplFromJson(
-  Map<String, dynamic> json,
-) => _$ArrivalCollectCacheImpl(
-  progresses:
-      (json['progresses'] as List<dynamic>?)
-          ?.map(
-            (e) => ArrivalCollectProgress.fromJson(e as Map<String, dynamic>),
-          )
-          .toList() ??
-      const <ArrivalCollectProgress>[],
-  hasPendingSubmit: json['hasPendingSubmit'] as bool? ?? false,
-  arrivalsBillId: json['arrivalsBillId'] as String?,
-);
+        Map<String, dynamic> json) =>
+    _$ArrivalCollectCacheImpl(
+      progresses: (json['progresses'] as List<dynamic>?)
+              ?.map((e) =>
+                  ArrivalCollectProgress.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <ArrivalCollectProgress>[],
+      hasPendingSubmit: json['hasPendingSubmit'] as bool? ?? false,
+      arrivalsBillId: json['arrivalsBillId'] as String?,
+    );
 
 Map<String, dynamic> _$$ArrivalCollectCacheImplToJson(
-  _$ArrivalCollectCacheImpl instance,
-) => <String, dynamic>{
-  'progresses': instance.progresses.map((e) => e.toJson()).toList(),
-  'hasPendingSubmit': instance.hasPendingSubmit,
-  'arrivalsBillId': instance.arrivalsBillId,
-};
+        _$ArrivalCollectCacheImpl instance) =>
+    <String, dynamic>{
+      'progresses': instance.progresses.map((e) => e.toJson()).toList(),
+      'hasPendingSubmit': instance.hasPendingSubmit,
+      'arrivalsBillId': instance.arrivalsBillId,
+    };

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.freezed.dart
@@ -12,12 +12,10 @@ part of 'arrival_collect_progress.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 ArrivalCollectProgress _$ArrivalCollectProgressFromJson(
-  Map<String, dynamic> json,
-) {
+    Map<String, dynamic> json) {
   return _ArrivalCollectProgress.fromJson(json);
 }
 
@@ -41,31 +39,27 @@ mixin _$ArrivalCollectProgress {
 
 /// @nodoc
 abstract class $ArrivalCollectProgressCopyWith<$Res> {
-  factory $ArrivalCollectProgressCopyWith(
-    ArrivalCollectProgress value,
-    $Res Function(ArrivalCollectProgress) then,
-  ) = _$ArrivalCollectProgressCopyWithImpl<$Res, ArrivalCollectProgress>;
+  factory $ArrivalCollectProgressCopyWith(ArrivalCollectProgress value,
+          $Res Function(ArrivalCollectProgress) then) =
+      _$ArrivalCollectProgressCopyWithImpl<$Res, ArrivalCollectProgress>;
   @useResult
-  $Res call({
-    String id,
-    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
-    ArrivalCollectTask task,
-    double collectQty,
-    String? batchNo,
-    String? serialNumber,
-    String? productionDate,
-    String? validDays,
-    bool submitted,
-  });
+  $Res call(
+      {String id,
+      @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+      ArrivalCollectTask task,
+      double collectQty,
+      String? batchNo,
+      String? serialNumber,
+      String? productionDate,
+      String? validDays,
+      bool submitted});
 
   $ArrivalCollectTaskCopyWith<$Res> get task;
 }
 
 /// @nodoc
-class _$ArrivalCollectProgressCopyWithImpl<
-  $Res,
-  $Val extends ArrivalCollectProgress
->
+class _$ArrivalCollectProgressCopyWithImpl<$Res,
+        $Val extends ArrivalCollectProgress>
     implements $ArrivalCollectProgressCopyWith<$Res> {
   _$ArrivalCollectProgressCopyWithImpl(this._value, this._then);
 
@@ -86,43 +80,40 @@ class _$ArrivalCollectProgressCopyWithImpl<
     Object? validDays = freezed,
     Object? submitted = null,
   }) {
-    return _then(
-      _value.copyWith(
-            id: null == id
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                      as String,
-            task: null == task
-                ? _value.task
-                : task // ignore: cast_nullable_to_non_nullable
-                      as ArrivalCollectTask,
-            collectQty: null == collectQty
-                ? _value.collectQty
-                : collectQty // ignore: cast_nullable_to_non_nullable
-                      as double,
-            batchNo: freezed == batchNo
-                ? _value.batchNo
-                : batchNo // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            serialNumber: freezed == serialNumber
-                ? _value.serialNumber
-                : serialNumber // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            productionDate: freezed == productionDate
-                ? _value.productionDate
-                : productionDate // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            validDays: freezed == validDays
-                ? _value.validDays
-                : validDays // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            submitted: null == submitted
-                ? _value.submitted
-                : submitted // ignore: cast_nullable_to_non_nullable
-                      as bool,
-          )
-          as $Val,
-    );
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      task: null == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectTask,
+      collectQty: null == collectQty
+          ? _value.collectQty
+          : collectQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as String?,
+      submitted: null == submitted
+          ? _value.submitted
+          : submitted // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
   }
 
   @override
@@ -138,22 +129,21 @@ class _$ArrivalCollectProgressCopyWithImpl<
 abstract class _$$ArrivalCollectProgressImplCopyWith<$Res>
     implements $ArrivalCollectProgressCopyWith<$Res> {
   factory _$$ArrivalCollectProgressImplCopyWith(
-    _$ArrivalCollectProgressImpl value,
-    $Res Function(_$ArrivalCollectProgressImpl) then,
-  ) = __$$ArrivalCollectProgressImplCopyWithImpl<$Res>;
+          _$ArrivalCollectProgressImpl value,
+          $Res Function(_$ArrivalCollectProgressImpl) then) =
+      __$$ArrivalCollectProgressImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    String id,
-    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
-    ArrivalCollectTask task,
-    double collectQty,
-    String? batchNo,
-    String? serialNumber,
-    String? productionDate,
-    String? validDays,
-    bool submitted,
-  });
+  $Res call(
+      {String id,
+      @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+      ArrivalCollectTask task,
+      double collectQty,
+      String? batchNo,
+      String? serialNumber,
+      String? productionDate,
+      String? validDays,
+      bool submitted});
 
   @override
   $ArrivalCollectTaskCopyWith<$Res> get task;
@@ -161,13 +151,13 @@ abstract class _$$ArrivalCollectProgressImplCopyWith<$Res>
 
 /// @nodoc
 class __$$ArrivalCollectProgressImplCopyWithImpl<$Res>
-    extends
-        _$ArrivalCollectProgressCopyWithImpl<$Res, _$ArrivalCollectProgressImpl>
+    extends _$ArrivalCollectProgressCopyWithImpl<$Res,
+        _$ArrivalCollectProgressImpl>
     implements _$$ArrivalCollectProgressImplCopyWith<$Res> {
   __$$ArrivalCollectProgressImplCopyWithImpl(
-    _$ArrivalCollectProgressImpl _value,
-    $Res Function(_$ArrivalCollectProgressImpl) _then,
-  ) : super(_value, _then);
+      _$ArrivalCollectProgressImpl _value,
+      $Res Function(_$ArrivalCollectProgressImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -181,42 +171,40 @@ class __$$ArrivalCollectProgressImplCopyWithImpl<$Res>
     Object? validDays = freezed,
     Object? submitted = null,
   }) {
-    return _then(
-      _$ArrivalCollectProgressImpl(
-        id: null == id
-            ? _value.id
-            : id // ignore: cast_nullable_to_non_nullable
-                  as String,
-        task: null == task
-            ? _value.task
-            : task // ignore: cast_nullable_to_non_nullable
-                  as ArrivalCollectTask,
-        collectQty: null == collectQty
-            ? _value.collectQty
-            : collectQty // ignore: cast_nullable_to_non_nullable
-                  as double,
-        batchNo: freezed == batchNo
-            ? _value.batchNo
-            : batchNo // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        serialNumber: freezed == serialNumber
-            ? _value.serialNumber
-            : serialNumber // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        productionDate: freezed == productionDate
-            ? _value.productionDate
-            : productionDate // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        validDays: freezed == validDays
-            ? _value.validDays
-            : validDays // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        submitted: null == submitted
-            ? _value.submitted
-            : submitted // ignore: cast_nullable_to_non_nullable
-                  as bool,
-      ),
-    );
+    return _then(_$ArrivalCollectProgressImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      task: null == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectTask,
+      collectQty: null == collectQty
+          ? _value.collectQty
+          : collectQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as String?,
+      submitted: null == submitted
+          ? _value.submitted
+          : submitted // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
   }
 }
 
@@ -224,17 +212,16 @@ class __$$ArrivalCollectProgressImplCopyWithImpl<$Res>
 
 @JsonSerializable(explicitToJson: true)
 class _$ArrivalCollectProgressImpl implements _ArrivalCollectProgress {
-  const _$ArrivalCollectProgressImpl({
-    required this.id,
-    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
-    required this.task,
-    required this.collectQty,
-    this.batchNo,
-    this.serialNumber,
-    this.productionDate,
-    this.validDays,
-    this.submitted = false,
-  });
+  const _$ArrivalCollectProgressImpl(
+      {required this.id,
+      @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+      required this.task,
+      required this.collectQty,
+      this.batchNo,
+      this.serialNumber,
+      this.productionDate,
+      this.validDays,
+      this.submitted = false});
 
   factory _$ArrivalCollectProgressImpl.fromJson(Map<String, dynamic> json) =>
       _$$ArrivalCollectProgressImplFromJson(json);
@@ -285,46 +272,35 @@ class _$ArrivalCollectProgressImpl implements _ArrivalCollectProgress {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-    runtimeType,
-    id,
-    task,
-    collectQty,
-    batchNo,
-    serialNumber,
-    productionDate,
-    validDays,
-    submitted,
-  );
+  int get hashCode => Object.hash(runtimeType, id, task, collectQty, batchNo,
+      serialNumber, productionDate, validDays, submitted);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ArrivalCollectProgressImplCopyWith<_$ArrivalCollectProgressImpl>
-  get copyWith =>
-      __$$ArrivalCollectProgressImplCopyWithImpl<_$ArrivalCollectProgressImpl>(
-        this,
-        _$identity,
-      );
+      get copyWith => __$$ArrivalCollectProgressImplCopyWithImpl<
+          _$ArrivalCollectProgressImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ArrivalCollectProgressImplToJson(this);
+    return _$$ArrivalCollectProgressImplToJson(
+      this,
+    );
   }
 }
 
 abstract class _ArrivalCollectProgress implements ArrivalCollectProgress {
-  const factory _ArrivalCollectProgress({
-    required final String id,
-    @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
-    required final ArrivalCollectTask task,
-    required final double collectQty,
-    final String? batchNo,
-    final String? serialNumber,
-    final String? productionDate,
-    final String? validDays,
-    final bool submitted,
-  }) = _$ArrivalCollectProgressImpl;
+  const factory _ArrivalCollectProgress(
+      {required final String id,
+      @JsonKey(fromJson: ArrivalCollectTask.fromJson, toJson: _taskToJson)
+      required final ArrivalCollectTask task,
+      required final double collectQty,
+      final String? batchNo,
+      final String? serialNumber,
+      final String? productionDate,
+      final String? validDays,
+      final bool submitted}) = _$ArrivalCollectProgressImpl;
 
   factory _ArrivalCollectProgress.fromJson(Map<String, dynamic> json) =
       _$ArrivalCollectProgressImpl.fromJson;
@@ -349,12 +325,11 @@ abstract class _ArrivalCollectProgress implements ArrivalCollectProgress {
   @override
   @JsonKey(ignore: true)
   _$$ArrivalCollectProgressImplCopyWith<_$ArrivalCollectProgressImpl>
-  get copyWith => throw _privateConstructorUsedError;
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ArrivalCollectSummary _$ArrivalCollectSummaryFromJson(
-  Map<String, dynamic> json,
-) {
+    Map<String, dynamic> json) {
   return _ArrivalCollectSummary.fromJson(json);
 }
 
@@ -379,30 +354,26 @@ mixin _$ArrivalCollectSummary {
 
 /// @nodoc
 abstract class $ArrivalCollectSummaryCopyWith<$Res> {
-  factory $ArrivalCollectSummaryCopyWith(
-    ArrivalCollectSummary value,
-    $Res Function(ArrivalCollectSummary) then,
-  ) = _$ArrivalCollectSummaryCopyWithImpl<$Res, ArrivalCollectSummary>;
+  factory $ArrivalCollectSummaryCopyWith(ArrivalCollectSummary value,
+          $Res Function(ArrivalCollectSummary) then) =
+      _$ArrivalCollectSummaryCopyWithImpl<$Res, ArrivalCollectSummary>;
   @useResult
-  $Res call({
-    String id,
-    String materialCode,
-    String? materialName,
-    String? batchNo,
-    String? serialNumber,
-    double? collectQty,
-    double? taskQty,
-    String? productionDate,
-    String? validDays,
-    bool committed,
-  });
+  $Res call(
+      {String id,
+      String materialCode,
+      String? materialName,
+      String? batchNo,
+      String? serialNumber,
+      double? collectQty,
+      double? taskQty,
+      String? productionDate,
+      String? validDays,
+      bool committed});
 }
 
 /// @nodoc
-class _$ArrivalCollectSummaryCopyWithImpl<
-  $Res,
-  $Val extends ArrivalCollectSummary
->
+class _$ArrivalCollectSummaryCopyWithImpl<$Res,
+        $Val extends ArrivalCollectSummary>
     implements $ArrivalCollectSummaryCopyWith<$Res> {
   _$ArrivalCollectSummaryCopyWithImpl(this._value, this._then);
 
@@ -425,51 +396,48 @@ class _$ArrivalCollectSummaryCopyWithImpl<
     Object? validDays = freezed,
     Object? committed = null,
   }) {
-    return _then(
-      _value.copyWith(
-            id: null == id
-                ? _value.id
-                : id // ignore: cast_nullable_to_non_nullable
-                      as String,
-            materialCode: null == materialCode
-                ? _value.materialCode
-                : materialCode // ignore: cast_nullable_to_non_nullable
-                      as String,
-            materialName: freezed == materialName
-                ? _value.materialName
-                : materialName // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            batchNo: freezed == batchNo
-                ? _value.batchNo
-                : batchNo // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            serialNumber: freezed == serialNumber
-                ? _value.serialNumber
-                : serialNumber // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            collectQty: freezed == collectQty
-                ? _value.collectQty
-                : collectQty // ignore: cast_nullable_to_non_nullable
-                      as double?,
-            taskQty: freezed == taskQty
-                ? _value.taskQty
-                : taskQty // ignore: cast_nullable_to_non_nullable
-                      as double?,
-            productionDate: freezed == productionDate
-                ? _value.productionDate
-                : productionDate // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            validDays: freezed == validDays
-                ? _value.validDays
-                : validDays // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            committed: null == committed
-                ? _value.committed
-                : committed // ignore: cast_nullable_to_non_nullable
-                      as bool,
-          )
-          as $Val,
-    );
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      collectQty: freezed == collectQty
+          ? _value.collectQty
+          : collectQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      taskQty: freezed == taskQty
+          ? _value.taskQty
+          : taskQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as String?,
+      committed: null == committed
+          ? _value.committed
+          : committed // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
   }
 }
 
@@ -477,34 +445,32 @@ class _$ArrivalCollectSummaryCopyWithImpl<
 abstract class _$$ArrivalCollectSummaryImplCopyWith<$Res>
     implements $ArrivalCollectSummaryCopyWith<$Res> {
   factory _$$ArrivalCollectSummaryImplCopyWith(
-    _$ArrivalCollectSummaryImpl value,
-    $Res Function(_$ArrivalCollectSummaryImpl) then,
-  ) = __$$ArrivalCollectSummaryImplCopyWithImpl<$Res>;
+          _$ArrivalCollectSummaryImpl value,
+          $Res Function(_$ArrivalCollectSummaryImpl) then) =
+      __$$ArrivalCollectSummaryImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    String id,
-    String materialCode,
-    String? materialName,
-    String? batchNo,
-    String? serialNumber,
-    double? collectQty,
-    double? taskQty,
-    String? productionDate,
-    String? validDays,
-    bool committed,
-  });
+  $Res call(
+      {String id,
+      String materialCode,
+      String? materialName,
+      String? batchNo,
+      String? serialNumber,
+      double? collectQty,
+      double? taskQty,
+      String? productionDate,
+      String? validDays,
+      bool committed});
 }
 
 /// @nodoc
 class __$$ArrivalCollectSummaryImplCopyWithImpl<$Res>
-    extends
-        _$ArrivalCollectSummaryCopyWithImpl<$Res, _$ArrivalCollectSummaryImpl>
+    extends _$ArrivalCollectSummaryCopyWithImpl<$Res,
+        _$ArrivalCollectSummaryImpl>
     implements _$$ArrivalCollectSummaryImplCopyWith<$Res> {
-  __$$ArrivalCollectSummaryImplCopyWithImpl(
-    _$ArrivalCollectSummaryImpl _value,
-    $Res Function(_$ArrivalCollectSummaryImpl) _then,
-  ) : super(_value, _then);
+  __$$ArrivalCollectSummaryImplCopyWithImpl(_$ArrivalCollectSummaryImpl _value,
+      $Res Function(_$ArrivalCollectSummaryImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -520,68 +486,65 @@ class __$$ArrivalCollectSummaryImplCopyWithImpl<$Res>
     Object? validDays = freezed,
     Object? committed = null,
   }) {
-    return _then(
-      _$ArrivalCollectSummaryImpl(
-        id: null == id
-            ? _value.id
-            : id // ignore: cast_nullable_to_non_nullable
-                  as String,
-        materialCode: null == materialCode
-            ? _value.materialCode
-            : materialCode // ignore: cast_nullable_to_non_nullable
-                  as String,
-        materialName: freezed == materialName
-            ? _value.materialName
-            : materialName // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        batchNo: freezed == batchNo
-            ? _value.batchNo
-            : batchNo // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        serialNumber: freezed == serialNumber
-            ? _value.serialNumber
-            : serialNumber // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        collectQty: freezed == collectQty
-            ? _value.collectQty
-            : collectQty // ignore: cast_nullable_to_non_nullable
-                  as double?,
-        taskQty: freezed == taskQty
-            ? _value.taskQty
-            : taskQty // ignore: cast_nullable_to_non_nullable
-                  as double?,
-        productionDate: freezed == productionDate
-            ? _value.productionDate
-            : productionDate // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        validDays: freezed == validDays
-            ? _value.validDays
-            : validDays // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        committed: null == committed
-            ? _value.committed
-            : committed // ignore: cast_nullable_to_non_nullable
-                  as bool,
-      ),
-    );
+    return _then(_$ArrivalCollectSummaryImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      collectQty: freezed == collectQty
+          ? _value.collectQty
+          : collectQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      taskQty: freezed == taskQty
+          ? _value.taskQty
+          : taskQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as String?,
+      committed: null == committed
+          ? _value.committed
+          : committed // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$ArrivalCollectSummaryImpl implements _ArrivalCollectSummary {
-  const _$ArrivalCollectSummaryImpl({
-    required this.id,
-    required this.materialCode,
-    this.materialName,
-    this.batchNo,
-    this.serialNumber,
-    this.collectQty,
-    this.taskQty,
-    this.productionDate,
-    this.validDays,
-    this.committed = false,
-  });
+  const _$ArrivalCollectSummaryImpl(
+      {required this.id,
+      required this.materialCode,
+      this.materialName,
+      this.batchNo,
+      this.serialNumber,
+      this.collectQty,
+      this.taskQty,
+      this.productionDate,
+      this.validDays,
+      this.committed = false});
 
   factory _$ArrivalCollectSummaryImpl.fromJson(Map<String, dynamic> json) =>
       _$$ArrivalCollectSummaryImplFromJson(json);
@@ -640,48 +603,45 @@ class _$ArrivalCollectSummaryImpl implements _ArrivalCollectSummary {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    id,
-    materialCode,
-    materialName,
-    batchNo,
-    serialNumber,
-    collectQty,
-    taskQty,
-    productionDate,
-    validDays,
-    committed,
-  );
+      runtimeType,
+      id,
+      materialCode,
+      materialName,
+      batchNo,
+      serialNumber,
+      collectQty,
+      taskQty,
+      productionDate,
+      validDays,
+      committed);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ArrivalCollectSummaryImplCopyWith<_$ArrivalCollectSummaryImpl>
-  get copyWith =>
-      __$$ArrivalCollectSummaryImplCopyWithImpl<_$ArrivalCollectSummaryImpl>(
-        this,
-        _$identity,
-      );
+      get copyWith => __$$ArrivalCollectSummaryImplCopyWithImpl<
+          _$ArrivalCollectSummaryImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ArrivalCollectSummaryImplToJson(this);
+    return _$$ArrivalCollectSummaryImplToJson(
+      this,
+    );
   }
 }
 
 abstract class _ArrivalCollectSummary implements ArrivalCollectSummary {
-  const factory _ArrivalCollectSummary({
-    required final String id,
-    required final String materialCode,
-    final String? materialName,
-    final String? batchNo,
-    final String? serialNumber,
-    final double? collectQty,
-    final double? taskQty,
-    final String? productionDate,
-    final String? validDays,
-    final bool committed,
-  }) = _$ArrivalCollectSummaryImpl;
+  const factory _ArrivalCollectSummary(
+      {required final String id,
+      required final String materialCode,
+      final String? materialName,
+      final String? batchNo,
+      final String? serialNumber,
+      final double? collectQty,
+      final double? taskQty,
+      final String? productionDate,
+      final String? validDays,
+      final bool committed}) = _$ArrivalCollectSummaryImpl;
 
   factory _ArrivalCollectSummary.fromJson(Map<String, dynamic> json) =
       _$ArrivalCollectSummaryImpl.fromJson;
@@ -709,5 +669,5 @@ abstract class _ArrivalCollectSummary implements ArrivalCollectSummary {
   @override
   @JsonKey(ignore: true)
   _$$ArrivalCollectSummaryImplCopyWith<_$ArrivalCollectSummaryImpl>
-  get copyWith => throw _privateConstructorUsedError;
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.g.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_progress.g.dart
@@ -7,57 +7,57 @@ part of 'arrival_collect_progress.dart';
 // **************************************************************************
 
 _$ArrivalCollectProgressImpl _$$ArrivalCollectProgressImplFromJson(
-  Map<String, dynamic> json,
-) => _$ArrivalCollectProgressImpl(
-  id: json['id'] as String,
-  task: ArrivalCollectTask.fromJson(json['task'] as Map<String, dynamic>),
-  collectQty: (json['collectQty'] as num).toDouble(),
-  batchNo: json['batchNo'] as String?,
-  serialNumber: json['serialNumber'] as String?,
-  productionDate: json['productionDate'] as String?,
-  validDays: json['validDays'] as String?,
-  submitted: json['submitted'] as bool? ?? false,
-);
+        Map<String, dynamic> json) =>
+    _$ArrivalCollectProgressImpl(
+      id: json['id'] as String,
+      task: ArrivalCollectTask.fromJson(json['task'] as Map<String, dynamic>),
+      collectQty: (json['collectQty'] as num).toDouble(),
+      batchNo: json['batchNo'] as String?,
+      serialNumber: json['serialNumber'] as String?,
+      productionDate: json['productionDate'] as String?,
+      validDays: json['validDays'] as String?,
+      submitted: json['submitted'] as bool? ?? false,
+    );
 
 Map<String, dynamic> _$$ArrivalCollectProgressImplToJson(
-  _$ArrivalCollectProgressImpl instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'task': _taskToJson(instance.task),
-  'collectQty': instance.collectQty,
-  'batchNo': instance.batchNo,
-  'serialNumber': instance.serialNumber,
-  'productionDate': instance.productionDate,
-  'validDays': instance.validDays,
-  'submitted': instance.submitted,
-};
+        _$ArrivalCollectProgressImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'task': _taskToJson(instance.task),
+      'collectQty': instance.collectQty,
+      'batchNo': instance.batchNo,
+      'serialNumber': instance.serialNumber,
+      'productionDate': instance.productionDate,
+      'validDays': instance.validDays,
+      'submitted': instance.submitted,
+    };
 
 _$ArrivalCollectSummaryImpl _$$ArrivalCollectSummaryImplFromJson(
-  Map<String, dynamic> json,
-) => _$ArrivalCollectSummaryImpl(
-  id: json['id'] as String,
-  materialCode: json['materialCode'] as String,
-  materialName: json['materialName'] as String?,
-  batchNo: json['batchNo'] as String?,
-  serialNumber: json['serialNumber'] as String?,
-  collectQty: (json['collectQty'] as num?)?.toDouble(),
-  taskQty: (json['taskQty'] as num?)?.toDouble(),
-  productionDate: json['productionDate'] as String?,
-  validDays: json['validDays'] as String?,
-  committed: json['committed'] as bool? ?? false,
-);
+        Map<String, dynamic> json) =>
+    _$ArrivalCollectSummaryImpl(
+      id: json['id'] as String,
+      materialCode: json['materialCode'] as String,
+      materialName: json['materialName'] as String?,
+      batchNo: json['batchNo'] as String?,
+      serialNumber: json['serialNumber'] as String?,
+      collectQty: (json['collectQty'] as num?)?.toDouble(),
+      taskQty: (json['taskQty'] as num?)?.toDouble(),
+      productionDate: json['productionDate'] as String?,
+      validDays: json['validDays'] as String?,
+      committed: json['committed'] as bool? ?? false,
+    );
 
 Map<String, dynamic> _$$ArrivalCollectSummaryImplToJson(
-  _$ArrivalCollectSummaryImpl instance,
-) => <String, dynamic>{
-  'id': instance.id,
-  'materialCode': instance.materialCode,
-  'materialName': instance.materialName,
-  'batchNo': instance.batchNo,
-  'serialNumber': instance.serialNumber,
-  'collectQty': instance.collectQty,
-  'taskQty': instance.taskQty,
-  'productionDate': instance.productionDate,
-  'validDays': instance.validDays,
-  'committed': instance.committed,
-};
+        _$ArrivalCollectSummaryImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'materialCode': instance.materialCode,
+      'materialName': instance.materialName,
+      'batchNo': instance.batchNo,
+      'serialNumber': instance.serialNumber,
+      'collectQty': instance.collectQty,
+      'taskQty': instance.taskQty,
+      'productionDate': instance.productionDate,
+      'validDays': instance.validDays,
+      'committed': instance.committed,
+    };

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.freezed.dart
@@ -12,12 +12,10 @@ part of 'arrival_collect_submit_request.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 ArrivalCollectSubmitRequest _$ArrivalCollectSubmitRequestFromJson(
-  Map<String, dynamic> json,
-) {
+    Map<String, dynamic> json) {
   return _ArrivalCollectSubmitRequest.fromJson(json);
 }
 
@@ -35,36 +33,30 @@ mixin _$ArrivalCollectSubmitRequest {
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $ArrivalCollectSubmitRequestCopyWith<ArrivalCollectSubmitRequest>
-  get copyWith => throw _privateConstructorUsedError;
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $ArrivalCollectSubmitRequestCopyWith<$Res> {
   factory $ArrivalCollectSubmitRequestCopyWith(
-    ArrivalCollectSubmitRequest value,
-    $Res Function(ArrivalCollectSubmitRequest) then,
-  ) =
-      _$ArrivalCollectSubmitRequestCopyWithImpl<
-        $Res,
-        ArrivalCollectSubmitRequest
-      >;
+          ArrivalCollectSubmitRequest value,
+          $Res Function(ArrivalCollectSubmitRequest) then) =
+      _$ArrivalCollectSubmitRequestCopyWithImpl<$Res,
+          ArrivalCollectSubmitRequest>;
   @useResult
-  $Res call({
-    @JsonKey(name: 'upShelvesInfos')
-    List<ArrivalCollectSubmitItem> upShelvesInfos,
-    @JsonKey(name: 'itemListInfos')
-    List<ArrivalCollectSubmitItem> itemListInfos,
-    @JsonKey(name: 'filter') ArrivalCollectSubmitFilter? filter,
-  });
+  $Res call(
+      {@JsonKey(name: 'upShelvesInfos')
+      List<ArrivalCollectSubmitItem> upShelvesInfos,
+      @JsonKey(name: 'itemListInfos')
+      List<ArrivalCollectSubmitItem> itemListInfos,
+      @JsonKey(name: 'filter') ArrivalCollectSubmitFilter? filter});
 
   $ArrivalCollectSubmitFilterCopyWith<$Res>? get filter;
 }
 
 /// @nodoc
-class _$ArrivalCollectSubmitRequestCopyWithImpl<
-  $Res,
-  $Val extends ArrivalCollectSubmitRequest
->
+class _$ArrivalCollectSubmitRequestCopyWithImpl<$Res,
+        $Val extends ArrivalCollectSubmitRequest>
     implements $ArrivalCollectSubmitRequestCopyWith<$Res> {
   _$ArrivalCollectSubmitRequestCopyWithImpl(this._value, this._then);
 
@@ -80,23 +72,20 @@ class _$ArrivalCollectSubmitRequestCopyWithImpl<
     Object? itemListInfos = null,
     Object? filter = freezed,
   }) {
-    return _then(
-      _value.copyWith(
-            upShelvesInfos: null == upShelvesInfos
-                ? _value.upShelvesInfos
-                : upShelvesInfos // ignore: cast_nullable_to_non_nullable
-                      as List<ArrivalCollectSubmitItem>,
-            itemListInfos: null == itemListInfos
-                ? _value.itemListInfos
-                : itemListInfos // ignore: cast_nullable_to_non_nullable
-                      as List<ArrivalCollectSubmitItem>,
-            filter: freezed == filter
-                ? _value.filter
-                : filter // ignore: cast_nullable_to_non_nullable
-                      as ArrivalCollectSubmitFilter?,
-          )
-          as $Val,
-    );
+    return _then(_value.copyWith(
+      upShelvesInfos: null == upShelvesInfos
+          ? _value.upShelvesInfos
+          : upShelvesInfos // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectSubmitItem>,
+      itemListInfos: null == itemListInfos
+          ? _value.itemListInfos
+          : itemListInfos // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectSubmitItem>,
+      filter: freezed == filter
+          ? _value.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectSubmitFilter?,
+    ) as $Val);
   }
 
   @override
@@ -116,18 +105,17 @@ class _$ArrivalCollectSubmitRequestCopyWithImpl<
 abstract class _$$ArrivalCollectSubmitRequestImplCopyWith<$Res>
     implements $ArrivalCollectSubmitRequestCopyWith<$Res> {
   factory _$$ArrivalCollectSubmitRequestImplCopyWith(
-    _$ArrivalCollectSubmitRequestImpl value,
-    $Res Function(_$ArrivalCollectSubmitRequestImpl) then,
-  ) = __$$ArrivalCollectSubmitRequestImplCopyWithImpl<$Res>;
+          _$ArrivalCollectSubmitRequestImpl value,
+          $Res Function(_$ArrivalCollectSubmitRequestImpl) then) =
+      __$$ArrivalCollectSubmitRequestImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    @JsonKey(name: 'upShelvesInfos')
-    List<ArrivalCollectSubmitItem> upShelvesInfos,
-    @JsonKey(name: 'itemListInfos')
-    List<ArrivalCollectSubmitItem> itemListInfos,
-    @JsonKey(name: 'filter') ArrivalCollectSubmitFilter? filter,
-  });
+  $Res call(
+      {@JsonKey(name: 'upShelvesInfos')
+      List<ArrivalCollectSubmitItem> upShelvesInfos,
+      @JsonKey(name: 'itemListInfos')
+      List<ArrivalCollectSubmitItem> itemListInfos,
+      @JsonKey(name: 'filter') ArrivalCollectSubmitFilter? filter});
 
   @override
   $ArrivalCollectSubmitFilterCopyWith<$Res>? get filter;
@@ -135,16 +123,13 @@ abstract class _$$ArrivalCollectSubmitRequestImplCopyWith<$Res>
 
 /// @nodoc
 class __$$ArrivalCollectSubmitRequestImplCopyWithImpl<$Res>
-    extends
-        _$ArrivalCollectSubmitRequestCopyWithImpl<
-          $Res,
-          _$ArrivalCollectSubmitRequestImpl
-        >
+    extends _$ArrivalCollectSubmitRequestCopyWithImpl<$Res,
+        _$ArrivalCollectSubmitRequestImpl>
     implements _$$ArrivalCollectSubmitRequestImplCopyWith<$Res> {
   __$$ArrivalCollectSubmitRequestImplCopyWithImpl(
-    _$ArrivalCollectSubmitRequestImpl _value,
-    $Res Function(_$ArrivalCollectSubmitRequestImpl) _then,
-  ) : super(_value, _then);
+      _$ArrivalCollectSubmitRequestImpl _value,
+      $Res Function(_$ArrivalCollectSubmitRequestImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -153,22 +138,20 @@ class __$$ArrivalCollectSubmitRequestImplCopyWithImpl<$Res>
     Object? itemListInfos = null,
     Object? filter = freezed,
   }) {
-    return _then(
-      _$ArrivalCollectSubmitRequestImpl(
-        upShelvesInfos: null == upShelvesInfos
-            ? _value._upShelvesInfos
-            : upShelvesInfos // ignore: cast_nullable_to_non_nullable
-                  as List<ArrivalCollectSubmitItem>,
-        itemListInfos: null == itemListInfos
-            ? _value._itemListInfos
-            : itemListInfos // ignore: cast_nullable_to_non_nullable
-                  as List<ArrivalCollectSubmitItem>,
-        filter: freezed == filter
-            ? _value.filter
-            : filter // ignore: cast_nullable_to_non_nullable
-                  as ArrivalCollectSubmitFilter?,
-      ),
-    );
+    return _then(_$ArrivalCollectSubmitRequestImpl(
+      upShelvesInfos: null == upShelvesInfos
+          ? _value._upShelvesInfos
+          : upShelvesInfos // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectSubmitItem>,
+      itemListInfos: null == itemListInfos
+          ? _value._itemListInfos
+          : itemListInfos // ignore: cast_nullable_to_non_nullable
+              as List<ArrivalCollectSubmitItem>,
+      filter: freezed == filter
+          ? _value.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as ArrivalCollectSubmitFilter?,
+    ));
   }
 }
 
@@ -176,20 +159,20 @@ class __$$ArrivalCollectSubmitRequestImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$ArrivalCollectSubmitRequestImpl
     implements _ArrivalCollectSubmitRequest {
-  const _$ArrivalCollectSubmitRequestImpl({
-    @JsonKey(name: 'upShelvesInfos')
-    final List<ArrivalCollectSubmitItem> upShelvesInfos =
-        const <ArrivalCollectSubmitItem>[],
-    @JsonKey(name: 'itemListInfos')
-    final List<ArrivalCollectSubmitItem> itemListInfos =
-        const <ArrivalCollectSubmitItem>[],
-    @JsonKey(name: 'filter') this.filter,
-  }) : _upShelvesInfos = upShelvesInfos,
-       _itemListInfos = itemListInfos;
+  const _$ArrivalCollectSubmitRequestImpl(
+      {@JsonKey(name: 'upShelvesInfos')
+      final List<ArrivalCollectSubmitItem> upShelvesInfos =
+          const <ArrivalCollectSubmitItem>[],
+      @JsonKey(name: 'itemListInfos')
+      final List<ArrivalCollectSubmitItem> itemListInfos =
+          const <ArrivalCollectSubmitItem>[],
+      @JsonKey(name: 'filter') this.filter})
+      : _upShelvesInfos = upShelvesInfos,
+        _itemListInfos = itemListInfos;
 
   factory _$ArrivalCollectSubmitRequestImpl.fromJson(
-    Map<String, dynamic> json,
-  ) => _$$ArrivalCollectSubmitRequestImplFromJson(json);
+          Map<String, dynamic> json) =>
+      _$$ArrivalCollectSubmitRequestImplFromJson(json);
 
   final List<ArrivalCollectSubmitItem> _upShelvesInfos;
   @override
@@ -223,50 +206,45 @@ class _$ArrivalCollectSubmitRequestImpl
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$ArrivalCollectSubmitRequestImpl &&
-            const DeepCollectionEquality().equals(
-              other._upShelvesInfos,
-              _upShelvesInfos,
-            ) &&
-            const DeepCollectionEquality().equals(
-              other._itemListInfos,
-              _itemListInfos,
-            ) &&
+            const DeepCollectionEquality()
+                .equals(other._upShelvesInfos, _upShelvesInfos) &&
+            const DeepCollectionEquality()
+                .equals(other._itemListInfos, _itemListInfos) &&
             (identical(other.filter, filter) || other.filter == filter));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    const DeepCollectionEquality().hash(_upShelvesInfos),
-    const DeepCollectionEquality().hash(_itemListInfos),
-    filter,
-  );
+      runtimeType,
+      const DeepCollectionEquality().hash(_upShelvesInfos),
+      const DeepCollectionEquality().hash(_itemListInfos),
+      filter);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ArrivalCollectSubmitRequestImplCopyWith<_$ArrivalCollectSubmitRequestImpl>
-  get copyWith =>
-      __$$ArrivalCollectSubmitRequestImplCopyWithImpl<
-        _$ArrivalCollectSubmitRequestImpl
-      >(this, _$identity);
+      get copyWith => __$$ArrivalCollectSubmitRequestImplCopyWithImpl<
+          _$ArrivalCollectSubmitRequestImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ArrivalCollectSubmitRequestImplToJson(this);
+    return _$$ArrivalCollectSubmitRequestImplToJson(
+      this,
+    );
   }
 }
 
 abstract class _ArrivalCollectSubmitRequest
     implements ArrivalCollectSubmitRequest {
-  const factory _ArrivalCollectSubmitRequest({
-    @JsonKey(name: 'upShelvesInfos')
-    final List<ArrivalCollectSubmitItem> upShelvesInfos,
-    @JsonKey(name: 'itemListInfos')
-    final List<ArrivalCollectSubmitItem> itemListInfos,
-    @JsonKey(name: 'filter') final ArrivalCollectSubmitFilter? filter,
-  }) = _$ArrivalCollectSubmitRequestImpl;
+  const factory _ArrivalCollectSubmitRequest(
+          {@JsonKey(name: 'upShelvesInfos')
+          final List<ArrivalCollectSubmitItem> upShelvesInfos,
+          @JsonKey(name: 'itemListInfos')
+          final List<ArrivalCollectSubmitItem> itemListInfos,
+          @JsonKey(name: 'filter') final ArrivalCollectSubmitFilter? filter}) =
+      _$ArrivalCollectSubmitRequestImpl;
 
   factory _ArrivalCollectSubmitRequest.fromJson(Map<String, dynamic> json) =
       _$ArrivalCollectSubmitRequestImpl.fromJson;
@@ -283,12 +261,11 @@ abstract class _ArrivalCollectSubmitRequest
   @override
   @JsonKey(ignore: true)
   _$$ArrivalCollectSubmitRequestImplCopyWith<_$ArrivalCollectSubmitRequestImpl>
-  get copyWith => throw _privateConstructorUsedError;
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ArrivalCollectSubmitItem _$ArrivalCollectSubmitItemFromJson(
-  Map<String, dynamic> json,
-) {
+    Map<String, dynamic> json) {
   return _ArrivalCollectSubmitItem.fromJson(json);
 }
 
@@ -311,24 +288,20 @@ mixin _$ArrivalCollectSubmitItem {
 
 /// @nodoc
 abstract class $ArrivalCollectSubmitItemCopyWith<$Res> {
-  factory $ArrivalCollectSubmitItemCopyWith(
-    ArrivalCollectSubmitItem value,
-    $Res Function(ArrivalCollectSubmitItem) then,
-  ) = _$ArrivalCollectSubmitItemCopyWithImpl<$Res, ArrivalCollectSubmitItem>;
+  factory $ArrivalCollectSubmitItemCopyWith(ArrivalCollectSubmitItem value,
+          $Res Function(ArrivalCollectSubmitItem) then) =
+      _$ArrivalCollectSubmitItemCopyWithImpl<$Res, ArrivalCollectSubmitItem>;
   @useResult
-  $Res call({
-    @JsonKey(name: 'matcode') String matCode,
-    @JsonKey(name: 'batchno') String? batchNo,
-    @JsonKey(name: 'sn') String? serialNumber,
-    @JsonKey(name: 'qty') double quantity,
-  });
+  $Res call(
+      {@JsonKey(name: 'matcode') String matCode,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNumber,
+      @JsonKey(name: 'qty') double quantity});
 }
 
 /// @nodoc
-class _$ArrivalCollectSubmitItemCopyWithImpl<
-  $Res,
-  $Val extends ArrivalCollectSubmitItem
->
+class _$ArrivalCollectSubmitItemCopyWithImpl<$Res,
+        $Val extends ArrivalCollectSubmitItem>
     implements $ArrivalCollectSubmitItemCopyWith<$Res> {
   _$ArrivalCollectSubmitItemCopyWithImpl(this._value, this._then);
 
@@ -345,27 +318,24 @@ class _$ArrivalCollectSubmitItemCopyWithImpl<
     Object? serialNumber = freezed,
     Object? quantity = null,
   }) {
-    return _then(
-      _value.copyWith(
-            matCode: null == matCode
-                ? _value.matCode
-                : matCode // ignore: cast_nullable_to_non_nullable
-                      as String,
-            batchNo: freezed == batchNo
-                ? _value.batchNo
-                : batchNo // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            serialNumber: freezed == serialNumber
-                ? _value.serialNumber
-                : serialNumber // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            quantity: null == quantity
-                ? _value.quantity
-                : quantity // ignore: cast_nullable_to_non_nullable
-                      as double,
-          )
-          as $Val,
-    );
+    return _then(_value.copyWith(
+      matCode: null == matCode
+          ? _value.matCode
+          : matCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      quantity: null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double,
+    ) as $Val);
   }
 }
 
@@ -373,31 +343,27 @@ class _$ArrivalCollectSubmitItemCopyWithImpl<
 abstract class _$$ArrivalCollectSubmitItemImplCopyWith<$Res>
     implements $ArrivalCollectSubmitItemCopyWith<$Res> {
   factory _$$ArrivalCollectSubmitItemImplCopyWith(
-    _$ArrivalCollectSubmitItemImpl value,
-    $Res Function(_$ArrivalCollectSubmitItemImpl) then,
-  ) = __$$ArrivalCollectSubmitItemImplCopyWithImpl<$Res>;
+          _$ArrivalCollectSubmitItemImpl value,
+          $Res Function(_$ArrivalCollectSubmitItemImpl) then) =
+      __$$ArrivalCollectSubmitItemImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    @JsonKey(name: 'matcode') String matCode,
-    @JsonKey(name: 'batchno') String? batchNo,
-    @JsonKey(name: 'sn') String? serialNumber,
-    @JsonKey(name: 'qty') double quantity,
-  });
+  $Res call(
+      {@JsonKey(name: 'matcode') String matCode,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNumber,
+      @JsonKey(name: 'qty') double quantity});
 }
 
 /// @nodoc
 class __$$ArrivalCollectSubmitItemImplCopyWithImpl<$Res>
-    extends
-        _$ArrivalCollectSubmitItemCopyWithImpl<
-          $Res,
-          _$ArrivalCollectSubmitItemImpl
-        >
+    extends _$ArrivalCollectSubmitItemCopyWithImpl<$Res,
+        _$ArrivalCollectSubmitItemImpl>
     implements _$$ArrivalCollectSubmitItemImplCopyWith<$Res> {
   __$$ArrivalCollectSubmitItemImplCopyWithImpl(
-    _$ArrivalCollectSubmitItemImpl _value,
-    $Res Function(_$ArrivalCollectSubmitItemImpl) _then,
-  ) : super(_value, _then);
+      _$ArrivalCollectSubmitItemImpl _value,
+      $Res Function(_$ArrivalCollectSubmitItemImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -407,38 +373,35 @@ class __$$ArrivalCollectSubmitItemImplCopyWithImpl<$Res>
     Object? serialNumber = freezed,
     Object? quantity = null,
   }) {
-    return _then(
-      _$ArrivalCollectSubmitItemImpl(
-        matCode: null == matCode
-            ? _value.matCode
-            : matCode // ignore: cast_nullable_to_non_nullable
-                  as String,
-        batchNo: freezed == batchNo
-            ? _value.batchNo
-            : batchNo // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        serialNumber: freezed == serialNumber
-            ? _value.serialNumber
-            : serialNumber // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        quantity: null == quantity
-            ? _value.quantity
-            : quantity // ignore: cast_nullable_to_non_nullable
-                  as double,
-      ),
-    );
+    return _then(_$ArrivalCollectSubmitItemImpl(
+      matCode: null == matCode
+          ? _value.matCode
+          : matCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      quantity: null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$ArrivalCollectSubmitItemImpl implements _ArrivalCollectSubmitItem {
-  const _$ArrivalCollectSubmitItemImpl({
-    @JsonKey(name: 'matcode') required this.matCode,
-    @JsonKey(name: 'batchno') this.batchNo,
-    @JsonKey(name: 'sn') this.serialNumber,
-    @JsonKey(name: 'qty') required this.quantity,
-  });
+  const _$ArrivalCollectSubmitItemImpl(
+      {@JsonKey(name: 'matcode') required this.matCode,
+      @JsonKey(name: 'batchno') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNumber,
+      @JsonKey(name: 'qty') required this.quantity});
 
   factory _$ArrivalCollectSubmitItemImpl.fromJson(Map<String, dynamic> json) =>
       _$$ArrivalCollectSubmitItemImplFromJson(json);
@@ -483,24 +446,24 @@ class _$ArrivalCollectSubmitItemImpl implements _ArrivalCollectSubmitItem {
   @override
   @pragma('vm:prefer-inline')
   _$$ArrivalCollectSubmitItemImplCopyWith<_$ArrivalCollectSubmitItemImpl>
-  get copyWith =>
-      __$$ArrivalCollectSubmitItemImplCopyWithImpl<
-        _$ArrivalCollectSubmitItemImpl
-      >(this, _$identity);
+      get copyWith => __$$ArrivalCollectSubmitItemImplCopyWithImpl<
+          _$ArrivalCollectSubmitItemImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ArrivalCollectSubmitItemImplToJson(this);
+    return _$$ArrivalCollectSubmitItemImplToJson(
+      this,
+    );
   }
 }
 
 abstract class _ArrivalCollectSubmitItem implements ArrivalCollectSubmitItem {
-  const factory _ArrivalCollectSubmitItem({
-    @JsonKey(name: 'matcode') required final String matCode,
-    @JsonKey(name: 'batchno') final String? batchNo,
-    @JsonKey(name: 'sn') final String? serialNumber,
-    @JsonKey(name: 'qty') required final double quantity,
-  }) = _$ArrivalCollectSubmitItemImpl;
+  const factory _ArrivalCollectSubmitItem(
+          {@JsonKey(name: 'matcode') required final String matCode,
+          @JsonKey(name: 'batchno') final String? batchNo,
+          @JsonKey(name: 'sn') final String? serialNumber,
+          @JsonKey(name: 'qty') required final double quantity}) =
+      _$ArrivalCollectSubmitItemImpl;
 
   factory _ArrivalCollectSubmitItem.fromJson(Map<String, dynamic> json) =
       _$ArrivalCollectSubmitItemImpl.fromJson;
@@ -520,12 +483,11 @@ abstract class _ArrivalCollectSubmitItem implements ArrivalCollectSubmitItem {
   @override
   @JsonKey(ignore: true)
   _$$ArrivalCollectSubmitItemImplCopyWith<_$ArrivalCollectSubmitItemImpl>
-  get copyWith => throw _privateConstructorUsedError;
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 ArrivalCollectSubmitFilter _$ArrivalCollectSubmitFilterFromJson(
-  Map<String, dynamic> json,
-) {
+    Map<String, dynamic> json) {
   return _ArrivalCollectSubmitFilter.fromJson(json);
 }
 
@@ -539,31 +501,24 @@ mixin _$ArrivalCollectSubmitFilter {
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $ArrivalCollectSubmitFilterCopyWith<ArrivalCollectSubmitFilter>
-  get copyWith => throw _privateConstructorUsedError;
+      get copyWith => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
 abstract class $ArrivalCollectSubmitFilterCopyWith<$Res> {
-  factory $ArrivalCollectSubmitFilterCopyWith(
-    ArrivalCollectSubmitFilter value,
-    $Res Function(ArrivalCollectSubmitFilter) then,
-  ) =
-      _$ArrivalCollectSubmitFilterCopyWithImpl<
-        $Res,
-        ArrivalCollectSubmitFilter
-      >;
+  factory $ArrivalCollectSubmitFilterCopyWith(ArrivalCollectSubmitFilter value,
+          $Res Function(ArrivalCollectSubmitFilter) then) =
+      _$ArrivalCollectSubmitFilterCopyWithImpl<$Res,
+          ArrivalCollectSubmitFilter>;
   @useResult
-  $Res call({
-    @JsonKey(name: 'userCode') String userCode,
-    @JsonKey(name: 'arrivalsBillid') String arrivalsBillId,
-  });
+  $Res call(
+      {@JsonKey(name: 'userCode') String userCode,
+      @JsonKey(name: 'arrivalsBillid') String arrivalsBillId});
 }
 
 /// @nodoc
-class _$ArrivalCollectSubmitFilterCopyWithImpl<
-  $Res,
-  $Val extends ArrivalCollectSubmitFilter
->
+class _$ArrivalCollectSubmitFilterCopyWithImpl<$Res,
+        $Val extends ArrivalCollectSubmitFilter>
     implements $ArrivalCollectSubmitFilterCopyWith<$Res> {
   _$ArrivalCollectSubmitFilterCopyWithImpl(this._value, this._then);
 
@@ -574,20 +529,20 @@ class _$ArrivalCollectSubmitFilterCopyWithImpl<
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? userCode = null, Object? arrivalsBillId = null}) {
-    return _then(
-      _value.copyWith(
-            userCode: null == userCode
-                ? _value.userCode
-                : userCode // ignore: cast_nullable_to_non_nullable
-                      as String,
-            arrivalsBillId: null == arrivalsBillId
-                ? _value.arrivalsBillId
-                : arrivalsBillId // ignore: cast_nullable_to_non_nullable
-                      as String,
-          )
-          as $Val,
-    );
+  $Res call({
+    Object? userCode = null,
+    Object? arrivalsBillId = null,
+  }) {
+    return _then(_value.copyWith(
+      userCode: null == userCode
+          ? _value.userCode
+          : userCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      arrivalsBillId: null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
   }
 }
 
@@ -595,59 +550,55 @@ class _$ArrivalCollectSubmitFilterCopyWithImpl<
 abstract class _$$ArrivalCollectSubmitFilterImplCopyWith<$Res>
     implements $ArrivalCollectSubmitFilterCopyWith<$Res> {
   factory _$$ArrivalCollectSubmitFilterImplCopyWith(
-    _$ArrivalCollectSubmitFilterImpl value,
-    $Res Function(_$ArrivalCollectSubmitFilterImpl) then,
-  ) = __$$ArrivalCollectSubmitFilterImplCopyWithImpl<$Res>;
+          _$ArrivalCollectSubmitFilterImpl value,
+          $Res Function(_$ArrivalCollectSubmitFilterImpl) then) =
+      __$$ArrivalCollectSubmitFilterImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    @JsonKey(name: 'userCode') String userCode,
-    @JsonKey(name: 'arrivalsBillid') String arrivalsBillId,
-  });
+  $Res call(
+      {@JsonKey(name: 'userCode') String userCode,
+      @JsonKey(name: 'arrivalsBillid') String arrivalsBillId});
 }
 
 /// @nodoc
 class __$$ArrivalCollectSubmitFilterImplCopyWithImpl<$Res>
-    extends
-        _$ArrivalCollectSubmitFilterCopyWithImpl<
-          $Res,
-          _$ArrivalCollectSubmitFilterImpl
-        >
+    extends _$ArrivalCollectSubmitFilterCopyWithImpl<$Res,
+        _$ArrivalCollectSubmitFilterImpl>
     implements _$$ArrivalCollectSubmitFilterImplCopyWith<$Res> {
   __$$ArrivalCollectSubmitFilterImplCopyWithImpl(
-    _$ArrivalCollectSubmitFilterImpl _value,
-    $Res Function(_$ArrivalCollectSubmitFilterImpl) _then,
-  ) : super(_value, _then);
+      _$ArrivalCollectSubmitFilterImpl _value,
+      $Res Function(_$ArrivalCollectSubmitFilterImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
-  $Res call({Object? userCode = null, Object? arrivalsBillId = null}) {
-    return _then(
-      _$ArrivalCollectSubmitFilterImpl(
-        userCode: null == userCode
-            ? _value.userCode
-            : userCode // ignore: cast_nullable_to_non_nullable
-                  as String,
-        arrivalsBillId: null == arrivalsBillId
-            ? _value.arrivalsBillId
-            : arrivalsBillId // ignore: cast_nullable_to_non_nullable
-                  as String,
-      ),
-    );
+  $Res call({
+    Object? userCode = null,
+    Object? arrivalsBillId = null,
+  }) {
+    return _then(_$ArrivalCollectSubmitFilterImpl(
+      userCode: null == userCode
+          ? _value.userCode
+          : userCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      arrivalsBillId: null == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$ArrivalCollectSubmitFilterImpl implements _ArrivalCollectSubmitFilter {
-  const _$ArrivalCollectSubmitFilterImpl({
-    @JsonKey(name: 'userCode') required this.userCode,
-    @JsonKey(name: 'arrivalsBillid') required this.arrivalsBillId,
-  });
+  const _$ArrivalCollectSubmitFilterImpl(
+      {@JsonKey(name: 'userCode') required this.userCode,
+      @JsonKey(name: 'arrivalsBillid') required this.arrivalsBillId});
 
   factory _$ArrivalCollectSubmitFilterImpl.fromJson(
-    Map<String, dynamic> json,
-  ) => _$$ArrivalCollectSubmitFilterImplFromJson(json);
+          Map<String, dynamic> json) =>
+      _$$ArrivalCollectSubmitFilterImplFromJson(json);
 
   @override
   @JsonKey(name: 'userCode')
@@ -680,23 +631,23 @@ class _$ArrivalCollectSubmitFilterImpl implements _ArrivalCollectSubmitFilter {
   @override
   @pragma('vm:prefer-inline')
   _$$ArrivalCollectSubmitFilterImplCopyWith<_$ArrivalCollectSubmitFilterImpl>
-  get copyWith =>
-      __$$ArrivalCollectSubmitFilterImplCopyWithImpl<
-        _$ArrivalCollectSubmitFilterImpl
-      >(this, _$identity);
+      get copyWith => __$$ArrivalCollectSubmitFilterImplCopyWithImpl<
+          _$ArrivalCollectSubmitFilterImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ArrivalCollectSubmitFilterImplToJson(this);
+    return _$$ArrivalCollectSubmitFilterImplToJson(
+      this,
+    );
   }
 }
 
 abstract class _ArrivalCollectSubmitFilter
     implements ArrivalCollectSubmitFilter {
-  const factory _ArrivalCollectSubmitFilter({
-    @JsonKey(name: 'userCode') required final String userCode,
-    @JsonKey(name: 'arrivalsBillid') required final String arrivalsBillId,
-  }) = _$ArrivalCollectSubmitFilterImpl;
+  const factory _ArrivalCollectSubmitFilter(
+      {@JsonKey(name: 'userCode') required final String userCode,
+      @JsonKey(name: 'arrivalsBillid')
+      required final String arrivalsBillId}) = _$ArrivalCollectSubmitFilterImpl;
 
   factory _ArrivalCollectSubmitFilter.fromJson(Map<String, dynamic> json) =
       _$ArrivalCollectSubmitFilterImpl.fromJson;
@@ -710,5 +661,5 @@ abstract class _ArrivalCollectSubmitFilter
   @override
   @JsonKey(ignore: true)
   _$$ArrivalCollectSubmitFilterImplCopyWith<_$ArrivalCollectSubmitFilterImpl>
-  get copyWith => throw _privateConstructorUsedError;
+      get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.g.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_submit_request.g.dart
@@ -7,65 +7,60 @@ part of 'arrival_collect_submit_request.dart';
 // **************************************************************************
 
 _$ArrivalCollectSubmitRequestImpl _$$ArrivalCollectSubmitRequestImplFromJson(
-  Map<String, dynamic> json,
-) => _$ArrivalCollectSubmitRequestImpl(
-  upShelvesInfos:
-      (json['upShelvesInfos'] as List<dynamic>?)
-          ?.map(
-            (e) => ArrivalCollectSubmitItem.fromJson(e as Map<String, dynamic>),
-          )
-          .toList() ??
-      const <ArrivalCollectSubmitItem>[],
-  itemListInfos:
-      (json['itemListInfos'] as List<dynamic>?)
-          ?.map(
-            (e) => ArrivalCollectSubmitItem.fromJson(e as Map<String, dynamic>),
-          )
-          .toList() ??
-      const <ArrivalCollectSubmitItem>[],
-  filter: json['filter'] == null
-      ? null
-      : ArrivalCollectSubmitFilter.fromJson(
-          json['filter'] as Map<String, dynamic>,
-        ),
-);
+        Map<String, dynamic> json) =>
+    _$ArrivalCollectSubmitRequestImpl(
+      upShelvesInfos: (json['upShelvesInfos'] as List<dynamic>?)
+              ?.map((e) =>
+                  ArrivalCollectSubmitItem.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <ArrivalCollectSubmitItem>[],
+      itemListInfos: (json['itemListInfos'] as List<dynamic>?)
+              ?.map((e) =>
+                  ArrivalCollectSubmitItem.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <ArrivalCollectSubmitItem>[],
+      filter: json['filter'] == null
+          ? null
+          : ArrivalCollectSubmitFilter.fromJson(
+              json['filter'] as Map<String, dynamic>),
+    );
 
 Map<String, dynamic> _$$ArrivalCollectSubmitRequestImplToJson(
-  _$ArrivalCollectSubmitRequestImpl instance,
-) => <String, dynamic>{
-  'upShelvesInfos': instance.upShelvesInfos,
-  'itemListInfos': instance.itemListInfos,
-  'filter': instance.filter,
-};
+        _$ArrivalCollectSubmitRequestImpl instance) =>
+    <String, dynamic>{
+      'upShelvesInfos': instance.upShelvesInfos,
+      'itemListInfos': instance.itemListInfos,
+      'filter': instance.filter,
+    };
 
 _$ArrivalCollectSubmitItemImpl _$$ArrivalCollectSubmitItemImplFromJson(
-  Map<String, dynamic> json,
-) => _$ArrivalCollectSubmitItemImpl(
-  matCode: json['matcode'] as String,
-  batchNo: json['batchno'] as String?,
-  serialNumber: json['sn'] as String?,
-  quantity: (json['qty'] as num).toDouble(),
-);
+        Map<String, dynamic> json) =>
+    _$ArrivalCollectSubmitItemImpl(
+      matCode: json['matcode'] as String,
+      batchNo: json['batchno'] as String?,
+      serialNumber: json['sn'] as String?,
+      quantity: (json['qty'] as num).toDouble(),
+    );
 
 Map<String, dynamic> _$$ArrivalCollectSubmitItemImplToJson(
-  _$ArrivalCollectSubmitItemImpl instance,
-) => <String, dynamic>{
-  'matcode': instance.matCode,
-  'batchno': instance.batchNo,
-  'sn': instance.serialNumber,
-  'qty': instance.quantity,
-};
+        _$ArrivalCollectSubmitItemImpl instance) =>
+    <String, dynamic>{
+      'matcode': instance.matCode,
+      'batchno': instance.batchNo,
+      'sn': instance.serialNumber,
+      'qty': instance.quantity,
+    };
 
 _$ArrivalCollectSubmitFilterImpl _$$ArrivalCollectSubmitFilterImplFromJson(
-  Map<String, dynamic> json,
-) => _$ArrivalCollectSubmitFilterImpl(
-  userCode: json['userCode'] as String,
-  arrivalsBillId: json['arrivalsBillid'] as String,
-);
+        Map<String, dynamic> json) =>
+    _$ArrivalCollectSubmitFilterImpl(
+      userCode: json['userCode'] as String,
+      arrivalsBillId: json['arrivalsBillid'] as String,
+    );
 
 Map<String, dynamic> _$$ArrivalCollectSubmitFilterImplToJson(
-  _$ArrivalCollectSubmitFilterImpl instance,
-) => <String, dynamic>{
-  'userCode': instance.userCode,
-  'arrivalsBillid': instance.arrivalsBillId,
-};
+        _$ArrivalCollectSubmitFilterImpl instance) =>
+    <String, dynamic>{
+      'userCode': instance.userCode,
+      'arrivalsBillid': instance.arrivalsBillId,
+    };

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.freezed.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.freezed.dart
@@ -12,8 +12,7 @@ part of 'arrival_collect_task.dart';
 T _$identity<T>(T value) => value;
 
 final _privateConstructorUsedError = UnsupportedError(
-  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
-);
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 ArrivalCollectTask _$ArrivalCollectTaskFromJson(Map<String, dynamic> json) {
   return _ArrivalCollectTask.fromJson(json);
@@ -89,27 +88,25 @@ mixin _$ArrivalCollectTask {
 /// @nodoc
 abstract class $ArrivalCollectTaskCopyWith<$Res> {
   factory $ArrivalCollectTaskCopyWith(
-    ArrivalCollectTask value,
-    $Res Function(ArrivalCollectTask) then,
-  ) = _$ArrivalCollectTaskCopyWithImpl<$Res, ArrivalCollectTask>;
+          ArrivalCollectTask value, $Res Function(ArrivalCollectTask) then) =
+      _$ArrivalCollectTaskCopyWithImpl<$Res, ArrivalCollectTask>;
   @useResult
-  $Res call({
-    @JsonKey(name: 'matcode') String materialCode,
-    @JsonKey(name: 'matname') String? materialName,
-    @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
-    @JsonKey(name: 'arrivalsBillid') String? arrivalsBillId,
-    @JsonKey(name: 'orderno') String? orderNo,
-    @JsonKey(name: 'qty') double plannedQuantity,
-    @JsonKey(name: 'goodqty') double collectedQuantity,
-    @JsonKey(ignore: true) double baseCollectedQuantity,
-    @JsonKey(name: 'meins') String? unit,
-    @JsonKey(name: 'batchno') String? batchNo,
-    String? serialNumber,
-    @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
-    @JsonKey(name: 'matcodecontrol') int? materialControlType,
-    @JsonKey(name: 'pdate') String? productionDate,
-    @JsonKey(name: 'vdays') String? validDays,
-  });
+  $Res call(
+      {@JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
+      @JsonKey(name: 'arrivalsBillid') String? arrivalsBillId,
+      @JsonKey(name: 'orderno') String? orderNo,
+      @JsonKey(name: 'qty') double plannedQuantity,
+      @JsonKey(name: 'goodqty') double collectedQuantity,
+      @JsonKey(ignore: true) double baseCollectedQuantity,
+      @JsonKey(name: 'meins') String? unit,
+      @JsonKey(name: 'batchno') String? batchNo,
+      String? serialNumber,
+      @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
+      @JsonKey(name: 'matcodecontrol') int? materialControlType,
+      @JsonKey(name: 'pdate') String? productionDate,
+      @JsonKey(name: 'vdays') String? validDays});
 }
 
 /// @nodoc
@@ -141,110 +138,104 @@ class _$ArrivalCollectTaskCopyWithImpl<$Res, $Val extends ArrivalCollectTask>
     Object? productionDate = freezed,
     Object? validDays = freezed,
   }) {
-    return _then(
-      _value.copyWith(
-            materialCode: null == materialCode
-                ? _value.materialCode
-                : materialCode // ignore: cast_nullable_to_non_nullable
-                      as String,
-            materialName: freezed == materialName
-                ? _value.materialName
-                : materialName // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            arrivalsBillNo: freezed == arrivalsBillNo
-                ? _value.arrivalsBillNo
-                : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            arrivalsBillId: freezed == arrivalsBillId
-                ? _value.arrivalsBillId
-                : arrivalsBillId // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            orderNo: freezed == orderNo
-                ? _value.orderNo
-                : orderNo // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            plannedQuantity: null == plannedQuantity
-                ? _value.plannedQuantity
-                : plannedQuantity // ignore: cast_nullable_to_non_nullable
-                      as double,
-            collectedQuantity: null == collectedQuantity
-                ? _value.collectedQuantity
-                : collectedQuantity // ignore: cast_nullable_to_non_nullable
-                      as double,
-            baseCollectedQuantity: null == baseCollectedQuantity
-                ? _value.baseCollectedQuantity
-                : baseCollectedQuantity // ignore: cast_nullable_to_non_nullable
-                      as double,
-            unit: freezed == unit
-                ? _value.unit
-                : unit // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            batchNo: freezed == batchNo
-                ? _value.batchNo
-                : batchNo // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            serialNumber: freezed == serialNumber
-                ? _value.serialNumber
-                : serialNumber // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            subInventoryCode: freezed == subInventoryCode
-                ? _value.subInventoryCode
-                : subInventoryCode // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            materialControlType: freezed == materialControlType
-                ? _value.materialControlType
-                : materialControlType // ignore: cast_nullable_to_non_nullable
-                      as int?,
-            productionDate: freezed == productionDate
-                ? _value.productionDate
-                : productionDate // ignore: cast_nullable_to_non_nullable
-                      as String?,
-            validDays: freezed == validDays
-                ? _value.validDays
-                : validDays // ignore: cast_nullable_to_non_nullable
-                      as String?,
-          )
-          as $Val,
-    );
+    return _then(_value.copyWith(
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      arrivalsBillNo: freezed == arrivalsBillNo
+          ? _value.arrivalsBillNo
+          : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      arrivalsBillId: freezed == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      orderNo: freezed == orderNo
+          ? _value.orderNo
+          : orderNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      plannedQuantity: null == plannedQuantity
+          ? _value.plannedQuantity
+          : plannedQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      collectedQuantity: null == collectedQuantity
+          ? _value.collectedQuantity
+          : collectedQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      baseCollectedQuantity: null == baseCollectedQuantity
+          ? _value.baseCollectedQuantity
+          : baseCollectedQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      unit: freezed == unit
+          ? _value.unit
+          : unit // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      subInventoryCode: freezed == subInventoryCode
+          ? _value.subInventoryCode
+          : subInventoryCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialControlType: freezed == materialControlType
+          ? _value.materialControlType
+          : materialControlType // ignore: cast_nullable_to_non_nullable
+              as int?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
   }
 }
 
 /// @nodoc
 abstract class _$$ArrivalCollectTaskImplCopyWith<$Res>
     implements $ArrivalCollectTaskCopyWith<$Res> {
-  factory _$$ArrivalCollectTaskImplCopyWith(
-    _$ArrivalCollectTaskImpl value,
-    $Res Function(_$ArrivalCollectTaskImpl) then,
-  ) = __$$ArrivalCollectTaskImplCopyWithImpl<$Res>;
+  factory _$$ArrivalCollectTaskImplCopyWith(_$ArrivalCollectTaskImpl value,
+          $Res Function(_$ArrivalCollectTaskImpl) then) =
+      __$$ArrivalCollectTaskImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    @JsonKey(name: 'matcode') String materialCode,
-    @JsonKey(name: 'matname') String? materialName,
-    @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
-    @JsonKey(name: 'arrivalsBillid') String? arrivalsBillId,
-    @JsonKey(name: 'orderno') String? orderNo,
-    @JsonKey(name: 'qty') double plannedQuantity,
-    @JsonKey(name: 'goodqty') double collectedQuantity,
-    @JsonKey(ignore: true) double baseCollectedQuantity,
-    @JsonKey(name: 'meins') String? unit,
-    @JsonKey(name: 'batchno') String? batchNo,
-    String? serialNumber,
-    @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
-    @JsonKey(name: 'matcodecontrol') int? materialControlType,
-    @JsonKey(name: 'pdate') String? productionDate,
-    @JsonKey(name: 'vdays') String? validDays,
-  });
+  $Res call(
+      {@JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'arrivalsBillno') String? arrivalsBillNo,
+      @JsonKey(name: 'arrivalsBillid') String? arrivalsBillId,
+      @JsonKey(name: 'orderno') String? orderNo,
+      @JsonKey(name: 'qty') double plannedQuantity,
+      @JsonKey(name: 'goodqty') double collectedQuantity,
+      @JsonKey(ignore: true) double baseCollectedQuantity,
+      @JsonKey(name: 'meins') String? unit,
+      @JsonKey(name: 'batchno') String? batchNo,
+      String? serialNumber,
+      @JsonKey(name: 'subinventoryCode') String? subInventoryCode,
+      @JsonKey(name: 'matcodecontrol') int? materialControlType,
+      @JsonKey(name: 'pdate') String? productionDate,
+      @JsonKey(name: 'vdays') String? validDays});
 }
 
 /// @nodoc
 class __$$ArrivalCollectTaskImplCopyWithImpl<$Res>
     extends _$ArrivalCollectTaskCopyWithImpl<$Res, _$ArrivalCollectTaskImpl>
     implements _$$ArrivalCollectTaskImplCopyWith<$Res> {
-  __$$ArrivalCollectTaskImplCopyWithImpl(
-    _$ArrivalCollectTaskImpl _value,
-    $Res Function(_$ArrivalCollectTaskImpl) _then,
-  ) : super(_value, _then);
+  __$$ArrivalCollectTaskImplCopyWithImpl(_$ArrivalCollectTaskImpl _value,
+      $Res Function(_$ArrivalCollectTaskImpl) _then)
+      : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
@@ -265,93 +256,91 @@ class __$$ArrivalCollectTaskImplCopyWithImpl<$Res>
     Object? productionDate = freezed,
     Object? validDays = freezed,
   }) {
-    return _then(
-      _$ArrivalCollectTaskImpl(
-        materialCode: null == materialCode
-            ? _value.materialCode
-            : materialCode // ignore: cast_nullable_to_non_nullable
-                  as String,
-        materialName: freezed == materialName
-            ? _value.materialName
-            : materialName // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        arrivalsBillNo: freezed == arrivalsBillNo
-            ? _value.arrivalsBillNo
-            : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        arrivalsBillId: freezed == arrivalsBillId
-            ? _value.arrivalsBillId
-            : arrivalsBillId // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        orderNo: freezed == orderNo
-            ? _value.orderNo
-            : orderNo // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        plannedQuantity: null == plannedQuantity
-            ? _value.plannedQuantity
-            : plannedQuantity // ignore: cast_nullable_to_non_nullable
-                  as double,
-        collectedQuantity: null == collectedQuantity
-            ? _value.collectedQuantity
-            : collectedQuantity // ignore: cast_nullable_to_non_nullable
-                  as double,
-        baseCollectedQuantity: null == baseCollectedQuantity
-            ? _value.baseCollectedQuantity
-            : baseCollectedQuantity // ignore: cast_nullable_to_non_nullable
-                  as double,
-        unit: freezed == unit
-            ? _value.unit
-            : unit // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        batchNo: freezed == batchNo
-            ? _value.batchNo
-            : batchNo // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        serialNumber: freezed == serialNumber
-            ? _value.serialNumber
-            : serialNumber // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        subInventoryCode: freezed == subInventoryCode
-            ? _value.subInventoryCode
-            : subInventoryCode // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        materialControlType: freezed == materialControlType
-            ? _value.materialControlType
-            : materialControlType // ignore: cast_nullable_to_non_nullable
-                  as int?,
-        productionDate: freezed == productionDate
-            ? _value.productionDate
-            : productionDate // ignore: cast_nullable_to_non_nullable
-                  as String?,
-        validDays: freezed == validDays
-            ? _value.validDays
-            : validDays // ignore: cast_nullable_to_non_nullable
-                  as String?,
-      ),
-    );
+    return _then(_$ArrivalCollectTaskImpl(
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      arrivalsBillNo: freezed == arrivalsBillNo
+          ? _value.arrivalsBillNo
+          : arrivalsBillNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      arrivalsBillId: freezed == arrivalsBillId
+          ? _value.arrivalsBillId
+          : arrivalsBillId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      orderNo: freezed == orderNo
+          ? _value.orderNo
+          : orderNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      plannedQuantity: null == plannedQuantity
+          ? _value.plannedQuantity
+          : plannedQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      collectedQuantity: null == collectedQuantity
+          ? _value.collectedQuantity
+          : collectedQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      baseCollectedQuantity: null == baseCollectedQuantity
+          ? _value.baseCollectedQuantity
+          : baseCollectedQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      unit: freezed == unit
+          ? _value.unit
+          : unit // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNumber: freezed == serialNumber
+          ? _value.serialNumber
+          : serialNumber // ignore: cast_nullable_to_non_nullable
+              as String?,
+      subInventoryCode: freezed == subInventoryCode
+          ? _value.subInventoryCode
+          : subInventoryCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialControlType: freezed == materialControlType
+          ? _value.materialControlType
+          : materialControlType // ignore: cast_nullable_to_non_nullable
+              as int?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as String?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
   }
 }
 
 /// @nodoc
 @JsonSerializable()
 class _$ArrivalCollectTaskImpl extends _ArrivalCollectTask {
-  const _$ArrivalCollectTaskImpl({
-    @JsonKey(name: 'matcode') required this.materialCode,
-    @JsonKey(name: 'matname') this.materialName,
-    @JsonKey(name: 'arrivalsBillno') this.arrivalsBillNo,
-    @JsonKey(name: 'arrivalsBillid') this.arrivalsBillId,
-    @JsonKey(name: 'orderno') this.orderNo,
-    @JsonKey(name: 'qty') required this.plannedQuantity,
-    @JsonKey(name: 'goodqty') required this.collectedQuantity,
-    @JsonKey(ignore: true) this.baseCollectedQuantity = 0,
-    @JsonKey(name: 'meins') this.unit,
-    @JsonKey(name: 'batchno') this.batchNo,
-    this.serialNumber,
-    @JsonKey(name: 'subinventoryCode') this.subInventoryCode,
-    @JsonKey(name: 'matcodecontrol') this.materialControlType,
-    @JsonKey(name: 'pdate') this.productionDate,
-    @JsonKey(name: 'vdays') this.validDays,
-  }) : super._();
+  const _$ArrivalCollectTaskImpl(
+      {@JsonKey(name: 'matcode') required this.materialCode,
+      @JsonKey(name: 'matname') this.materialName,
+      @JsonKey(name: 'arrivalsBillno') this.arrivalsBillNo,
+      @JsonKey(name: 'arrivalsBillid') this.arrivalsBillId,
+      @JsonKey(name: 'orderno') this.orderNo,
+      @JsonKey(name: 'qty') required this.plannedQuantity,
+      @JsonKey(name: 'goodqty') required this.collectedQuantity,
+      @JsonKey(ignore: true) this.baseCollectedQuantity = 0,
+      @JsonKey(name: 'meins') this.unit,
+      @JsonKey(name: 'batchno') this.batchNo,
+      this.serialNumber,
+      @JsonKey(name: 'subinventoryCode') this.subInventoryCode,
+      @JsonKey(name: 'matcodecontrol') this.materialControlType,
+      @JsonKey(name: 'pdate') this.productionDate,
+      @JsonKey(name: 'vdays') this.validDays})
+      : super._();
 
   factory _$ArrivalCollectTaskImpl.fromJson(Map<String, dynamic> json) =>
       _$$ArrivalCollectTaskImplFromJson(json);
@@ -472,118 +461,132 @@ class _$ArrivalCollectTaskImpl extends _ArrivalCollectTask {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-    runtimeType,
-    materialCode,
-    materialName,
-    arrivalsBillNo,
-    arrivalsBillId,
-    orderNo,
-    plannedQuantity,
-    collectedQuantity,
-    baseCollectedQuantity,
-    unit,
-    batchNo,
-    serialNumber,
-    subInventoryCode,
-    materialControlType,
-    productionDate,
-    validDays,
-  );
+      runtimeType,
+      materialCode,
+      materialName,
+      arrivalsBillNo,
+      arrivalsBillId,
+      orderNo,
+      plannedQuantity,
+      collectedQuantity,
+      baseCollectedQuantity,
+      unit,
+      batchNo,
+      serialNumber,
+      subInventoryCode,
+      materialControlType,
+      productionDate,
+      validDays);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
   _$$ArrivalCollectTaskImplCopyWith<_$ArrivalCollectTaskImpl> get copyWith =>
       __$$ArrivalCollectTaskImplCopyWithImpl<_$ArrivalCollectTaskImpl>(
-        this,
-        _$identity,
-      );
+          this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$ArrivalCollectTaskImplToJson(this);
+    return _$$ArrivalCollectTaskImplToJson(
+      this,
+    );
   }
 }
 
 abstract class _ArrivalCollectTask extends ArrivalCollectTask {
-  const factory _ArrivalCollectTask({
-    @JsonKey(name: 'matcode') required final String materialCode,
-    @JsonKey(name: 'matname') final String? materialName,
-    @JsonKey(name: 'arrivalsBillno') final String? arrivalsBillNo,
-    @JsonKey(name: 'arrivalsBillid') final String? arrivalsBillId,
-    @JsonKey(name: 'orderno') final String? orderNo,
-    @JsonKey(name: 'qty') required final double plannedQuantity,
-    @JsonKey(name: 'goodqty') required final double collectedQuantity,
-    @JsonKey(ignore: true) final double baseCollectedQuantity,
-    @JsonKey(name: 'meins') final String? unit,
-    @JsonKey(name: 'batchno') final String? batchNo,
-    final String? serialNumber,
-    @JsonKey(name: 'subinventoryCode') final String? subInventoryCode,
-    @JsonKey(name: 'matcodecontrol') final int? materialControlType,
-    @JsonKey(name: 'pdate') final String? productionDate,
-    @JsonKey(name: 'vdays') final String? validDays,
-  }) = _$ArrivalCollectTaskImpl;
+  const factory _ArrivalCollectTask(
+          {@JsonKey(name: 'matcode') required final String materialCode,
+          @JsonKey(name: 'matname') final String? materialName,
+          @JsonKey(name: 'arrivalsBillno') final String? arrivalsBillNo,
+          @JsonKey(name: 'arrivalsBillid') final String? arrivalsBillId,
+          @JsonKey(name: 'orderno') final String? orderNo,
+          @JsonKey(name: 'qty') required final double plannedQuantity,
+          @JsonKey(name: 'goodqty') required final double collectedQuantity,
+          @JsonKey(ignore: true) final double baseCollectedQuantity,
+          @JsonKey(name: 'meins') final String? unit,
+          @JsonKey(name: 'batchno') final String? batchNo,
+          final String? serialNumber,
+          @JsonKey(name: 'subinventoryCode') final String? subInventoryCode,
+          @JsonKey(name: 'matcodecontrol') final int? materialControlType,
+          @JsonKey(name: 'pdate') final String? productionDate,
+          @JsonKey(name: 'vdays') final String? validDays}) =
+      _$ArrivalCollectTaskImpl;
   const _ArrivalCollectTask._() : super._();
 
   factory _ArrivalCollectTask.fromJson(Map<String, dynamic> json) =
       _$ArrivalCollectTaskImpl.fromJson;
 
   @override
+
   /// 物料编码
   @JsonKey(name: 'matcode')
   String get materialCode;
   @override
+
   /// 物料名称
   @JsonKey(name: 'matname')
   String? get materialName;
   @override
+
   /// 到货单号
   @JsonKey(name: 'arrivalsBillno')
   String? get arrivalsBillNo;
   @override
+
   /// 到货单行ID
   @JsonKey(name: 'arrivalsBillid')
   String? get arrivalsBillId;
   @override
+
   /// 采购单号
   @JsonKey(name: 'orderno')
   String? get orderNo;
   @override
+
   /// 计划数量
   @JsonKey(name: 'qty')
   double get plannedQuantity;
   @override
+
   /// 已良品数量
   @JsonKey(name: 'goodqty')
   double get collectedQuantity;
   @override
+
   /// 初始良品数量（用于删除/恢复时回写）
   @JsonKey(ignore: true)
   double get baseCollectedQuantity;
   @override
+
   /// 单位
   @JsonKey(name: 'meins')
   String? get unit;
   @override
+
   /// 批次号
   @JsonKey(name: 'batchno')
   String? get batchNo;
   @override
+
   /// 序列号
   String? get serialNumber;
   @override
+
   /// 库位编码
   @JsonKey(name: 'subinventoryCode')
   String? get subInventoryCode;
   @override
+
   /// 物料控制类型（0 无、1 批次、2 序列）
   @JsonKey(name: 'matcodecontrol')
   int? get materialControlType;
   @override
+
   /// 生产日期
   @JsonKey(name: 'pdate')
   String? get productionDate;
   @override
+
   /// 有效天数
   @JsonKey(name: 'vdays')
   String? get validDays;

--- a/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.g.dart
+++ b/lib/modules/arrival_sign/task_collect/models/arrival_collect_task.g.dart
@@ -7,39 +7,39 @@ part of 'arrival_collect_task.dart';
 // **************************************************************************
 
 _$ArrivalCollectTaskImpl _$$ArrivalCollectTaskImplFromJson(
-  Map<String, dynamic> json,
-) => _$ArrivalCollectTaskImpl(
-  materialCode: json['matcode'] as String,
-  materialName: json['matname'] as String?,
-  arrivalsBillNo: json['arrivalsBillno'] as String?,
-  arrivalsBillId: json['arrivalsBillid'] as String?,
-  orderNo: json['orderno'] as String?,
-  plannedQuantity: (json['qty'] as num).toDouble(),
-  collectedQuantity: (json['goodqty'] as num).toDouble(),
-  unit: json['meins'] as String?,
-  batchNo: json['batchno'] as String?,
-  serialNumber: json['serialNumber'] as String?,
-  subInventoryCode: json['subinventoryCode'] as String?,
-  materialControlType: (json['matcodecontrol'] as num?)?.toInt(),
-  productionDate: json['pdate'] as String?,
-  validDays: json['vdays'] as String?,
-);
+        Map<String, dynamic> json) =>
+    _$ArrivalCollectTaskImpl(
+      materialCode: json['matcode'] as String,
+      materialName: json['matname'] as String?,
+      arrivalsBillNo: json['arrivalsBillno'] as String?,
+      arrivalsBillId: json['arrivalsBillid'] as String?,
+      orderNo: json['orderno'] as String?,
+      plannedQuantity: (json['qty'] as num).toDouble(),
+      collectedQuantity: (json['goodqty'] as num).toDouble(),
+      unit: json['meins'] as String?,
+      batchNo: json['batchno'] as String?,
+      serialNumber: json['serialNumber'] as String?,
+      subInventoryCode: json['subinventoryCode'] as String?,
+      materialControlType: (json['matcodecontrol'] as num?)?.toInt(),
+      productionDate: json['pdate'] as String?,
+      validDays: json['vdays'] as String?,
+    );
 
 Map<String, dynamic> _$$ArrivalCollectTaskImplToJson(
-  _$ArrivalCollectTaskImpl instance,
-) => <String, dynamic>{
-  'matcode': instance.materialCode,
-  'matname': instance.materialName,
-  'arrivalsBillno': instance.arrivalsBillNo,
-  'arrivalsBillid': instance.arrivalsBillId,
-  'orderno': instance.orderNo,
-  'qty': instance.plannedQuantity,
-  'goodqty': instance.collectedQuantity,
-  'meins': instance.unit,
-  'batchno': instance.batchNo,
-  'serialNumber': instance.serialNumber,
-  'subinventoryCode': instance.subInventoryCode,
-  'matcodecontrol': instance.materialControlType,
-  'pdate': instance.productionDate,
-  'vdays': instance.validDays,
-};
+        _$ArrivalCollectTaskImpl instance) =>
+    <String, dynamic>{
+      'matcode': instance.materialCode,
+      'matname': instance.materialName,
+      'arrivalsBillno': instance.arrivalsBillNo,
+      'arrivalsBillid': instance.arrivalsBillId,
+      'orderno': instance.orderNo,
+      'qty': instance.plannedQuantity,
+      'goodqty': instance.collectedQuantity,
+      'meins': instance.unit,
+      'batchno': instance.batchNo,
+      'serialNumber': instance.serialNumber,
+      'subinventoryCode': instance.subInventoryCode,
+      'matcodecontrol': instance.materialControlType,
+      'pdate': instance.productionDate,
+      'vdays': instance.validDays,
+    };

--- a/lib/modules/aswh_inventory/aswh_inventory_module.dart
+++ b/lib/modules/aswh_inventory/aswh_inventory_module.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../app_module.dart';
+import '../../services/dio_client.dart';
+import '../../services/user_manager.dart';
+import 'collection_task/aswh_inventory_collect_page.dart';
+import 'collection_task/bloc/aswh_inventory_collect_bloc.dart';
+import 'collection_task/collect_detail/aswh_inventory_collect_detail_page.dart';
+import 'collection_task/collect_detail/bloc/aswh_inventory_collect_detail_bloc.dart';
+import 'collection_task/repositories/inventory_collect_cache_repository.dart';
+import 'collection_task/services/aswh_inventory_collect_service.dart';
+import 'command_list/aswh_inventory_command_page.dart';
+import 'command_list/bloc/aswh_inventory_command_bloc.dart';
+import 'command_list/services/aswh_inventory_command_service.dart';
+import 'pallet_item/aswh_inventory_pallet_item_page.dart';
+import 'pallet_item/bloc/aswh_inventory_pallet_item_bloc.dart';
+import 'pallet_item/services/aswh_inventory_pallet_service.dart';
+import 'services/aswh_inventory_task_service.dart';
+import 'task_list/aswh_inventory_task_list_page.dart';
+import 'task_list/bloc/aswh_inventory_task_list_bloc.dart';
+import 'task_receive/aswh_inventory_receive_page.dart';
+import 'task_receive/bloc/aswh_inventory_receive_bloc.dart';
+
+class AswhInventoryModule extends Module {
+  @override
+  List<Module> get imports => [AppModule()];
+
+  @override
+  void binds(Injector i) {
+    i.addSingleton<AswhInventoryTaskService>(
+      () => AswhInventoryTaskService(i.get<DioClient>().dio),
+    );
+
+    i.addSingleton<AswhInventoryCollectService>(
+      () => AswhInventoryCollectService(i.get<DioClient>().dio),
+    );
+
+    i.addSingleton<AswhInventoryCommandService>(
+      () => AswhInventoryCommandService(i.get<DioClient>().dio),
+    );
+
+    i.addSingleton<AswhInventoryPalletService>(
+      () => AswhInventoryPalletService(i.get<DioClient>().dio),
+    );
+
+    i.addSingleton<InventoryCollectCacheRepository>(
+      InventoryCollectCacheRepository.new,
+    );
+
+    i.add<AswhInventoryTaskListBloc>(
+      () => AswhInventoryTaskListBloc(
+        taskService: i.get<AswhInventoryTaskService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+
+    i.add<AswhInventoryCollectBloc>(
+      () => AswhInventoryCollectBloc(
+        collectService: i.get<AswhInventoryCollectService>(),
+        cacheRepository: i.get<InventoryCollectCacheRepository>(),
+      ),
+    );
+
+    i.add<AswhInventoryCollectDetailBloc>(
+      () => AswhInventoryCollectDetailBloc(
+        cacheRepository: i.get<InventoryCollectCacheRepository>(),
+      ),
+    );
+
+    i.add<AswhInventoryReceiveBloc>(
+      () => AswhInventoryReceiveBloc(
+        taskService: i.get<AswhInventoryTaskService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+
+    i.add<AswhInventoryCommandBloc>(
+      () => AswhInventoryCommandBloc(
+        commandService: i.get<AswhInventoryCommandService>(),
+      ),
+    );
+
+    i.add<AswhInventoryPalletItemBloc>(
+      () => AswhInventoryPalletItemBloc(
+        service: i.get<AswhInventoryPalletService>(),
+      ),
+    );
+  }
+
+  @override
+  void routes(RouteManager r) {
+    r.child(
+      '/',
+      child: (context) => BlocProvider(
+        create: (context) => Modular.get<AswhInventoryTaskListBloc>(),
+        child: const AswhInventoryTaskListPage(),
+      ),
+    );
+
+    r.child(
+      '/collect/:taskId',
+      child: (context) => BlocProvider(
+        create: (context) => Modular.get<AswhInventoryCollectBloc>(),
+        child: const AswhInventoryCollectPage(),
+      ),
+    );
+
+    r.child(
+      '/collect/result',
+      child: (context) => BlocProvider(
+        create: (context) => Modular.get<AswhInventoryCollectDetailBloc>(),
+        child: const AswhInventoryCollectDetailPage(),
+      ),
+    );
+
+    r.child(
+      '/receive',
+      child: (context) => BlocProvider(
+        create: (context) => Modular.get<AswhInventoryReceiveBloc>(),
+        child: const AswhInventoryReceivePage(),
+      ),
+    );
+
+    r.child(
+      '/commands',
+      child: (context) => BlocProvider(
+        create: (context) => Modular.get<AswhInventoryCommandBloc>(),
+        child: const AswhInventoryCommandPage(),
+      ),
+    );
+
+    r.child(
+      '/commands/checkorder',
+      child: (context) => BlocProvider(
+        create: (context) => Modular.get<AswhInventoryCommandBloc>(),
+        child: const AswhInventoryCommandPage(),
+      ),
+    );
+
+    r.child(
+      '/pallet/:trayNo',
+      child: (context) => BlocProvider(
+        create: (context) => Modular.get<AswhInventoryPalletItemBloc>(),
+        child: const AswhInventoryPalletItemPage(),
+      ),
+    );
+  }
+}

--- a/lib/modules/aswh_inventory/collection_task/aswh_inventory_collect_page.dart
+++ b/lib/modules/aswh_inventory/collection_task/aswh_inventory_collect_page.dart
@@ -1,0 +1,940 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../task_list/models/inventory_task.dart';
+import 'bloc/aswh_inventory_collect_bloc.dart';
+import 'bloc/aswh_inventory_collect_enums.dart';
+import 'bloc/aswh_inventory_collect_event.dart';
+import 'bloc/aswh_inventory_collect_state.dart';
+import 'models/inventory_collect_models.dart';
+
+class AswhInventoryCollectPage extends StatefulWidget {
+  const AswhInventoryCollectPage({super.key});
+
+  @override
+  State<AswhInventoryCollectPage> createState() =>
+      _AswhInventoryCollectPageState();
+}
+
+class _AswhInventoryCollectPageState
+    extends State<AswhInventoryCollectPage> {
+  String? _taskId;
+  InventoryTaskSummary? _taskSummary;
+  bool _routeBound = false;
+  late final TextEditingController _scanController;
+  late final TextEditingController _quantityController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scanController = TextEditingController();
+    _quantityController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _scanController.dispose();
+    _quantityController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_routeBound) {
+      return;
+    }
+
+    final args = Modular.args;
+    _taskId = args.params['taskId'];
+
+    final payload = args.data;
+    if (payload is Map && payload['task'] is Map) {
+      final taskJson = Map<String, dynamic>.from(
+        payload['task'] as Map,
+      );
+
+      final summary = InventoryTaskSummary.fromJson(taskJson);
+      final query = InventoryTaskItemQuery(
+        taskComment: summary.taskComment,
+        checkTaskNo: summary.checkTaskNo,
+        checkTaskId: summary.checkTaskId?.toString(),
+      );
+
+      context.read<AswhInventoryCollectBloc>().add(
+            AswhInventoryCollectStarted(
+              query: query,
+              taskKey: summary.checkTaskId?.toString() ?? summary.checkTaskNo,
+            ),
+          );
+
+      setState(() {
+        _taskSummary = summary;
+        _routeBound = true;
+      });
+    } else {
+      setState(() {
+        _routeBound = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<AswhInventoryCollectBloc, AswhInventoryCollectState>(
+      listenWhen: (previous, current) =>
+          previous.message != current.message ||
+          previous.popup != current.popup,
+      listener: (context, state) {
+        final message = state.message;
+        if (message != null && message.isNotEmpty) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(content: Text(message)),
+            );
+        }
+
+        final popup = state.popup;
+        if (popup != null) {
+          showDialog<void>(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: Text(popup.title),
+              content: Text(popup.message),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    context
+                        .read<AswhInventoryCollectBloc>()
+                        .add(const AswhInventoryCollectPopupClosed());
+                  },
+                  child: const Text('确定'),
+                ),
+              ],
+            ),
+          );
+        }
+      },
+      builder: (context, state) {
+        final isSubmitting = state.isSubmitting;
+        final isLoading = state.isLoading && state.taskItems.isEmpty;
+
+        return Scaffold(
+          appBar: AppBar(title: const Text('立库盘点采集')),
+          body: Stack(
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _buildTaskInfo(context, state),
+                        const SizedBox(height: 12),
+                        _buildStepIndicator(context, state),
+                        const SizedBox(height: 12),
+                        _buildScanInput(context, state),
+                        if (state.currentStep ==
+                            AswhInventoryCollectStep.quantityInput)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 12),
+                            child: _buildQuantityInput(context, state),
+                          ),
+                      ],
+                    ),
+                  ),
+                  _buildTabHeader(context, state),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: _buildTabBody(context, state),
+                    ),
+                  ),
+                  _buildBottomBar(context, state),
+                ],
+              ),
+              if (isLoading || isSubmitting)
+                Container(
+                  color: Colors.black45,
+                  child: Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const CircularProgressIndicator(),
+                        const SizedBox(height: 12),
+                        Text(
+                          isSubmitting ? '正在提交采集结果' : '数据加载中',
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildTaskInfo(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) {
+    final summary = _taskSummary;
+    if (summary == null) {
+      return Text(
+        '任务编号: ${_taskId ?? '-'}',
+        style: Theme.of(context).textTheme.titleMedium,
+      );
+    }
+
+    final pickLocation = state.selectedPickLocation;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '盘库单号: ${summary.taskComment}',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 4),
+        Text('任务号: ${summary.checkTaskNo}'),
+        if (summary.storeRoomName != null)
+          Text('库房: ${summary.storeRoomName} (${summary.storeRoomNo})'),
+        if (summary.workStation != null && summary.workStation!.isNotEmpty)
+          Text('拣选工位: ${summary.workStation}'),
+        if (pickLocation != null)
+          Text('拣选口: ${pickLocation.displayName ?? pickLocation.code ?? '-'}'),
+      ],
+    );
+  }
+
+  Widget _buildStepIndicator(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) {
+    final steps = {
+      AswhInventoryCollectStep.trayScan: '扫描托盘',
+      AswhInventoryCollectStep.siteScan: '扫描库位',
+      AswhInventoryCollectStep.materialScan: '扫描物料',
+      AswhInventoryCollectStep.quantityInput: '录入数量',
+    };
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: steps.entries
+          .map(
+            (entry) => Chip(
+              label: Text(entry.value),
+              backgroundColor: entry.key == state.currentStep
+                  ? Theme.of(context).colorScheme.primaryContainer
+                  : Theme.of(context).colorScheme.surfaceVariant,
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  Widget _buildScanInput(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) {
+    final hintText = switch (state.currentStep) {
+      AswhInventoryCollectStep.trayScan => '请扫描托盘条码',
+      AswhInventoryCollectStep.siteScan => '请扫描库位条码',
+      AswhInventoryCollectStep.materialScan => '请扫描物料条码',
+      AswhInventoryCollectStep.quantityInput => '请输入采集数量',
+    };
+
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            controller: _scanController,
+            decoration: InputDecoration(
+              labelText: '扫码输入',
+              hintText: hintText,
+              border: const OutlineInputBorder(),
+            ),
+            onSubmitted: (value) {
+              _scanController.clear();
+              context
+                  .read<AswhInventoryCollectBloc>()
+                  .add(AswhInventoryCollectScanCaptured(value));
+            },
+          ),
+        ),
+        const SizedBox(width: 8),
+        FilledButton(
+          onPressed: () {
+            final value = _scanController.text.trim();
+            _scanController.clear();
+            if (value.isNotEmpty) {
+              context
+                  .read<AswhInventoryCollectBloc>()
+                  .add(AswhInventoryCollectScanCaptured(value));
+            }
+          },
+          child: const Text('确认'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildQuantityInput(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) {
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            controller: _quantityController,
+            decoration: const InputDecoration(
+              labelText: '采集数量',
+              hintText: '请输入采集数量',
+              border: OutlineInputBorder(),
+            ),
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            onSubmitted: (value) {
+              final qty = double.tryParse(value.trim());
+              if (qty != null) {
+                _quantityController.clear();
+                context
+                    .read<AswhInventoryCollectBloc>()
+                    .add(AswhInventoryCollectQuantityEntered(qty));
+              }
+            },
+          ),
+        ),
+        const SizedBox(width: 8),
+        FilledButton(
+          onPressed: () {
+            final qty = double.tryParse(_quantityController.text.trim());
+            if (qty != null) {
+              _quantityController.clear();
+              context
+                  .read<AswhInventoryCollectBloc>()
+                  .add(AswhInventoryCollectQuantityEntered(qty));
+            }
+          },
+          child: const Text('录入'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTabHeader(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        children: [
+          ChoiceChip(
+            label: const Text('任务列表'),
+            selected: state.activeTab == AswhInventoryCollectTab.taskList,
+            onSelected: (_) => context
+                .read<AswhInventoryCollectBloc>()
+                .add(const AswhInventoryCollectSwitchTabRequested(
+                    AswhInventoryCollectTab.taskList)),
+          ),
+          const SizedBox(width: 12),
+          ChoiceChip(
+            label: const Text('采集中'),
+            selected: state.activeTab == AswhInventoryCollectTab.collecting,
+            onSelected: (_) => context
+                .read<AswhInventoryCollectBloc>()
+                .add(const AswhInventoryCollectSwitchTabRequested(
+                    AswhInventoryCollectTab.collecting)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabBody(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) {
+    if (state.activeTab == AswhInventoryCollectTab.collecting) {
+      if (state.collectingItems.isEmpty) {
+        return const Center(child: Text('暂无采集中记录'));
+      }
+      return ListView.separated(
+        itemCount: state.collectingItems.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final record = state.collectingItems[index];
+          return ListTile(
+            title: Text('物料: ${record.materialCode}'),
+            subtitle: Text(
+              '托盘: ${record.trayNo ?? '-'} / 库位: ${record.storeSiteNo} / 数量: ${record.collectQty}',
+            ),
+            trailing: Text(
+              record.collectedAt != null
+                  ? record.collectedAt!.toString()
+                  : '',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          );
+        },
+      );
+    }
+
+    if (state.taskItems.isEmpty) {
+      return const Center(child: Text('暂无待采集任务'));
+    }
+
+    final bloc = context.read<AswhInventoryCollectBloc>();
+    final selectableIds = state.taskItems
+        .map(_itemIdentifier)
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    final allSelected = selectableIds.isNotEmpty &&
+        selectableIds.every((id) => state.selectedIds.contains(id));
+
+    return ListView.builder(
+      itemCount: state.taskItems.length + 1,
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return CheckboxListTile(
+            value: allSelected,
+            onChanged: selectableIds.isEmpty
+                ? null
+                : (value) {
+                    final nextSelection = <String>{...state.selectedIds};
+                    if (value == true) {
+                      nextSelection.addAll(selectableIds);
+                    } else {
+                      nextSelection
+                          .removeWhere((element) => selectableIds.contains(element));
+                    }
+                    bloc.add(AswhInventoryCollectSelectionChanged(nextSelection));
+                  },
+            title: const Text('全选任务明细'),
+          );
+        }
+
+        final item = state.taskItems[index - 1];
+        final itemId = _itemIdentifier(item);
+        final isChecked =
+            itemId.isNotEmpty && state.selectedIds.contains(itemId);
+        final isActive = state.activeTask == item;
+
+        return Column(
+          children: [
+            ListTile(
+              selected: isActive,
+              leading: Checkbox(
+                value: isChecked,
+                onChanged: itemId.isEmpty
+                    ? null
+                    : (value) {
+                        final updated = <String>{...state.selectedIds};
+                        if (value == true) {
+                          updated.add(itemId);
+                        } else {
+                          updated.remove(itemId);
+                        }
+                        bloc.add(
+                          AswhInventoryCollectSelectionChanged(updated),
+                        );
+                      },
+              ),
+              title: Text(item.materialName ?? item.materialCode ?? '-'),
+              subtitle: Text(
+                '托盘: ${item.palletNo ?? '-'} 库位: ${item.storeSiteNo ?? '-'} 计划: ${item.planQty} 已采集: ${item.collectedQty}',
+              ),
+              onTap: () => bloc.add(
+                AswhInventoryCollectTaskItemSelected(item),
+              ),
+            ),
+            if (index <= state.taskItems.length)
+              const Divider(height: 1),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildBottomBar(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) {
+    final bloc = context.read<AswhInventoryCollectBloc>();
+    final pickLabel = state.selectedPickLocation?.displayName ??
+        state.selectedPickLocation?.code ??
+        '选择拣选口';
+
+    return _CollectBottomBar(
+      pickLocationLabel: pickLabel,
+      onPickLocationTap: () => _showPickLocationPicker(context, state),
+      onViewResults: () =>
+          _navigateToCollectResults(context: context, state: state),
+      collectingCount: state.collectingItems.length,
+      hasCollecting: state.collectingItems.isNotEmpty,
+      onSubmit: state.collectingItems.isEmpty
+          ? null
+          : () => bloc.add(const AswhInventoryCollectSubmitRequested()),
+      onMore: () => _showMoreMenu(context, state),
+      isMoreOpen: state.commandMenu.isOpen,
+    );
+  }
+
+  Future<void> _navigateToCollectResults({
+    required BuildContext context,
+    required AswhInventoryCollectState state,
+  }) async {
+    if (state.collectingItems.isEmpty) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(content: Text('暂无采集记录')),
+        );
+      return;
+    }
+
+    final taskComment = state.taskComment ??
+        _taskSummary?.taskComment ??
+        _taskSummary?.checkTaskNo ??
+        '';
+    final taskId = state.taskId ??
+        _taskSummary?.checkTaskId?.toString() ??
+        _taskSummary?.checkTaskNo ??
+        _taskId ??
+        '';
+
+    final result = await Modular.to.pushNamed(
+      '/aswh-inventory/collect/result',
+      arguments: {
+        'taskId': taskId,
+        'taskComment': taskComment,
+        'records': state.collectingItems.map((e) => e.toJson()).toList(),
+        'taskItems': state.taskItems.map((e) => e.toJson()).toList(),
+        'currentTrayNo': state.currentTrayCode,
+        'currentSiteNo': state.currentSiteCode,
+        'lastScannedCode': state.lastScannedCode,
+      },
+    );
+
+    if (result is Map) {
+      final recordsJson = result['records'];
+      final taskItemsJson = result['taskItems'];
+      final message = result['message'] as String?;
+
+      final updatedRecords = recordsJson is List
+          ? recordsJson
+              .map(
+                (e) => InventoryCollectingRecord.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList()
+          : null;
+      final updatedTaskItems = taskItemsJson is List
+          ? taskItemsJson
+              .map(
+                (e) => InventoryTaskItem.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList()
+          : null;
+
+      if (updatedRecords != null && updatedTaskItems != null) {
+        context.read<AswhInventoryCollectBloc>().add(
+              AswhInventoryCollectResultsPatched(
+                records: updatedRecords,
+                taskItems: updatedTaskItems,
+                message: message,
+              ),
+            );
+      }
+    }
+  }
+
+  Future<void> _showPickLocationPicker(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) async {
+    final bloc = context.read<AswhInventoryCollectBloc>();
+    if (state.pickLocations.isEmpty) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(content: Text('暂无可选的拣选口位置')),
+        );
+      return;
+    }
+
+    final selected = await showModalBottomSheet<InventoryPickLocation>(
+      context: context,
+      builder: (context) {
+        return ListView.builder(
+          itemCount: state.pickLocations.length,
+          itemBuilder: (context, index) {
+            final location = state.pickLocations[index];
+            final isActive = location == state.selectedPickLocation;
+            return ListTile(
+              title: Text(location.displayName ?? location.code ?? '-'),
+              trailing: isActive ? const Icon(Icons.check) : null,
+              onTap: () => Navigator.of(context).pop(location),
+            );
+          },
+        );
+      },
+    );
+
+    if (selected != null) {
+      bloc.add(AswhInventoryCollectPickLocationChanged(selected));
+    }
+  }
+
+  Future<void> _showMoreMenu(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) async {
+    final bloc = context.read<AswhInventoryCollectBloc>();
+    bloc.add(const AswhInventoryCollectCommandMenuVisibilityChanged(true));
+
+    final action = await showModalBottomSheet<_CollectMoreAction>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.list_alt_outlined),
+                title: const Text('查询指令'),
+                onTap: () => Navigator.of(context).pop(_CollectMoreAction.viewCommands),
+              ),
+              ListTile(
+                leading: const Icon(Icons.move_down_outlined),
+                title: const Text('单个托盘'),
+                onTap: () =>
+                    Navigator.of(context).pop(_CollectMoreAction.singleTray),
+              ),
+              ListTile(
+                leading: const Icon(Icons.inventory_2_outlined),
+                title: const Text('全部托盘'),
+                onTap: () =>
+                    Navigator.of(context).pop(_CollectMoreAction.bulkTray),
+              ),
+              ListTile(
+                leading: const Icon(Icons.undo_outlined),
+                title: const Text('托盘回库'),
+                onTap: () =>
+                    Navigator.of(context).pop(_CollectMoreAction.returnTray),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    bloc.add(const AswhInventoryCollectCommandMenuVisibilityChanged(false));
+
+    switch (action) {
+      case _CollectMoreAction.viewCommands:
+        _navigateToCommands();
+        break;
+      case _CollectMoreAction.singleTray:
+        await _handleSingleTrayDetail(context, state);
+        break;
+      case _CollectMoreAction.bulkTray:
+        final quantity = await _promptBulkTrayQuantity(context, state);
+        if (quantity != null) {
+          bloc.add(AswhInventoryCollectBulkTrayRequested(quantity));
+        }
+        break;
+      case _CollectMoreAction.returnTray:
+        bloc.add(const AswhInventoryCollectReturnTrayRequested());
+        break;
+      case null:
+        break;
+    }
+  }
+
+  Future<int?> _promptBulkTrayQuantity(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) async {
+    final maxQuantity = state.taskItems.length;
+    return showDialog<int>(
+      context: context,
+      builder: (context) => _TrayQuantityDialog(maxQuantity: maxQuantity),
+    );
+  }
+
+  Future<void> _handleSingleTrayDetail(
+    BuildContext context,
+    AswhInventoryCollectState state,
+  ) async {
+    final bloc = context.read<AswhInventoryCollectBloc>();
+    final pickLocation = state.selectedPickLocation;
+    if (pickLocation == null) {
+      _showSnackBar(context, '请先选择拣选口位置');
+      return;
+    }
+
+    if (state.selectedIds.isEmpty) {
+      _showSnackBar(context, '请至少勾选一条任务明细');
+      return;
+    }
+
+    InventoryTaskItem? taskItem;
+    for (final item in state.taskItems) {
+      if (state.selectedIds.contains(_itemIdentifier(item))) {
+        taskItem = item;
+        break;
+      }
+    }
+
+    final trayNo = taskItem?.palletNo;
+    if (trayNo == null || trayNo.isEmpty) {
+      _showSnackBar(context, '所选任务缺少托盘号，无法查看明细');
+      return;
+    }
+
+    final shouldDispatch = await Modular.to.pushNamed<bool>(
+      '/aswh-inventory/pallet/${Uri.encodeComponent(trayNo)}',
+      arguments: {
+        'trayNo': trayNo,
+      },
+    );
+
+    if (shouldDispatch == true) {
+      bloc.add(const AswhInventoryCollectSingleTrayRequested());
+    }
+  }
+
+  void _showSnackBar(BuildContext context, String message) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _navigateToCommands() {
+    final summary = _taskSummary;
+    final taskId = summary?.checkTaskId?.toString() ?? summary?.checkTaskNo;
+    if (summary == null || taskId == null) {
+      return;
+    }
+
+    Modular.to.pushNamed(
+      '/aswh-inventory/commands/checkorder',
+      arguments: {
+        'taskComment': summary.taskComment,
+        'taskId': taskId,
+        'taskType': '03',
+        'taskNo': summary.checkTaskNo,
+        'category': 'checkOrder',
+      },
+    );
+  }
+
+  String _itemIdentifier(InventoryTaskItem item) {
+    return item.checkItemId?.toString() ??
+        item.palletNo ??
+        item.materialCode ??
+        item.checkTaskNo ??
+        '';
+  }
+}
+
+enum _CollectMoreAction { viewCommands, singleTray, bulkTray, returnTray }
+
+class _CollectBottomBar extends StatelessWidget {
+  const _CollectBottomBar({
+    required this.pickLocationLabel,
+    required this.onPickLocationTap,
+    required this.onViewResults,
+    required this.collectingCount,
+    required this.hasCollecting,
+    required this.onSubmit,
+    required this.onMore,
+    required this.isMoreOpen,
+  });
+
+  final String pickLocationLabel;
+  final VoidCallback onPickLocationTap;
+  final VoidCallback onViewResults;
+  final int collectingCount;
+  final bool hasCollecting;
+  final VoidCallback? onSubmit;
+  final VoidCallback onMore;
+  final bool isMoreOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            offset: const Offset(0, -2),
+            blurRadius: 4,
+          )
+        ],
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: onPickLocationTap,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.place_outlined, size: 18),
+                  const SizedBox(height: 4),
+                  Text(
+                    pickLocationLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: OutlinedButton(
+              onPressed: hasCollecting ? onViewResults : null,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.assignment_outlined,
+                    size: 18,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    hasCollecting
+                        ? '采集结果($collectingCount)'
+                        : '采集结果',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: FilledButton(
+              onPressed: onSubmit,
+              child: const Text('提交采集'),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: OutlinedButton(
+              onPressed: onMore,
+              style: isMoreOpen
+                  ? OutlinedButton.styleFrom(
+                      backgroundColor: colorScheme.secondaryContainer,
+                    )
+                  : null,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.more_horiz,
+                    size: 18,
+                    color: isMoreOpen
+                        ? colorScheme.onSecondaryContainer
+                        : null,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '更多',
+                    style: TextStyle(
+                      color: isMoreOpen
+                          ? colorScheme.onSecondaryContainer
+                          : null,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrayQuantityDialog extends StatefulWidget {
+  const _TrayQuantityDialog({required this.maxQuantity});
+
+  final int maxQuantity;
+
+  @override
+  State<_TrayQuantityDialog> createState() => _TrayQuantityDialogState();
+}
+
+class _TrayQuantityDialogState extends State<_TrayQuantityDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: '1');
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('托盘数量确认'),
+      content: TextField(
+        controller: _controller,
+        keyboardType: TextInputType.number,
+        decoration: InputDecoration(
+          labelText: '托盘数量',
+          helperText: '最多可请求 ${widget.maxQuantity} 个托盘',
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('取消'),
+        ),
+        FilledButton(
+          onPressed: () {
+            final parsed = int.tryParse(_controller.text.trim());
+            if (parsed == null || parsed <= 0) {
+              ScaffoldMessenger.of(context)
+                ..hideCurrentSnackBar()
+                ..showSnackBar(
+                  const SnackBar(content: Text('请输入合法的托盘数量')),
+                );
+              return;
+            }
+            Navigator.of(context).pop(parsed);
+          },
+          child: const Text('确认'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/modules/aswh_inventory/collection_task/bloc/aswh_inventory_collect_bloc.dart
+++ b/lib/modules/aswh_inventory/collection_task/bloc/aswh_inventory_collect_bloc.dart
@@ -1,0 +1,838 @@
+
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../models/inventory_collect_models.dart';
+import '../repositories/inventory_collect_cache_repository.dart';
+import '../services/aswh_inventory_collect_service.dart';
+import 'aswh_inventory_collect_enums.dart';
+import 'aswh_inventory_collect_event.dart';
+import 'aswh_inventory_collect_state.dart';
+
+
+class AswhInventoryCollectBloc
+    extends Bloc<AswhInventoryCollectEvent, AswhInventoryCollectState> {
+  AswhInventoryCollectBloc({
+    required AswhInventoryCollectService collectService,
+    required InventoryCollectCacheRepository cacheRepository,
+  })  : _collectService = collectService,
+        _cacheRepository = cacheRepository,
+        super(const AswhInventoryCollectState()) {
+    on<AswhInventoryCollectStarted>(_onStarted);
+    on<AswhInventoryCollectScanCaptured>(_onScanCaptured);
+    on<AswhInventoryCollectTrayConfirmed>(_onTrayConfirmed);
+    on<AswhInventoryCollectSiteValidated>(_onSiteValidated);
+    on<AswhInventoryCollectMaterialDecoded>(_onMaterialDecoded);
+    on<AswhInventoryCollectQuantityEntered>(_onQuantityEntered);
+    on<AswhInventoryCollectTaskItemSelected>(_onTaskItemSelected);
+    on<AswhInventoryCollectSwitchTabRequested>(_onSwitchTab);
+    on<AswhInventoryCollectSubmitRequested>(_onSubmitRequested);
+    on<AswhInventoryCollectCommandActionTriggered>(_onCommandActionTriggered);
+    on<AswhInventoryCollectPopupClosed>(_onPopupClosed);
+    on<AswhInventoryCollectSelectionChanged>(_onSelectionChanged);
+    on<AswhInventoryCollectResetRequested>(_onResetRequested);
+    on<AswhInventoryCollectPickLocationChanged>(_onPickLocationChanged);
+    on<AswhInventoryCollectCommandMenuVisibilityChanged>(
+      _onCommandMenuVisibilityChanged,
+    );
+    on<AswhInventoryCollectSingleTrayRequested>(_onSingleTrayRequested);
+    on<AswhInventoryCollectBulkTrayRequested>(_onBulkTrayRequested);
+    on<AswhInventoryCollectReturnTrayRequested>(_onReturnTrayRequested);
+    on<AswhInventoryCollectResultsPatched>(_onResultsPatched);
+  }
+
+  final AswhInventoryCollectService _collectService;
+  final InventoryCollectCacheRepository _cacheRepository;
+
+  late InventoryTaskItemQuery _query;
+  String? _taskId;
+  String? _taskComment;
+  String? _taskKey;
+
+  Future<void> _onStarted(
+    AswhInventoryCollectStarted event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        status: AswhInventoryCollectStatus.loading,
+        isLoading: true,
+        message: null,
+      ),
+    );
+
+    _query = event.query;
+    _taskComment = event.query.taskComment;
+    _taskId = event.query.checkTaskId ?? event.query.checkTaskNo;
+    _taskKey = event.taskKey ?? _taskId;
+
+    if (_taskKey != null) {
+      await _cacheRepository.initialize(_taskKey!);
+    }
+
+    try {
+      final items = await _collectService.fetchTaskItems(query: event.query);
+      emit(
+        state.copyWith(
+          status: AswhInventoryCollectStatus.ready,
+          isLoading: false,
+          taskItems: items,
+          message: null,
+          taskId: _taskId,
+          taskComment: _taskComment,
+        ),
+      );
+
+      await _loadPickLocations(emit);
+      await _restoreFromCache(emit);
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryCollectStatus.failure,
+          isLoading: false,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> _restoreFromCache(Emitter<AswhInventoryCollectState> emit) async {
+    if (!_cacheRepository.isReady) return;
+
+    final snapshot = await _cacheRepository.readSnapshot();
+    if (snapshot == null) return;
+
+    emit(
+      state.copyWith(
+        collectingItems: snapshot.collectedRecords,
+        taskItems:
+            snapshot.taskItems.isEmpty ? state.taskItems : snapshot.taskItems,
+        currentTrayCode: snapshot.activeTrayNo,
+        currentSiteCode: snapshot.activeStoreSiteNo,
+        lastScannedCode: snapshot.lastScannedCode,
+        restoredSnapshot: snapshot,
+        message: '已从本地缓存恢复采集进度',
+      ),
+    );
+  }
+
+  Future<void> _onScanCaptured(
+    AswhInventoryCollectScanCaptured event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    final sanitized = event.code.trim();
+    if (sanitized.isEmpty) {
+      return;
+    }
+
+    switch (state.currentStep) {
+      case AswhInventoryCollectStep.trayScan:
+        return _handleTrayScan(sanitized, emit);
+      case AswhInventoryCollectStep.siteScan:
+        return _handleSiteScan(sanitized, emit);
+      case AswhInventoryCollectStep.materialScan:
+        return _handleMaterialScan(sanitized, emit);
+      case AswhInventoryCollectStep.quantityInput:
+        final quantity = double.tryParse(sanitized);
+        if (quantity == null) {
+          emit(
+            state.copyWith(
+              message: '数量格式不正确，请重新输入',
+            ),
+          );
+          return;
+        }
+        return _onQuantityEntered(
+          AswhInventoryCollectQuantityEntered(quantity),
+          emit,
+        );
+    }
+  }
+
+  Future<void> _handleTrayScan(
+    String trayCode,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        currentTrayCode: trayCode,
+        currentStep: AswhInventoryCollectStep.siteScan,
+        lastScannedCode: trayCode,
+        message: '托盘号 $trayCode 扫描成功，请继续扫描库位',
+      ),
+    );
+    await _persistSnapshot();
+  }
+
+  Future<void> _handleSiteScan(
+    String siteCode,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    final storeRoom = _resolveStoreRoomNo();
+    if (storeRoom == null) {
+      emit(
+        state.copyWith(
+          message: '未获取到库房信息，无法校验库位',
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(message: '库位校验中...', isLoading: true));
+    try {
+      final results = await _collectService.validateStoreSite(
+        storeRoomNo: storeRoom,
+        storeSiteNo: siteCode,
+      );
+
+      final matched = results.firstWhereOrNull(
+        (item) => item.storeSiteNo == siteCode,
+      );
+
+      if (matched != null && matched.siteFlag != null &&
+          matched.siteFlag!.toUpperCase() != 'Y') {
+        emit(
+          state.copyWith(
+            isLoading: false,
+            message: '库位 ${matched.storeSiteNo} 未开放，无法采集',
+          ),
+        );
+        return;
+      }
+
+      final expectedErpSite = state.activeTask?.erpStoreSite;
+      if (expectedErpSite != null &&
+          matched != null &&
+          matched.erpStoreSite != null &&
+          expectedErpSite != matched.erpStoreSite) {
+        emit(
+          state.copyWith(
+            isLoading: false,
+            message: 'ERP 库位不匹配，请确认扫描库位是否正确',
+          ),
+        );
+        return;
+      }
+
+      emit(
+        state.copyWith(
+          isLoading: false,
+          currentSiteCode: matched?.storeSiteNo ?? siteCode,
+          currentStep: AswhInventoryCollectStep.materialScan,
+          lastScannedCode: siteCode,
+          message: '库位 ${matched?.storeSiteNo ?? siteCode} 校验通过，继续扫描物料',
+        ),
+      );
+      await _persistSnapshot();
+    } catch (error) {
+      emit(
+        state.copyWith(
+          isLoading: false,
+          message: '库位校验失败：${error.toString()}',
+        ),
+      );
+    }
+  }
+
+  Future<void> _handleMaterialScan(
+    String materialCode,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    final matched = state.taskItems.firstWhereOrNull((item) {
+      final matchesMaterial =
+          (item.materialCode ?? '').contains(materialCode) ||
+              materialCode.contains(item.materialCode ?? '');
+      final matchesTray = state.currentTrayCode == null ||
+          item.palletNo == null ||
+          item.palletNo == state.currentTrayCode;
+      final matchesSite = state.currentSiteCode == null ||
+          item.storeSiteNo == null ||
+          item.storeSiteNo == state.currentSiteCode;
+      return matchesMaterial && matchesTray && matchesSite;
+    });
+
+    if (matched == null) {
+      emit(
+        state.copyWith(
+          message: '未在任务明细中找到物料 $materialCode，请确认后重试',
+        ),
+      );
+      return;
+    }
+
+    await _ensureMaterialControl(matched.materialCode);
+
+    final control = state.materialControls[matched.materialCode];
+    if (control != null && control.batchRequired &&
+        (matched.batchNo == null || matched.batchNo!.isEmpty)) {
+      emit(
+        state.copyWith(
+          message: '物料需校验批次，当前任务批次为空，请检查',
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        activeTask: matched,
+        currentStep: AswhInventoryCollectStep.quantityInput,
+        lastScannedCode: materialCode,
+        message: '物料 ${matched.materialCode ?? materialCode} 校验成功，请录入数量',
+      ),
+    );
+    await _persistSnapshot();
+  }
+
+  Future<void> _onTrayConfirmed(
+    AswhInventoryCollectTrayConfirmed event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    await _handleTrayScan(event.trayCode, emit);
+  }
+
+  Future<void> _onSiteValidated(
+    AswhInventoryCollectSiteValidated event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    await _handleSiteScan(event.siteCode, emit);
+  }
+
+  Future<void> _onMaterialDecoded(
+    AswhInventoryCollectMaterialDecoded event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    await _handleMaterialScan(event.materialCode, emit);
+  }
+
+  Future<void> _onQuantityEntered(
+    AswhInventoryCollectQuantityEntered event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    final activeTask = state.activeTask;
+    if (activeTask == null) {
+      emit(
+        state.copyWith(
+          message: '请先扫描物料并选择任务明细',
+        ),
+      );
+      return;
+    }
+
+    if (event.quantity <= 0) {
+      emit(state.copyWith(message: '采集数量必须大于 0'));
+      return;
+    }
+
+    final remainingQty = activeTask.planQty - activeTask.collectedQty;
+    if (remainingQty > 0 && event.quantity > remainingQty + 0.0001) {
+      emit(
+        state.copyWith(
+          message: '采集数量超过计划数量，请核对后重新录入',
+        ),
+      );
+      return;
+    }
+
+    final control = state.materialControls[activeTask.materialCode];
+    if (control != null && control.supplierRequired &&
+        (activeTask.supplierCode == null ||
+            activeTask.supplierCode!.isEmpty)) {
+      emit(
+        state.copyWith(
+          message: '物料需校验供应商，请补充供应商信息',
+        ),
+      );
+      return;
+    }
+
+    if (control != null && control.serialRequired &&
+        (activeTask.serialNo == null || activeTask.serialNo!.isEmpty)) {
+      emit(
+        state.copyWith(
+          message: '物料需校验序列号，请扫描包含序列信息的条码',
+        ),
+      );
+      return;
+    }
+
+    if (control != null && control.validityRequired) {
+      final hasValidityInfo = (activeTask.batchNo != null &&
+              activeTask.batchNo!.isNotEmpty) ||
+          (state.lastScannedCode != null &&
+              state.lastScannedCode!.isNotEmpty);
+      if (!hasValidityInfo) {
+        emit(
+          state.copyWith(
+            message: '物料需校验有效期，请确认条码包含有效期信息',
+          ),
+        );
+        return;
+      }
+    }
+
+    final record = InventoryCollectingRecord(
+      taskComment: _taskComment ?? activeTask.taskComment ?? '',
+      taskItemId: (activeTask.checkItemId ?? activeTask.checkTaskId ?? '')
+          .toString(),
+      materialCode: activeTask.materialCode ?? '',
+      materialId: null,
+      storeRoomNo: activeTask.storeRoomNo ?? '',
+      storeSiteNo: state.currentSiteCode ?? activeTask.storeSiteNo ?? '',
+      collectQty: event.quantity,
+      batchNo: activeTask.batchNo,
+      serialNo: activeTask.serialNo,
+      trayNo: state.currentTrayCode ?? activeTask.palletNo,
+      collectedAt: DateTime.now(),
+    );
+
+    final updatedCollecting = [...state.collectingItems, record];
+    final updatedTaskItems = state.taskItems.map((item) {
+      if (item == activeTask) {
+        return item.copyWith(
+          collectedQty: (item.collectedQty) + event.quantity,
+        );
+      }
+      return item;
+    }).toList();
+
+    emit(
+      state.copyWith(
+        collectingItems: updatedCollecting,
+        taskItems: updatedTaskItems,
+        currentStep: AswhInventoryCollectStep.trayScan,
+        message: '已采集数量 ${event.quantity}，请继续扫描托盘',
+        currentTrayCode: null,
+        currentSiteCode: null,
+        activeTask: null,
+      ),
+    );
+    await _persistSnapshot();
+  }
+
+  Future<void> _onTaskItemSelected(
+    AswhInventoryCollectTaskItemSelected event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        activeTask: event.taskItem,
+        currentTrayCode: event.taskItem.palletNo,
+        currentSiteCode: event.taskItem.storeSiteNo,
+        message: '已选择任务明细 ${event.taskItem.materialCode ?? ''}',
+      ),
+    );
+    await _persistSnapshot();
+  }
+
+  Future<void> _onSwitchTab(
+    AswhInventoryCollectSwitchTabRequested event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(state.copyWith(activeTab: event.tab));
+  }
+
+  Future<void> _onSubmitRequested(
+    AswhInventoryCollectSubmitRequested event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    if (state.collectingItems.isEmpty) {
+      emit(state.copyWith(message: '暂无采集记录，无需提交'));
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: AswhInventoryCollectStatus.submitting,
+        isSubmitting: true,
+        message: '正在提交采集结果...',
+      ),
+    );
+
+    try {
+      await _collectService.submitCollectionRecords(
+        records: state.collectingItems,
+        taskComment: _taskComment ?? _query.taskComment,
+      );
+
+      emit(
+        state.copyWith(
+          status: AswhInventoryCollectStatus.success,
+          isSubmitting: false,
+          collectingItems: const [],
+          collectedItems: [...state.collectedItems, ...state.collectingItems],
+          message: '提交成功，待采集列表将刷新',
+        ),
+      );
+      await _cacheRepository.clear();
+      await _persistSnapshot();
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryCollectStatus.failure,
+          isSubmitting: false,
+          message: '提交失败：${error.toString()}',
+        ),
+      );
+    }
+  }
+
+  Future<void> _onCommandActionTriggered(
+    AswhInventoryCollectCommandActionTriggered event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(state.copyWith(message: '正在下发指令...', isLoading: true));
+    try {
+      await _collectService.dispatchCommand(event.command);
+      emit(
+        state.copyWith(
+          isLoading: false,
+          popup: const AswhCollectPopup(
+            type: AswhCollectPopupType.info,
+            title: '指令已发送',
+            message: '指令已成功下发。',
+          ),
+          message: '指令发送成功',
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          isLoading: false,
+          message: '指令下发失败：${error.toString()}',
+        ),
+      );
+    }
+  }
+
+  Future<void> _onResultsPatched(
+    AswhInventoryCollectResultsPatched event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        collectingItems: event.records,
+        taskItems: event.taskItems,
+        message: event.message ?? '采集结果已更新',
+      ),
+    );
+
+    await _persistSnapshot();
+  }
+
+  Future<void> _onPopupClosed(
+    AswhInventoryCollectPopupClosed event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(state.copyWith(popup: null));
+  }
+
+  Future<void> _onSelectionChanged(
+    AswhInventoryCollectSelectionChanged event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(state.copyWith(selectedIds: event.selectedIds));
+    await _persistSnapshot();
+  }
+
+  Future<void> _onResetRequested(
+    AswhInventoryCollectResetRequested event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        currentTrayCode: null,
+        currentSiteCode: null,
+        activeTask: null,
+        currentStep: AswhInventoryCollectStep.trayScan,
+        message: null,
+      ),
+    );
+    await _persistSnapshot();
+  }
+
+  Future<void> _onPickLocationChanged(
+    AswhInventoryCollectPickLocationChanged event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        selectedPickLocation: event.location,
+        commandMenu: state.commandMenu.copyWith(isOpen: false),
+      ),
+    );
+  }
+
+  Future<void> _onCommandMenuVisibilityChanged(
+    AswhInventoryCollectCommandMenuVisibilityChanged event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        commandMenu: state.commandMenu.copyWith(isOpen: event.isOpen),
+      ),
+    );
+  }
+
+  Future<void> _onSingleTrayRequested(
+    AswhInventoryCollectSingleTrayRequested event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    final pickLocation = state.selectedPickLocation;
+    if (pickLocation == null) {
+      emit(state.copyWith(message: '请先选择拣选口位置'));
+      return;
+    }
+
+    if (state.selectedIds.isEmpty) {
+      emit(state.copyWith(message: '请至少勾选一条任务明细'));
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        isLoading: true,
+        commandMenu: state.commandMenu.copyWith(isOpen: false),
+        message: '正在下发托盘指令...',
+      ),
+    );
+
+    final errors = <String>[];
+    for (final item in state.taskItems) {
+      if (!state.selectedIds.contains(_resolveItemId(item))) {
+        continue;
+      }
+
+      if (item.palletNo == null || item.storeSiteNo == null) {
+        errors.add(item.materialCode ?? '未知物料');
+        continue;
+      }
+
+      final command = InventoryCollectCommand(
+        taskId: _taskId ?? _query.checkTaskId ?? _query.checkTaskNo,
+        taskNo: _query.checkTaskNo,
+        trayNo: item.palletNo!,
+        startAddr: item.storeSiteNo!,
+        endAddr: pickLocation.code ?? '',
+        singleFlag: '1',
+      );
+
+      try {
+        await _collectService.dispatchCommand(command);
+      } catch (_) {
+        errors.add(item.palletNo ?? item.materialCode ?? '未知');
+      }
+    }
+
+    emit(
+      state.copyWith(
+        isLoading: false,
+        message: errors.isEmpty
+            ? '指令发送成功，请等待托盘到达'
+            : '部分托盘指令失败：${errors.join('、')}',
+      ),
+    );
+  }
+
+  Future<void> _onBulkTrayRequested(
+    AswhInventoryCollectBulkTrayRequested event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    final pickLocation = state.selectedPickLocation;
+    if (pickLocation == null) {
+      emit(state.copyWith(message: '请先选择拣选口位置'));
+      return;
+    }
+
+    if (event.quantity <= 0) {
+      emit(state.copyWith(message: '托盘数量必须大于 0'));
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        isLoading: true,
+        commandMenu: state.commandMenu.copyWith(isOpen: false),
+        message: '正在批量下发托盘指令...',
+      ),
+    );
+
+    final pendingItems = state.taskItems
+        .where((item) => item.palletNo != null && item.storeSiteNo != null)
+        .toList();
+
+    final errors = <String>[];
+    final limited = pendingItems.take(event.quantity);
+    for (final item in limited) {
+      final command = InventoryCollectCommand(
+        taskId: _taskId ?? _query.checkTaskId ?? _query.checkTaskNo,
+        taskNo: _query.checkTaskNo,
+        trayNo: item.palletNo!,
+        startAddr: item.storeSiteNo!,
+        endAddr: pickLocation.code ?? '',
+        singleFlag: '0',
+      );
+
+      try {
+        await _collectService.dispatchCommand(command);
+      } catch (_) {
+        errors.add(item.palletNo ?? '未知');
+      }
+    }
+
+    emit(
+      state.copyWith(
+        isLoading: false,
+        message: errors.isEmpty
+            ? '批量托盘指令已发送，请等待'
+            : '以下托盘发送失败：${errors.join('、')}',
+      ),
+    );
+  }
+
+  Future<void> _onReturnTrayRequested(
+    AswhInventoryCollectReturnTrayRequested event,
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    final pickLocation = state.selectedPickLocation;
+    if (pickLocation == null) {
+      emit(state.copyWith(message: '请先选择拣选口位置'));
+      return;
+    }
+
+    final trayNo = state.currentTrayCode;
+    if (trayNo == null || trayNo.isEmpty) {
+      emit(state.copyWith(message: '请先扫描托盘后再回库'));
+      return;
+    }
+
+    final target = state.taskItems.firstWhereOrNull(
+      (item) => item.palletNo == trayNo,
+    );
+
+    if (target == null || target.storeSiteNo == null) {
+      emit(state.copyWith(message: '未找到托盘对应的库位，无法回库'));
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        isLoading: true,
+        commandMenu: state.commandMenu.copyWith(isOpen: false),
+        message: '正在下发回库指令...',
+      ),
+    );
+
+    final command = InventoryCollectCommand(
+      taskId: _taskId ?? _query.checkTaskId ?? _query.checkTaskNo,
+      taskNo: _query.checkTaskNo,
+      trayNo: trayNo,
+      startAddr: pickLocation.code ?? '',
+      endAddr: target.storeSiteNo!,
+      action: InventoryCollectCommandAction.inventoryReset,
+    );
+
+    try {
+      await _collectService.dispatchCommand(command);
+      emit(
+        state.copyWith(
+          isLoading: false,
+          message: '回库指令已发送，请等待托盘回库',
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          isLoading: false,
+          message: '回库指令下发失败：${error.toString()}',
+        ),
+      );
+    }
+  }
+
+  Future<void> _persistSnapshot() async {
+    if (!_cacheRepository.isReady || _taskId == null || _taskComment == null) {
+      return;
+    }
+
+    final snapshot = InventoryCollectStateSnapshot(
+      taskId: _taskId!,
+      taskComment: _taskComment!,
+      activeTrayNo: state.currentTrayCode,
+      activeStoreSiteNo: state.currentSiteCode,
+      lastScannedCode: state.lastScannedCode,
+      taskItems: state.taskItems,
+      collectedRecords: state.collectingItems,
+      updatedAt: DateTime.now(),
+    );
+
+    await _cacheRepository.persistSnapshot(snapshot);
+  }
+
+  String? _resolveStoreRoomNo() {
+    return state.activeTask?.storeRoomNo ??
+        state.taskItems.firstOrNull?.storeRoomNo;
+  }
+
+  Future<void> _loadPickLocations(
+    Emitter<AswhInventoryCollectState> emit,
+  ) async {
+    try {
+      final locations = await _collectService.fetchPickLocations();
+      emit(
+        state.copyWith(
+          pickLocations: locations,
+          selectedPickLocation:
+              locations.isNotEmpty ? locations.first : state.selectedPickLocation,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          message: '拣选口位置加载失败：${error.toString()}',
+        ),
+      );
+    }
+  }
+
+  Future<void> _ensureMaterialControl(String? materialCode) async {
+    if (materialCode == null || materialCode.isEmpty) {
+      return;
+    }
+
+    if (state.materialControls.containsKey(materialCode)) {
+      return;
+    }
+
+    try {
+      final control = await _collectService.fetchMaterialControl(materialCode);
+      if (control != null) {
+        final updated = Map<String, InventoryMatControl>.from(
+          state.materialControls,
+        )
+          ..[materialCode] = control;
+        emit(state.copyWith(materialControls: updated));
+      }
+    } catch (_) {
+      // 忽略物料控制加载失败，避免阻塞采集流程
+    }
+  }
+
+  String _resolveItemId(InventoryTaskItem item) {
+    return (item.checkItemId ??
+            item.palletNo ??
+            item.materialCode ??
+            item.checkTaskNo ??
+            '')
+        .toString();
+  }
+
+
+  @override
+  Future<void> close() async {
+    await _cacheRepository.dispose();
+    return super.close();
+  }
+}

--- a/lib/modules/aswh_inventory/collection_task/bloc/aswh_inventory_collect_enums.dart
+++ b/lib/modules/aswh_inventory/collection_task/bloc/aswh_inventory_collect_enums.dart
@@ -1,0 +1,11 @@
+enum AswhInventoryCollectStep {
+  trayScan,
+  siteScan,
+  materialScan,
+  quantityInput,
+}
+
+enum AswhInventoryCollectTab {
+  taskList,
+  collecting,
+}

--- a/lib/modules/aswh_inventory/collection_task/bloc/aswh_inventory_collect_event.dart
+++ b/lib/modules/aswh_inventory/collection_task/bloc/aswh_inventory_collect_event.dart
@@ -1,0 +1,172 @@
+import 'package:equatable/equatable.dart';
+
+import '../models/inventory_collect_models.dart';
+import 'aswh_inventory_collect_enums.dart';
+
+abstract class AswhInventoryCollectEvent extends Equatable {
+  const AswhInventoryCollectEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AswhInventoryCollectStarted extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectStarted({
+    required this.query,
+    this.taskKey,
+  });
+
+  final InventoryTaskItemQuery query;
+  final String? taskKey;
+
+  @override
+  List<Object?> get props => [query, taskKey];
+}
+
+class AswhInventoryCollectScanCaptured extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectScanCaptured(this.code, {this.scannedAt});
+
+  final String code;
+  final DateTime? scannedAt;
+
+  @override
+  List<Object?> get props => [code, scannedAt];
+}
+
+class AswhInventoryCollectTrayConfirmed extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectTrayConfirmed(this.trayCode);
+
+  final String trayCode;
+
+  @override
+  List<Object?> get props => [trayCode];
+}
+
+class AswhInventoryCollectSiteValidated extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectSiteValidated(this.siteCode);
+
+  final String siteCode;
+
+  @override
+  List<Object?> get props => [siteCode];
+}
+
+class AswhInventoryCollectMaterialDecoded extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectMaterialDecoded(this.materialCode);
+
+  final String materialCode;
+
+  @override
+  List<Object?> get props => [materialCode];
+}
+
+class AswhInventoryCollectQuantityEntered extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectQuantityEntered(this.quantity);
+
+  final double quantity;
+
+  @override
+  List<Object?> get props => [quantity];
+}
+
+class AswhInventoryCollectTaskItemSelected extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectTaskItemSelected(this.taskItem);
+
+  final InventoryTaskItem taskItem;
+
+  @override
+  List<Object?> get props => [taskItem];
+}
+
+class AswhInventoryCollectSwitchTabRequested extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectSwitchTabRequested(this.tab);
+
+  final AswhInventoryCollectTab tab;
+
+  @override
+  List<Object?> get props => [tab];
+}
+
+class AswhInventoryCollectSubmitRequested extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectSubmitRequested();
+}
+
+class AswhInventoryCollectCommandActionTriggered
+    extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectCommandActionTriggered(this.command);
+
+  final InventoryCollectCommand command;
+
+  @override
+  List<Object?> get props => [command];
+}
+
+class AswhInventoryCollectPopupClosed extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectPopupClosed();
+}
+
+class AswhInventoryCollectSelectionChanged extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectSelectionChanged(this.selectedIds);
+
+  final Set<String> selectedIds;
+
+  @override
+  List<Object?> get props => [selectedIds];
+}
+
+class AswhInventoryCollectResetRequested extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectResetRequested();
+}
+
+class AswhInventoryCollectPickLocationChanged extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectPickLocationChanged(this.location);
+
+  final InventoryPickLocation location;
+
+  @override
+  List<Object?> get props => [location];
+}
+
+class AswhInventoryCollectCommandMenuVisibilityChanged
+    extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectCommandMenuVisibilityChanged(this.isOpen);
+
+  final bool isOpen;
+
+  @override
+  List<Object?> get props => [isOpen];
+}
+
+class AswhInventoryCollectSingleTrayRequested
+    extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectSingleTrayRequested();
+}
+
+class AswhInventoryCollectBulkTrayRequested extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectBulkTrayRequested(this.quantity);
+
+  final int quantity;
+
+  @override
+  List<Object?> get props => [quantity];
+}
+
+class AswhInventoryCollectReturnTrayRequested
+    extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectReturnTrayRequested();
+}
+
+class AswhInventoryCollectResultsPatched extends AswhInventoryCollectEvent {
+  const AswhInventoryCollectResultsPatched({
+    required this.records,
+    required this.taskItems,
+    this.message,
+  });
+
+  final List<InventoryCollectingRecord> records;
+  final List<InventoryTaskItem> taskItems;
+  final String? message;
+
+  @override
+  List<Object?> get props => [records, taskItems, message];
+}

--- a/lib/modules/aswh_inventory/collection_task/bloc/aswh_inventory_collect_state.dart
+++ b/lib/modules/aswh_inventory/collection_task/bloc/aswh_inventory_collect_state.dart
@@ -1,0 +1,200 @@
+import 'package:equatable/equatable.dart';
+
+import '../models/inventory_collect_models.dart';
+import 'aswh_inventory_collect_enums.dart';
+
+const _messageNoChange = Object();
+const _popupNoChange = Object();
+const _taskIdNoChange = Object();
+const _taskCommentNoChange = Object();
+
+enum AswhInventoryCollectStatus {
+  initial,
+  loading,
+  ready,
+  submitting,
+  success,
+  failure,
+}
+
+enum AswhCollectPopupType { info, confirm, trayQuantity }
+
+class AswhCollectPopupAction extends Equatable {
+  const AswhCollectPopupAction({
+    required this.key,
+    required this.label,
+    this.isPrimary = false,
+  });
+
+  final String key;
+  final String label;
+  final bool isPrimary;
+
+  @override
+  List<Object?> get props => [key, label, isPrimary];
+}
+
+class AswhCollectPopup extends Equatable {
+  const AswhCollectPopup({
+    required this.type,
+    required this.title,
+    required this.message,
+    this.actions = const [],
+  });
+
+  final AswhCollectPopupType type;
+  final String title;
+  final String message;
+  final List<AswhCollectPopupAction> actions;
+
+  @override
+  List<Object?> get props => [type, title, message, actions];
+}
+
+class AswhCollectCommandMenu extends Equatable {
+  const AswhCollectCommandMenu({this.isOpen = false});
+
+  final bool isOpen;
+
+  AswhCollectCommandMenu copyWith({bool? isOpen}) {
+    return AswhCollectCommandMenu(
+      isOpen: isOpen ?? this.isOpen,
+    );
+  }
+
+  @override
+  List<Object?> get props => [isOpen];
+}
+
+class AswhInventoryCollectState extends Equatable {
+  const AswhInventoryCollectState({
+    this.status = AswhInventoryCollectStatus.initial,
+    this.currentStep = AswhInventoryCollectStep.trayScan,
+    this.activeTab = AswhInventoryCollectTab.taskList,
+    this.taskItems = const <InventoryTaskItem>[],
+    this.collectingItems = const <InventoryCollectingRecord>[],
+    this.collectedItems = const <InventoryCollectingRecord>[],
+    this.selectedIds = const <String>{},
+    this.pickLocations = const <InventoryPickLocation>[],
+    this.isLoading = false,
+    this.isSubmitting = false,
+    this.message,
+    this.currentTrayCode,
+    this.currentSiteCode,
+    this.activeTask,
+    this.popup,
+    this.commandMenu = const AswhCollectCommandMenu(),
+    this.lastScannedCode,
+    this.restoredSnapshot,
+    this.selectedPickLocation,
+    this.materialControls = const {},
+    this.taskId,
+    this.taskComment,
+  });
+
+  final AswhInventoryCollectStatus status;
+  final AswhInventoryCollectStep currentStep;
+  final AswhInventoryCollectTab activeTab;
+  final List<InventoryTaskItem> taskItems;
+  final List<InventoryCollectingRecord> collectingItems;
+  final List<InventoryCollectingRecord> collectedItems;
+  final Set<String> selectedIds;
+  final List<InventoryPickLocation> pickLocations;
+  final bool isLoading;
+  final bool isSubmitting;
+  final String? message;
+  final String? currentTrayCode;
+  final String? currentSiteCode;
+  final InventoryTaskItem? activeTask;
+  final AswhCollectPopup? popup;
+  final AswhCollectCommandMenu commandMenu;
+  final String? lastScannedCode;
+  final InventoryCollectStateSnapshot? restoredSnapshot;
+  final InventoryPickLocation? selectedPickLocation;
+  final Map<String, InventoryMatControl> materialControls;
+  final String? taskId;
+  final String? taskComment;
+
+  AswhInventoryCollectState copyWith({
+    AswhInventoryCollectStatus? status,
+    AswhInventoryCollectStep? currentStep,
+    AswhInventoryCollectTab? activeTab,
+    List<InventoryTaskItem>? taskItems,
+    List<InventoryCollectingRecord>? collectingItems,
+    List<InventoryCollectingRecord>? collectedItems,
+    Set<String>? selectedIds,
+    List<InventoryPickLocation>? pickLocations,
+    bool? isLoading,
+    bool? isSubmitting,
+    Object? message = _messageNoChange,
+    String? currentTrayCode,
+    String? currentSiteCode,
+    InventoryTaskItem? activeTask,
+    Object? popup = _popupNoChange,
+    AswhCollectCommandMenu? commandMenu,
+    String? lastScannedCode,
+    InventoryCollectStateSnapshot? restoredSnapshot,
+    InventoryPickLocation? selectedPickLocation,
+    Map<String, InventoryMatControl>? materialControls,
+    Object? taskId = _taskIdNoChange,
+    Object? taskComment = _taskCommentNoChange,
+  }) {
+    return AswhInventoryCollectState(
+      status: status ?? this.status,
+      currentStep: currentStep ?? this.currentStep,
+      activeTab: activeTab ?? this.activeTab,
+      taskItems: taskItems ?? this.taskItems,
+      collectingItems: collectingItems ?? this.collectingItems,
+      collectedItems: collectedItems ?? this.collectedItems,
+      selectedIds: selectedIds ?? this.selectedIds,
+      pickLocations: pickLocations ?? this.pickLocations,
+      isLoading: isLoading ?? this.isLoading,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      message:
+          identical(message, _messageNoChange) ? this.message : message as String?,
+      currentTrayCode: currentTrayCode ?? this.currentTrayCode,
+      currentSiteCode: currentSiteCode ?? this.currentSiteCode,
+      activeTask: activeTask ?? this.activeTask,
+      popup: identical(popup, _popupNoChange)
+          ? this.popup
+          : popup as AswhCollectPopup?,
+      commandMenu: commandMenu ?? this.commandMenu,
+      lastScannedCode: lastScannedCode ?? this.lastScannedCode,
+      restoredSnapshot: restoredSnapshot ?? this.restoredSnapshot,
+      selectedPickLocation: selectedPickLocation ?? this.selectedPickLocation,
+      materialControls: materialControls ?? this.materialControls,
+      taskId: identical(taskId, _taskIdNoChange)
+          ? this.taskId
+          : taskId as String?,
+      taskComment: identical(taskComment, _taskCommentNoChange)
+          ? this.taskComment
+          : taskComment as String?,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        currentStep,
+        activeTab,
+        taskItems,
+        collectingItems,
+        collectedItems,
+        selectedIds.toList(),
+        pickLocations,
+        isLoading,
+        isSubmitting,
+        message,
+        currentTrayCode,
+        currentSiteCode,
+        activeTask,
+        popup,
+        commandMenu,
+        lastScannedCode,
+        restoredSnapshot,
+        selectedPickLocation,
+        materialControls,
+        taskId,
+        taskComment,
+      ];
+}

--- a/lib/modules/aswh_inventory/collection_task/collect_detail/aswh_inventory_collect_detail_page.dart
+++ b/lib/modules/aswh_inventory/collection_task/collect_detail/aswh_inventory_collect_detail_page.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../../../common_widgets/common_grid/common_data_grid.dart';
+import '../../models/inventory_collect_detail_models.dart';
+import '../../models/inventory_collect_models.dart';
+import '../bloc/aswh_inventory_collect_detail_bloc.dart';
+import '../bloc/aswh_inventory_collect_detail_event.dart';
+import '../bloc/aswh_inventory_collect_detail_state.dart';
+
+class AswhInventoryCollectDetailPage extends StatefulWidget {
+  const AswhInventoryCollectDetailPage({super.key});
+
+  @override
+  State<AswhInventoryCollectDetailPage> createState() =>
+      _AswhInventoryCollectDetailPageState();
+}
+
+class _AswhInventoryCollectDetailPageState
+    extends State<AswhInventoryCollectDetailPage> {
+  bool _initialized = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+
+    final args = Modular.args.data;
+    if (args is Map) {
+      final taskId = (args['taskId'] ?? '').toString();
+      final taskComment = (args['taskComment'] ?? '').toString();
+      final records = (args['records'] as List?)
+              ?.map(
+                (e) => InventoryCollectingRecord.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          const <InventoryCollectingRecord>[];
+      final taskItems = (args['taskItems'] as List?)
+              ?.map(
+                (e) => InventoryTaskItem.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          const <InventoryTaskItem>[];
+
+      final activeTrayNo = args['currentTrayNo'] as String?;
+      final activeStoreSiteNo = args['currentSiteNo'] as String?;
+      final lastScannedCode = args['lastScannedCode'] as String?;
+
+      context.read<AswhInventoryCollectDetailBloc>().add(
+            AswhInventoryCollectDetailStarted(
+              taskId: taskId,
+              taskComment: taskComment,
+              records: records,
+              taskItems: taskItems,
+              activeTrayNo: activeTrayNo,
+              activeStoreSiteNo: activeStoreSiteNo,
+              lastScannedCode: lastScannedCode,
+            ),
+          );
+    }
+
+    _initialized = true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<AswhInventoryCollectDetailBloc,
+        AswhInventoryCollectDetailState>(
+      listenWhen: (previous, current) =>
+          previous.pendingDeletion != current.pendingDeletion ||
+          previous.message != current.message ||
+          previous.status != current.status,
+      listener: (context, state) async {
+        final messenger = ScaffoldMessenger.of(context);
+
+        if (state.message != null && state.message!.isNotEmpty) {
+          messenger
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(content: Text(state.message!)),
+            );
+        }
+
+        if (state.pendingDeletion) {
+          final confirmed = await showDialog<bool>(
+            context: context,
+            builder: (context) {
+              return AlertDialog(
+                title: const Text('确认删除'),
+                content: Text('确定删除选中的 ${state.selectedIds.length} 条记录吗？'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(false),
+                    child: const Text('取消'),
+                  ),
+                  FilledButton(
+                    onPressed: () => Navigator.of(context).pop(true),
+                    child: const Text('删除'),
+                  ),
+                ],
+              );
+            },
+          );
+
+          if (confirmed == true) {
+            context
+                .read<AswhInventoryCollectDetailBloc>()
+                .add(const AswhInventoryCollectDetailDeletionConfirmed());
+          } else {
+            context
+                .read<AswhInventoryCollectDetailBloc>()
+                .add(const AswhInventoryCollectDetailDeletionCancelled());
+          }
+        }
+
+        if (state.status == AswhInventoryCollectDetailStatus.success) {
+          await Future.delayed(const Duration(milliseconds: 300));
+          if (mounted) {
+            _finishWithResult(context, state: state);
+          }
+        }
+      },
+      builder: (context, state) {
+        final selectedIndices = state.items.asMap().entries
+            .where((entry) => state.selectedIds.contains(entry.value.stockId))
+            .map((entry) => entry.key)
+            .toList();
+
+        return PopScope(
+          canPop: false,
+          onPopInvokedWithResult: (didPop, result) {
+            if (didPop) return;
+            _finishWithResult(context, state: state);
+          },
+          child: Scaffold(
+            appBar: AppBar(
+              title: const Text('立库盘点采集结果'),
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back_ios_new),
+                onPressed: () => _finishWithResult(context, state: state),
+              ),
+            ),
+            body: Stack(
+              children: [
+                Column(
+                  children: [
+                    Expanded(
+                      child: state.items.isEmpty
+                          ? const Center(child: Text('暂无采集记录'))
+                          : Padding(
+                              padding: const EdgeInsets.all(16),
+                              child: CommonDataGrid<InventoryCollectedItem>(
+                                columns: _resultColumns(),
+                                datas: state.items,
+                                allowPager: false,
+                                allowSelect: true,
+                                selectedRows: selectedIndices,
+                                onLoadData: (_) async {},
+                                onSelectionChanged: (indices) {
+                                  final ids = indices
+                                      .where((index) =>
+                                          index >= 0 &&
+                                          index < state.items.length)
+                                      .map((index) =>
+                                          state.items[index].stockId)
+                                      .toSet();
+                                  context
+                                      .read<AswhInventoryCollectDetailBloc>()
+                                      .add(
+                                        AswhInventoryCollectDetailSelectionChanged(
+                                          ids,
+                                        ),
+                                      );
+                                },
+                                currentPage: 1,
+                                totalPages: 1,
+                              ),
+                            ),
+                    ),
+                    _buildBottomBar(context, state),
+                  ],
+                ),
+                if (state.status == AswhInventoryCollectDetailStatus.updating ||
+                    state.status == AswhInventoryCollectDetailStatus.loading)
+                  Container(
+                    color: Colors.black26,
+                    child: const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildBottomBar(
+    BuildContext context,
+    AswhInventoryCollectDetailState state,
+  ) {
+    final bloc = context.read<AswhInventoryCollectDetailBloc>();
+    final total = state.items.length;
+    final selected = state.selectedIds.length;
+
+    return Container(
+      height: 64,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black12,
+            offset: Offset(0, -2),
+            blurRadius: 4,
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Checkbox(
+            value: total > 0 && state.isAllSelected,
+            onChanged: total == 0
+                ? null
+                : (value) => bloc.add(
+                      AswhInventoryCollectDetailSelectAllToggled(value ?? false),
+                    ),
+          ),
+          const Text('全选'),
+          const SizedBox(width: 12),
+          Text('已选 $selected / $total'),
+          const Spacer(),
+          FilledButton.icon(
+            onPressed: total == 0
+                ? null
+                : () => bloc.add(
+                      const AswhInventoryCollectDetailDeleteRequested(),
+                    ),
+            icon: const Icon(Icons.delete_outline),
+            label: const Text('删除'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<GridColumnConfig<InventoryCollectedItem>> _resultColumns() {
+    return [
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'trayNo',
+        headerText: '托盘号',
+        valueGetter: (row) => row.trayNo ?? '-',
+      ),
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'materialCode',
+        headerText: '物料编码',
+        valueGetter: (row) => row.materialCode,
+      ),
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'sourceQty',
+        headerText: '采集数量',
+        valueGetter: (row) => row.sourceQty.toString(),
+      ),
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'batchNo',
+        headerText: '批次号',
+        valueGetter: (row) => row.batchNo ?? '-',
+      ),
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'serialNo',
+        headerText: '序列号',
+        valueGetter: (row) => row.serialNo ?? '-',
+      ),
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'storeRoom',
+        headerText: '库房',
+        valueGetter: (row) => row.storeRoomNo,
+      ),
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'storeSite',
+        headerText: '库位',
+        valueGetter: (row) => row.storeSiteNo,
+      ),
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'invTaskItemId',
+        headerText: '任务明细ID',
+        valueGetter: (row) => row.invTaskItemId,
+      ),
+      GridColumnConfig<InventoryCollectedItem>(
+        name: 'stockId',
+        headerText: '记录ID',
+        valueGetter: (row) => row.stockId,
+      ),
+    ];
+  }
+
+  void _finishWithResult(
+    BuildContext context, {
+    AswhInventoryCollectDetailState? state,
+  }) {
+    final blocState = state ??
+        context.read<AswhInventoryCollectDetailBloc>().state;
+    final records = blocState.items
+        .map(
+          (item) => item
+              .toRecord(taskComment: blocState.taskComment ?? '')
+              .toJson(),
+        )
+        .toList();
+    final taskItems = blocState.taskItems.map((item) => item.toJson()).toList();
+
+    Modular.to.pop({
+      'records': records,
+      'taskItems': taskItems,
+      'message': blocState.hasChanges ? '采集结果已更新' : null,
+    });
+  }
+}

--- a/lib/modules/aswh_inventory/collection_task/collect_detail/bloc/aswh_inventory_collect_detail_bloc.dart
+++ b/lib/modules/aswh_inventory/collection_task/collect_detail/bloc/aswh_inventory_collect_detail_bloc.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../models/inventory_collect_detail_models.dart';
+import '../../models/inventory_collect_models.dart';
+import '../../repositories/inventory_collect_cache_repository.dart';
+import 'aswh_inventory_collect_detail_event.dart';
+import 'aswh_inventory_collect_detail_state.dart';
+
+class AswhInventoryCollectDetailBloc extends Bloc<
+    AswhInventoryCollectDetailEvent, AswhInventoryCollectDetailState> {
+  AswhInventoryCollectDetailBloc({
+    required InventoryCollectCacheRepository cacheRepository,
+  })  : _cacheRepository = cacheRepository,
+        super(const AswhInventoryCollectDetailState()) {
+    on<AswhInventoryCollectDetailStarted>(_onStarted);
+    on<AswhInventoryCollectDetailSelectionChanged>(_onSelectionChanged);
+    on<AswhInventoryCollectDetailSelectAllToggled>(_onSelectAllToggled);
+    on<AswhInventoryCollectDetailDeleteRequested>(_onDeleteRequested);
+    on<AswhInventoryCollectDetailDeletionCancelled>(_onDeletionCancelled);
+    on<AswhInventoryCollectDetailDeletionConfirmed>(_onDeletionConfirmed);
+  }
+
+  final InventoryCollectCacheRepository _cacheRepository;
+
+  Future<void> _onStarted(
+    AswhInventoryCollectDetailStarted event,
+    Emitter<AswhInventoryCollectDetailState> emit,
+  ) async {
+    emit(state.copyWith(status: AswhInventoryCollectDetailStatus.loading));
+
+    final generatedItems = event.records.mapIndexed((index, record) {
+      final timestamp = record.collectedAt?.millisecondsSinceEpoch ??
+          DateTime.now().millisecondsSinceEpoch;
+      final stockId =
+          '${record.taskItemId}_${record.trayNo ?? ''}_${record.batchNo ?? ''}_${record.serialNo ?? ''}_$timestamp\_$index';
+      return InventoryCollectedItem.fromRecord(
+        record,
+        stockId: stockId,
+        sourceQty: record.collectQty,
+      );
+    }).toList();
+
+    emit(
+      state.copyWith(
+        status: AswhInventoryCollectDetailStatus.ready,
+        items: generatedItems,
+        taskItems: event.taskItems,
+        taskId: event.taskId,
+        taskComment: event.taskComment,
+        activeTrayNo: event.activeTrayNo,
+        activeStoreSiteNo: event.activeStoreSiteNo,
+        lastScannedCode: event.lastScannedCode,
+        message: generatedItems.isEmpty ? '暂无采集记录' : null,
+      ),
+    );
+  }
+
+  Future<void> _onSelectionChanged(
+    AswhInventoryCollectDetailSelectionChanged event,
+    Emitter<AswhInventoryCollectDetailState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        selectedIds: event.selectedIds,
+        message: state.message,
+      ),
+    );
+  }
+
+  Future<void> _onSelectAllToggled(
+    AswhInventoryCollectDetailSelectAllToggled event,
+    Emitter<AswhInventoryCollectDetailState> emit,
+  ) async {
+    final updatedIds = event.selectAll
+        ? state.items.map((item) => item.stockId).toSet()
+        : <String>{};
+    emit(
+      state.copyWith(
+        selectedIds: updatedIds,
+        message: state.message,
+      ),
+    );
+  }
+
+  Future<void> _onDeleteRequested(
+    AswhInventoryCollectDetailDeleteRequested event,
+    Emitter<AswhInventoryCollectDetailState> emit,
+  ) async {
+    if (state.selectedIds.isEmpty) {
+      emit(
+        state.copyWith(
+          message: '请至少选择一条记录',
+          pendingDeletion: false,
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        pendingDeletion: true,
+        message: state.message,
+      ),
+    );
+  }
+
+  Future<void> _onDeletionCancelled(
+    AswhInventoryCollectDetailDeletionCancelled event,
+    Emitter<AswhInventoryCollectDetailState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        pendingDeletion: false,
+        message: state.message,
+      ),
+    );
+  }
+
+  Future<void> _onDeletionConfirmed(
+    AswhInventoryCollectDetailDeletionConfirmed event,
+    Emitter<AswhInventoryCollectDetailState> emit,
+  ) async {
+    if (state.selectedIds.isEmpty) {
+      emit(
+        state.copyWith(
+          pendingDeletion: false,
+          message: '请选择需要删除的记录',
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: AswhInventoryCollectDetailStatus.updating,
+        pendingDeletion: false,
+        message: '正在删除选中的采集记录...',
+      ),
+    );
+
+    final toRemove = state.items
+        .where((item) => state.selectedIds.contains(item.stockId))
+        .toList();
+
+    if (toRemove.isEmpty) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryCollectDetailStatus.ready,
+          message: '未找到需要删除的记录',
+        ),
+      );
+      return;
+    }
+
+    final remainingItems = state.items
+        .where((item) => !state.selectedIds.contains(item.stockId))
+        .toList();
+
+    final removalMap = <String, double>{};
+    for (final item in toRemove) {
+      removalMap[item.invTaskItemId] =
+          (removalMap[item.invTaskItemId] ?? 0) + item.sourceQty;
+    }
+
+    final updatedTaskItems = state.taskItems.map((taskItem) {
+      final itemId = _resolveTaskItemId(taskItem);
+      final removed = removalMap[itemId] ?? 0;
+      final updatedQty = math.max(0, taskItem.collectedQty - removed);
+      return taskItem.copyWith(collectedQty: updatedQty);
+    }).toList();
+
+    final updatedRecords = remainingItems
+        .map(
+          (item) => item.toRecord(
+            taskComment: state.taskComment ?? '',
+          ),
+        )
+        .toList();
+
+    if (_cacheRepository.isReady &&
+        state.taskId != null &&
+        state.taskComment != null) {
+      final snapshot = InventoryCollectStateSnapshot(
+        taskId: state.taskId!,
+        taskComment: state.taskComment!,
+        activeTrayNo: state.activeTrayNo,
+        activeStoreSiteNo: state.activeStoreSiteNo,
+        lastScannedCode: state.lastScannedCode,
+        taskItems: updatedTaskItems,
+        collectedRecords: updatedRecords,
+        updatedAt: DateTime.now(),
+      );
+      await _cacheRepository.persistSnapshot(snapshot);
+    }
+
+    emit(
+      state.copyWith(
+        status: AswhInventoryCollectDetailStatus.success,
+        items: remainingItems,
+        taskItems: updatedTaskItems,
+        selectedIds: <String>{},
+        hasChanges: true,
+        message: '已删除 ${toRemove.length} 条采集记录',
+      ),
+    );
+  }
+
+  String _resolveTaskItemId(InventoryTaskItem item) {
+    return (item.checkItemId?.toString().isNotEmpty == true
+            ? item.checkItemId.toString()
+            : item.checkTaskId?.toString()) ??
+        item.palletNo ??
+        item.materialCode ??
+        item.checkTaskNo ??
+        '';
+  }
+}

--- a/lib/modules/aswh_inventory/collection_task/collect_detail/bloc/aswh_inventory_collect_detail_event.dart
+++ b/lib/modules/aswh_inventory/collection_task/collect_detail/bloc/aswh_inventory_collect_detail_event.dart
@@ -1,0 +1,77 @@
+import 'package:equatable/equatable.dart';
+
+import '../../models/inventory_collect_models.dart';
+
+abstract class AswhInventoryCollectDetailEvent extends Equatable {
+  const AswhInventoryCollectDetailEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AswhInventoryCollectDetailStarted
+    extends AswhInventoryCollectDetailEvent {
+  const AswhInventoryCollectDetailStarted({
+    required this.taskId,
+    required this.taskComment,
+    required this.records,
+    required this.taskItems,
+    this.activeTrayNo,
+    this.activeStoreSiteNo,
+    this.lastScannedCode,
+  });
+
+  final String taskId;
+  final String taskComment;
+  final List<InventoryCollectingRecord> records;
+  final List<InventoryTaskItem> taskItems;
+  final String? activeTrayNo;
+  final String? activeStoreSiteNo;
+  final String? lastScannedCode;
+
+  @override
+  List<Object?> get props => [
+        taskId,
+        taskComment,
+        records,
+        taskItems,
+        activeTrayNo,
+        activeStoreSiteNo,
+        lastScannedCode,
+      ];
+}
+
+class AswhInventoryCollectDetailSelectionChanged
+    extends AswhInventoryCollectDetailEvent {
+  const AswhInventoryCollectDetailSelectionChanged(this.selectedIds);
+
+  final Set<String> selectedIds;
+
+  @override
+  List<Object?> get props => [selectedIds];
+}
+
+class AswhInventoryCollectDetailSelectAllToggled
+    extends AswhInventoryCollectDetailEvent {
+  const AswhInventoryCollectDetailSelectAllToggled(this.selectAll);
+
+  final bool selectAll;
+
+  @override
+  List<Object?> get props => [selectAll];
+}
+
+class AswhInventoryCollectDetailDeleteRequested
+    extends AswhInventoryCollectDetailEvent {
+  const AswhInventoryCollectDetailDeleteRequested();
+}
+
+class AswhInventoryCollectDetailDeletionConfirmed
+    extends AswhInventoryCollectDetailEvent {
+  const AswhInventoryCollectDetailDeletionConfirmed();
+}
+
+class AswhInventoryCollectDetailDeletionCancelled
+    extends AswhInventoryCollectDetailEvent {
+  const AswhInventoryCollectDetailDeletionCancelled();
+}

--- a/lib/modules/aswh_inventory/collection_task/collect_detail/bloc/aswh_inventory_collect_detail_state.dart
+++ b/lib/modules/aswh_inventory/collection_task/collect_detail/bloc/aswh_inventory_collect_detail_state.dart
@@ -1,0 +1,90 @@
+import 'package:equatable/equatable.dart';
+
+import '../../models/inventory_collect_models.dart';
+import '../../models/inventory_collect_detail_models.dart';
+
+enum AswhInventoryCollectDetailStatus { initial, loading, ready, updating, success, failure }
+
+class AswhInventoryCollectDetailState extends Equatable {
+  const AswhInventoryCollectDetailState({
+    this.status = AswhInventoryCollectDetailStatus.initial,
+    this.items = const <InventoryCollectedItem>[],
+    this.taskItems = const <InventoryTaskItem>[],
+    this.selectedIds = const <String>{},
+    this.pendingDeletion = false,
+    this.isAllSelected = false,
+    this.message,
+    this.taskId,
+    this.taskComment,
+    this.hasChanges = false,
+    this.activeTrayNo,
+    this.activeStoreSiteNo,
+    this.lastScannedCode,
+  });
+
+  final AswhInventoryCollectDetailStatus status;
+  final List<InventoryCollectedItem> items;
+  final List<InventoryTaskItem> taskItems;
+  final Set<String> selectedIds;
+  final bool pendingDeletion;
+  final bool isAllSelected;
+  final String? message;
+  final String? taskId;
+  final String? taskComment;
+  final bool hasChanges;
+  final String? activeTrayNo;
+  final String? activeStoreSiteNo;
+  final String? lastScannedCode;
+
+  AswhInventoryCollectDetailState copyWith({
+    AswhInventoryCollectDetailStatus? status,
+    List<InventoryCollectedItem>? items,
+    List<InventoryTaskItem>? taskItems,
+    Set<String>? selectedIds,
+    bool? pendingDeletion,
+    bool? isAllSelected,
+    String? message,
+    String? taskId,
+    String? taskComment,
+    bool? hasChanges,
+    String? activeTrayNo,
+    String? activeStoreSiteNo,
+    String? lastScannedCode,
+  }) {
+    return AswhInventoryCollectDetailState(
+      status: status ?? this.status,
+      items: items ?? this.items,
+      taskItems: taskItems ?? this.taskItems,
+      selectedIds: selectedIds ?? this.selectedIds,
+      pendingDeletion: pendingDeletion ?? this.pendingDeletion,
+      isAllSelected: isAllSelected ??
+          ((selectedIds ?? this.selectedIds).length ==
+                  (items ?? this.items).length &&
+              (items ?? this.items).isNotEmpty),
+      message: message,
+      taskId: taskId ?? this.taskId,
+      taskComment: taskComment ?? this.taskComment,
+      hasChanges: hasChanges ?? this.hasChanges,
+      activeTrayNo: activeTrayNo ?? this.activeTrayNo,
+      activeStoreSiteNo: activeStoreSiteNo ?? this.activeStoreSiteNo,
+      lastScannedCode: lastScannedCode ?? this.lastScannedCode,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        items,
+        taskItems,
+        selectedIds,
+        pendingDeletion,
+        isAllSelected,
+        message,
+        taskId,
+        taskComment,
+        hasChanges,
+        activeTrayNo,
+        activeStoreSiteNo,
+        lastScannedCode,
+      ];
+}

--- a/lib/modules/aswh_inventory/collection_task/models/inventory_collect_detail_models.dart
+++ b/lib/modules/aswh_inventory/collection_task/models/inventory_collect_detail_models.dart
@@ -1,0 +1,85 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'inventory_collect_models.dart';
+
+part 'inventory_collect_detail_models.freezed.dart';
+part 'inventory_collect_detail_models.g.dart';
+
+/// 采集结果项，用于采集结果页展示与删除操作
+@freezed
+class InventoryCollectedItem with _$InventoryCollectedItem {
+  const factory InventoryCollectedItem({
+    /// 本地缓存记录ID
+    @JsonKey(name: 'stockid') required String stockId,
+
+    /// 对应的盘点任务明细ID
+    @JsonKey(name: 'InvTaskItemid') required String invTaskItemId,
+
+    /// 采集数量（源数量）
+    @JsonKey(name: 'InventoryQty') @Default(0) double sourceQty,
+
+    /// 物料编码
+    @JsonKey(name: 'matcode') required String materialCode,
+
+    /// 物料名称
+    @JsonKey(name: 'matname') String? materialName,
+
+    /// 批次号
+    @JsonKey(name: 'batchno') String? batchNo,
+
+    /// 序列号
+    @JsonKey(name: 'sn') String? serialNo,
+
+    /// 库房编码
+    @JsonKey(name: 'storeRoom') required String storeRoomNo,
+
+    /// 库位编码
+    @JsonKey(name: 'storeSite') required String storeSiteNo,
+
+    /// 托盘号
+    @JsonKey(name: 'TrayNo') String? trayNo,
+
+    /// 物料主数据ID
+    @JsonKey(name: 'MatId') String? materialId,
+  }) = _InventoryCollectedItem;
+
+  factory InventoryCollectedItem.fromJson(Map<String, dynamic> json) =>
+      _$InventoryCollectedItemFromJson(json);
+
+  factory InventoryCollectedItem.fromRecord(
+    InventoryCollectingRecord record, {
+    required String stockId,
+    double? sourceQty,
+  }) {
+    return InventoryCollectedItem(
+      stockId: stockId,
+      invTaskItemId: record.taskItemId,
+      sourceQty: sourceQty ?? record.collectQty,
+      materialCode: record.materialCode,
+      materialName: null,
+      batchNo: record.batchNo,
+      serialNo: record.serialNo,
+      storeRoomNo: record.storeRoomNo,
+      storeSiteNo: record.storeSiteNo,
+      trayNo: record.trayNo,
+      materialId: record.materialId,
+    );
+  }
+}
+
+extension InventoryCollectedItemX on InventoryCollectedItem {
+  InventoryCollectingRecord toRecord({required String taskComment}) {
+    return InventoryCollectingRecord(
+      taskComment: taskComment,
+      taskItemId: invTaskItemId,
+      materialCode: materialCode,
+      materialId: materialId,
+      storeRoomNo: storeRoomNo,
+      storeSiteNo: storeSiteNo,
+      collectQty: sourceQty,
+      batchNo: batchNo,
+      serialNo: serialNo,
+      trayNo: trayNo,
+    );
+  }
+}

--- a/lib/modules/aswh_inventory/collection_task/models/inventory_collect_detail_models.freezed.dart
+++ b/lib/modules/aswh_inventory/collection_task/models/inventory_collect_detail_models.freezed.dart
@@ -1,0 +1,442 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package,
+// use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null,
+// invalid_override_different_default_values_named, prefer_expression_function_bodies,
+// annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_collect_detail_models.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+InventoryCollectedItem _$InventoryCollectedItemFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryCollectedItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryCollectedItem {
+  /// 本地缓存记录ID
+  @JsonKey(name: 'stockid')
+  String get stockId => throw _privateConstructorUsedError;
+
+  /// 对应的盘点任务明细ID
+  @JsonKey(name: 'InvTaskItemid')
+  String get invTaskItemId => throw _privateConstructorUsedError;
+
+  /// 采集数量（源数量）
+  @JsonKey(name: 'InventoryQty')
+  double get sourceQty => throw _privateConstructorUsedError;
+
+  /// 物料编码
+  @JsonKey(name: 'matcode')
+  String get materialCode => throw _privateConstructorUsedError;
+
+  /// 物料名称
+  @JsonKey(name: 'matname')
+  String? get materialName => throw _privateConstructorUsedError;
+
+  /// 批次号
+  @JsonKey(name: 'batchno')
+  String? get batchNo => throw _privateConstructorUsedError;
+
+  /// 序列号
+  @JsonKey(name: 'sn')
+  String? get serialNo => throw _privateConstructorUsedError;
+
+  /// 库房编码
+  @JsonKey(name: 'storeRoom')
+  String get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 库位编码
+  @JsonKey(name: 'storeSite')
+  String get storeSiteNo => throw _privateConstructorUsedError;
+
+  /// 托盘号
+  @JsonKey(name: 'TrayNo')
+  String? get trayNo => throw _privateConstructorUsedError;
+
+  /// 物料主数据ID
+  @JsonKey(name: 'MatId')
+  String? get materialId => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryCollectedItemCopyWith<InventoryCollectedItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryCollectedItemCopyWith<$Res> {
+  factory $InventoryCollectedItemCopyWith(InventoryCollectedItem value,
+          $Res Function(InventoryCollectedItem) then) =
+      _$InventoryCollectedItemCopyWithImpl<$Res, InventoryCollectedItem>;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'stockid') String stockId,
+    @JsonKey(name: 'InvTaskItemid') String invTaskItemId,
+    @JsonKey(name: 'InventoryQty') double sourceQty,
+    @JsonKey(name: 'matcode') String materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNo,
+    @JsonKey(name: 'storeRoom') String storeRoomNo,
+    @JsonKey(name: 'storeSite') String storeSiteNo,
+    @JsonKey(name: 'TrayNo') String? trayNo,
+    @JsonKey(name: 'MatId') String? materialId,
+  });
+}
+
+/// @nodoc
+class _$InventoryCollectedItemCopyWithImpl<$Res,
+        $Val extends InventoryCollectedItem>
+    implements $InventoryCollectedItemCopyWith<$Res> {
+  _$InventoryCollectedItemCopyWithImpl(this._value, this._then);
+
+  final $Val _value;
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? stockId = null,
+    Object? invTaskItemId = null,
+    Object? sourceQty = null,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? storeRoomNo = null,
+    Object? storeSiteNo = null,
+    Object? trayNo = freezed,
+    Object? materialId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      stockId: null == stockId
+          ? _value.stockId
+          : stockId // ignore: cast_nullable_to_non_nullable
+              as String,
+      invTaskItemId: null == invTaskItemId
+          ? _value.invTaskItemId
+          : invTaskItemId // ignore: cast_nullable_to_non_nullable
+              as String,
+      sourceQty: null == sourceQty
+          ? _value.sourceQty
+          : sourceQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomNo: null == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      trayNo: freezed == trayNo
+          ? _value.trayNo
+          : trayNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialId: freezed == materialId
+          ? _value.materialId
+          : materialId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryCollectedItemImplCopyWith<$Res>
+    implements $InventoryCollectedItemCopyWith<$Res> {
+  factory _$$InventoryCollectedItemImplCopyWith(
+          _$InventoryCollectedItemImpl value,
+          $Res Function(_$InventoryCollectedItemImpl) then) =
+      __$$InventoryCollectedItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'stockid') String stockId,
+    @JsonKey(name: 'InvTaskItemid') String invTaskItemId,
+    @JsonKey(name: 'InventoryQty') double sourceQty,
+    @JsonKey(name: 'matcode') String materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNo,
+    @JsonKey(name: 'storeRoom') String storeRoomNo,
+    @JsonKey(name: 'storeSite') String storeSiteNo,
+    @JsonKey(name: 'TrayNo') String? trayNo,
+    @JsonKey(name: 'MatId') String? materialId,
+  });
+}
+
+/// @nodoc
+class __$$InventoryCollectedItemImplCopyWithImpl<$Res>
+    extends _$InventoryCollectedItemCopyWithImpl<$Res,
+        _$InventoryCollectedItemImpl>
+    implements _$$InventoryCollectedItemImplCopyWith<$Res> {
+  __$$InventoryCollectedItemImplCopyWithImpl(
+      _$InventoryCollectedItemImpl _value,
+      $Res Function(_$InventoryCollectedItemImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? stockId = null,
+    Object? invTaskItemId = null,
+    Object? sourceQty = null,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? storeRoomNo = null,
+    Object? storeSiteNo = null,
+    Object? trayNo = freezed,
+    Object? materialId = freezed,
+  }) {
+    return _then(_$InventoryCollectedItemImpl(
+      stockId: null == stockId
+          ? _value.stockId
+          : stockId // ignore: cast_nullable_to_non_nullable
+              as String,
+      invTaskItemId: null == invTaskItemId
+          ? _value.invTaskItemId
+          : invTaskItemId // ignore: cast_nullable_to_non_nullable
+              as String,
+      sourceQty: null == sourceQty
+          ? _value.sourceQty
+          : sourceQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomNo: null == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      trayNo: freezed == trayNo
+          ? _value.trayNo
+          : trayNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialId: freezed == materialId
+          ? _value.materialId
+          : materialId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryCollectedItemImpl implements _InventoryCollectedItem {
+  const _$InventoryCollectedItemImpl({
+    @JsonKey(name: 'stockid') required this.stockId,
+    @JsonKey(name: 'InvTaskItemid') required this.invTaskItemId,
+    @JsonKey(name: 'InventoryQty') this.sourceQty = 0,
+    @JsonKey(name: 'matcode') required this.materialCode,
+    @JsonKey(name: 'matname') this.materialName,
+    @JsonKey(name: 'batchno') this.batchNo,
+    @JsonKey(name: 'sn') this.serialNo,
+    @JsonKey(name: 'storeRoom') required this.storeRoomNo,
+    @JsonKey(name: 'storeSite') required this.storeSiteNo,
+    @JsonKey(name: 'TrayNo') this.trayNo,
+    @JsonKey(name: 'MatId') this.materialId,
+  });
+
+  factory _$InventoryCollectedItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryCollectedItemImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'stockid')
+  final String stockId;
+  @override
+  @JsonKey(name: 'InvTaskItemid')
+  final String invTaskItemId;
+  @override
+  @JsonKey(name: 'InventoryQty')
+  final double sourceQty;
+  @override
+  @JsonKey(name: 'matcode')
+  final String materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  final String? materialName;
+  @override
+  @JsonKey(name: 'batchno')
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNo;
+  @override
+  @JsonKey(name: 'storeRoom')
+  final String storeRoomNo;
+  @override
+  @JsonKey(name: 'storeSite')
+  final String storeSiteNo;
+  @override
+  @JsonKey(name: 'TrayNo')
+  final String? trayNo;
+  @override
+  @JsonKey(name: 'MatId')
+  final String? materialId;
+
+  @override
+  String toString() {
+    return 'InventoryCollectedItem(stockId: $stockId, invTaskItemId: $invTaskItemId, sourceQty: $sourceQty, materialCode: $materialCode, materialName: $materialName, batchNo: $batchNo, serialNo: $serialNo, storeRoomNo: $storeRoomNo, storeSiteNo: $storeSiteNo, trayNo: $trayNo, materialId: $materialId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryCollectedItemImpl &&
+            (identical(other.stockId, stockId) || other.stockId == stockId) &&
+            (identical(other.invTaskItemId, invTaskItemId) ||
+                other.invTaskItemId == invTaskItemId) &&
+            (identical(other.sourceQty, sourceQty) ||
+                other.sourceQty == sourceQty) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.trayNo, trayNo) || other.trayNo == trayNo) &&
+            (identical(other.materialId, materialId) ||
+                other.materialId == materialId));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        stockId,
+        invTaskItemId,
+        sourceQty,
+        materialCode,
+        materialName,
+        batchNo,
+        serialNo,
+        storeRoomNo,
+        storeSiteNo,
+        trayNo,
+        materialId,
+      );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryCollectedItemImplCopyWith<_$InventoryCollectedItemImpl>
+      get copyWith => __$$InventoryCollectedItemImplCopyWithImpl<
+          _$InventoryCollectedItemImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryCollectedItemImplToJson(
+      this,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _InventoryCollectedItem implements InventoryCollectedItem {
+  const factory _InventoryCollectedItem({
+    @JsonKey(name: 'stockid') required final String stockId,
+    @JsonKey(name: 'InvTaskItemid') required final String invTaskItemId,
+    @JsonKey(name: 'InventoryQty') final double sourceQty,
+    @JsonKey(name: 'matcode') required final String materialCode,
+    @JsonKey(name: 'matname') final String? materialName,
+    @JsonKey(name: 'batchno') final String? batchNo,
+    @JsonKey(name: 'sn') final String? serialNo,
+    @JsonKey(name: 'storeRoom') required final String storeRoomNo,
+    @JsonKey(name: 'storeSite') required final String storeSiteNo,
+    @JsonKey(name: 'TrayNo') final String? trayNo,
+    @JsonKey(name: 'MatId') final String? materialId,
+  }) = _$InventoryCollectedItemImpl;
+
+  factory _InventoryCollectedItem.fromJson(Map<String, dynamic> json) =
+      _$InventoryCollectedItemImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'stockid')
+  String get stockId;
+  @override
+  @JsonKey(name: 'InvTaskItemid')
+  String get invTaskItemId;
+  @override
+  @JsonKey(name: 'InventoryQty')
+  double get sourceQty;
+  @override
+  @JsonKey(name: 'matcode')
+  String get materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  String? get materialName;
+  @override
+  @JsonKey(name: 'batchno')
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  String? get serialNo;
+  @override
+  @JsonKey(name: 'storeRoom')
+  String get storeRoomNo;
+  @override
+  @JsonKey(name: 'storeSite')
+  String get storeSiteNo;
+  @override
+  @JsonKey(name: 'TrayNo')
+  String? get trayNo;
+  @override
+  @JsonKey(name: 'MatId')
+  String? get materialId;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryCollectedItemImplCopyWith<_$InventoryCollectedItemImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/aswh_inventory/collection_task/models/inventory_collect_detail_models.g.dart
+++ b/lib/modules/aswh_inventory/collection_task/models/inventory_collect_detail_models.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_collect_detail_models.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryCollectedItemImpl _$$InventoryCollectedItemImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryCollectedItemImpl(
+      stockId: json['stockid'] as String,
+      invTaskItemId: json['InvTaskItemid'] as String,
+      sourceQty: (json['InventoryQty'] as num?)?.toDouble() ?? 0,
+      materialCode: json['matcode'] as String,
+      materialName: json['matname'] as String?,
+      batchNo: json['batchno'] as String?,
+      serialNo: json['sn'] as String?,
+      storeRoomNo: json['storeRoom'] as String,
+      storeSiteNo: json['storeSite'] as String,
+      trayNo: json['TrayNo'] as String?,
+      materialId: json['MatId'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryCollectedItemImplToJson(
+        _$InventoryCollectedItemImpl instance) =>
+    <String, dynamic>{
+      'stockid': instance.stockId,
+      'InvTaskItemid': instance.invTaskItemId,
+      'InventoryQty': instance.sourceQty,
+      'matcode': instance.materialCode,
+      'matname': instance.materialName,
+      'batchno': instance.batchNo,
+      'sn': instance.serialNo,
+      'storeRoom': instance.storeRoomNo,
+      'storeSite': instance.storeSiteNo,
+      'TrayNo': instance.trayNo,
+      'MatId': instance.materialId,
+    };

--- a/lib/modules/aswh_inventory/collection_task/models/inventory_collect_models.dart
+++ b/lib/modules/aswh_inventory/collection_task/models/inventory_collect_models.dart
@@ -1,0 +1,360 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_collect_models.freezed.dart';
+part 'inventory_collect_models.g.dart';
+
+DateTime? _dateTimeFromJson(String? value) =>
+    value == null ? null : DateTime.tryParse(value);
+String? _dateTimeToJson(DateTime? value) => value?.toIso8601String();
+
+/// 盘点任务明细行数据
+@freezed
+class InventoryTaskItem with _$InventoryTaskItem {
+  const factory InventoryTaskItem({
+    /// 明细主键
+    @JsonKey(name: 'co_checkitemid') int? checkItemId,
+
+    /// 任务ID
+    @JsonKey(name: 'checktaskid') int? checkTaskId,
+
+    /// 任务号
+    @JsonKey(name: 'checktaskno') String? checkTaskNo,
+
+    /// 盘库单号
+    @JsonKey(name: 'taskcomment') String? taskComment,
+
+    /// 库房编码
+    @JsonKey(name: 'storeroomno') String? storeRoomNo,
+
+    /// 库房名称
+    @JsonKey(name: 'storeroomname') String? storeRoomName,
+
+    /// 库位编码
+    @JsonKey(name: 'storesiteno') String? storeSiteNo,
+
+    /// 库位描述
+    @JsonKey(name: 'storesite') String? storeSiteName,
+
+    /// 托盘号
+    @JsonKey(name: 'palletno') String? palletNo,
+
+    /// 物料编码
+    @JsonKey(name: 'matcode2') String? materialCode,
+
+    /// 物料名称
+    @JsonKey(name: 'matname') String? materialName,
+
+    /// 计划数量
+    @JsonKey(name: 'qty') @Default(0) double planQty,
+
+    /// 已采集数量
+    @JsonKey(name: 'collectdataqty') @Default(0) double collectedQty,
+
+    /// 盘点类型
+    @JsonKey(name: 'checkmethod_nm') String? checkMethodName,
+
+    /// 批次号
+    @JsonKey(name: 'batchno') String? batchNo,
+
+    /// 序列号
+    @JsonKey(name: 'sn') String? serialNo,
+
+    /// 供应商编码
+    @JsonKey(name: 'suppliercode') String? supplierCode,
+
+    /// 拣选位置/终点地址
+    @JsonKey(name: 'endaddr') String? endAddr,
+
+    /// ERP 子库
+    @JsonKey(name: 'erpstoreroom') String? erpStoreRoom,
+
+    /// ERP 库位
+    @JsonKey(name: 'erpstoresite') String? erpStoreSite,
+
+    /// 物料控制标识
+    @JsonKey(name: 'matcontrolflag') String? materialControlFlag,
+
+    /// 是否完成
+    @JsonKey(name: 'isfinish') @Default(false) bool isFinished,
+  }) = _InventoryTaskItem;
+
+  const InventoryTaskItem._();
+
+  factory InventoryTaskItem.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskItemFromJson(json);
+}
+
+/// 采集中/已提交的采集记录
+@freezed
+class InventoryCollectingRecord with _$InventoryCollectingRecord {
+  const factory InventoryCollectingRecord({
+    /// 盘库单号
+    @JsonKey(name: 'TaskComment') required String taskComment,
+
+    /// 任务明细 ID
+    @JsonKey(name: 'invTaskItemid') required String taskItemId,
+
+    /// 物料编码
+    @JsonKey(name: 'matCode') required String materialCode,
+
+    /// 物料主数据 ID
+    @JsonKey(name: 'materialId') String? materialId,
+
+    /// 库房编码
+    @JsonKey(name: 'storeRoomNo') required String storeRoomNo,
+
+    /// 库位编码
+    @JsonKey(name: 'storeSiteNo') required String storeSiteNo,
+
+    /// 采集数量
+    @JsonKey(name: 'collectQty') @Default(0) double collectQty,
+
+    /// 批次号
+    @JsonKey(name: 'batchNo') String? batchNo,
+
+    /// 序列号
+    @JsonKey(name: 'sn') String? serialNo,
+
+    /// 托盘号
+    @JsonKey(name: 'trayNo') String? trayNo,
+
+    /// 采集时间
+    @JsonKey(
+      name: 'collectedAt',
+      fromJson: _dateTimeFromJson,
+      toJson: _dateTimeToJson,
+    )
+    DateTime? collectedAt,
+  }) = _InventoryCollectingRecord;
+
+  factory InventoryCollectingRecord.fromJson(Map<String, dynamic> json) =>
+      _$InventoryCollectingRecordFromJson(json);
+}
+
+/// WCS 指令动作类型
+enum InventoryCollectCommandAction {
+  inventoryDown,
+  inventoryReset,
+  emptyTray,
+}
+
+/// WCS 指令请求参数
+@freezed
+class InventoryCollectCommand with _$InventoryCollectCommand {
+  const factory InventoryCollectCommand({
+    /// 任务 ID
+    @JsonKey(name: 'taskId') required String taskId,
+
+    /// 任务号
+    @JsonKey(name: 'taskNo') required String taskNo,
+
+    /// 托盘号
+    @JsonKey(name: 'trayNo') required String trayNo,
+
+    /// 起始地址
+    @JsonKey(name: 'startAddr') required String startAddr,
+
+    /// 目标地址
+    @JsonKey(name: 'endAddr') required String endAddr,
+
+    /// 单托盘标识
+    @JsonKey(name: 'singleFlag') @Default('0') String singleFlag,
+
+    /// 指令类型（用于区分调用的接口）
+    @JsonKey(name: 'action')
+    @Default(InventoryCollectCommandAction.inventoryDown)
+    InventoryCollectCommandAction action,
+  }) = _InventoryCollectCommand;
+
+  factory InventoryCollectCommand.fromJson(Map<String, dynamic> json) =>
+      _$InventoryCollectCommandFromJson(json);
+}
+
+/// 采集状态快照，用于本地缓存
+@freezed
+class InventoryCollectStateSnapshot with _$InventoryCollectStateSnapshot {
+  const factory InventoryCollectStateSnapshot({
+    /// 任务 ID
+    @JsonKey(name: 'taskId') required String taskId,
+
+    /// 盘库单号
+    @JsonKey(name: 'taskComment') required String taskComment,
+
+    /// 当前托盘号
+    @JsonKey(name: 'activeTrayNo') String? activeTrayNo,
+
+    /// 当前库位
+    @JsonKey(name: 'activeStoreSiteNo') String? activeStoreSiteNo,
+
+    /// 最近一次扫描内容
+    @JsonKey(name: 'lastScannedCode') String? lastScannedCode,
+
+    /// 采集中任务明细
+    @JsonKey(name: 'taskItems')
+    @Default(<InventoryTaskItem>[])
+    List<InventoryTaskItem> taskItems,
+
+    /// 已采集记录
+    @JsonKey(name: 'collectedRecords')
+    @Default(<InventoryCollectingRecord>[])
+    List<InventoryCollectingRecord> collectedRecords,
+
+    /// 快照更新时间
+    @JsonKey(
+      name: 'updatedAt',
+      fromJson: _dateTimeFromJson,
+      toJson: _dateTimeToJson,
+    )
+    DateTime? updatedAt,
+  }) = _InventoryCollectStateSnapshot;
+
+  factory InventoryCollectStateSnapshot.fromJson(Map<String, dynamic> json) =>
+      _$InventoryCollectStateSnapshotFromJson(json);
+}
+
+/// 库位库存信息
+@freezed
+class InventoryPalletInfo with _$InventoryPalletInfo {
+  const factory InventoryPalletInfo({
+    /// 托盘号
+    @JsonKey(name: 'palletNo') String? palletNo,
+
+    /// 库位编码
+    @JsonKey(name: 'storeSite') String? storeSite,
+
+    /// 库房编码
+    @JsonKey(name: 'storeRoom') String? storeRoom,
+
+    /// 物料编码
+    @JsonKey(name: 'matCode') String? materialCode,
+
+    /// 物料名称
+    @JsonKey(name: 'matName') String? materialName,
+
+    /// 库存数量
+    @JsonKey(name: 'InventoryQty') @Default(0) double inventoryQty,
+
+    /// ERP 子库
+    @JsonKey(name: 'erpStoreRoom') String? erpStoreRoom,
+
+    /// ERP 库位
+    @JsonKey(name: 'erpStoreSite') String? erpStoreSite,
+
+    /// 批次号
+    @JsonKey(name: 'batchNo') String? batchNo,
+
+    /// 序列号
+    @JsonKey(name: 'sn') String? serialNo,
+  }) = _InventoryPalletInfo;
+
+  factory InventoryPalletInfo.fromJson(Map<String, dynamic> json) =>
+      _$InventoryPalletInfoFromJson(json);
+}
+
+/// 物料控制参数
+@freezed
+class InventoryMatControl with _$InventoryMatControl {
+  const factory InventoryMatControl({
+    /// 物料编码
+    @JsonKey(name: 'matCode') String? materialCode,
+
+    /// 批次管控
+    @JsonKey(name: 'batchFlag') @Default(true) bool batchRequired,
+
+    /// 供应商校验
+    @JsonKey(name: 'supplierFlag') @Default(true) bool supplierRequired,
+
+    /// 序列号管控
+    @JsonKey(name: 'snFlag') @Default(false) bool serialRequired,
+
+    /// 有效期校验
+    @JsonKey(name: 'validFlag') @Default(false) bool validityRequired,
+
+    /// 控制标记
+    @JsonKey(name: 'matControlFlag') String? controlFlag,
+  }) = _InventoryMatControl;
+
+  factory InventoryMatControl.fromJson(Map<String, dynamic> json) =>
+      _$InventoryMatControlFromJson(json);
+}
+
+/// 拣选口位置
+class InventoryPickLocation {
+  const InventoryPickLocation({
+    this.locationNo,
+    this.locationName,
+    this.text,
+    this.value,
+  });
+
+  final String? locationNo;
+  final String? locationName;
+  final String? text;
+  final String? value;
+
+  String? get displayName => locationName ?? text ?? value;
+
+  String? get code => locationNo ?? value ?? text ?? locationName;
+
+  factory InventoryPickLocation.fromJson(Map<String, dynamic> json) {
+    return InventoryPickLocation(
+      locationNo: json['locationNo'] as String?,
+      locationName: json['locationName'] as String?,
+      text: json['text'] as String?,
+      value: json['value'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'locationNo': locationNo,
+      'locationName': locationName,
+      'text': text,
+      'value': value,
+    };
+  }
+}
+
+/// 库位校验结果
+@freezed
+class InventorySiteInfo with _$InventorySiteInfo {
+  const factory InventorySiteInfo({
+    /// 库房编码
+    @JsonKey(name: 'storeroomno') String? storeRoomNo,
+
+    /// 库位编码
+    @JsonKey(name: 'storesiteno') String? storeSiteNo,
+
+    /// 库位名称
+    @JsonKey(name: 'storesite') String? storeSiteName,
+
+    /// 锁定状态（0-正常）
+    @JsonKey(name: 'isfrozen') String? frozenFlag,
+
+    /// ERP 库位
+    @JsonKey(name: 'erpstoresite') String? erpStoreSite,
+
+    /// 库位属性
+    @JsonKey(name: 'siteflag') String? siteFlag,
+  }) = _InventorySiteInfo;
+
+  factory InventorySiteInfo.fromJson(Map<String, dynamic> json) =>
+      _$InventorySiteInfoFromJson(json);
+}
+
+/// 盘点任务明细查询参数
+@freezed
+class InventoryTaskItemQuery with _$InventoryTaskItemQuery {
+  const factory InventoryTaskItemQuery({
+    @JsonKey(name: 'taskcomment') required String taskComment,
+    @JsonKey(name: 'checktaskno') required String checkTaskNo,
+    @JsonKey(name: 'checktaskid') String? checkTaskId,
+    @JsonKey(name: 'roomTag') @Default('1') String roomTag,
+    @JsonKey(name: 'sortType') String? sortType,
+    @JsonKey(name: 'sortColumn') String? sortColumn,
+    @JsonKey(name: 'searchKey') String? searchKey,
+  }) = _InventoryTaskItemQuery;
+
+  factory InventoryTaskItemQuery.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskItemQueryFromJson(json);
+}

--- a/lib/modules/aswh_inventory/collection_task/models/inventory_collect_models.freezed.dart
+++ b/lib/modules/aswh_inventory/collection_task/models/inventory_collect_models.freezed.dart
@@ -1,0 +1,3383 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_collect_models.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+InventoryTaskItem _$InventoryTaskItemFromJson(Map<String, dynamic> json) {
+  return _InventoryTaskItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskItem {
+  /// 明细主键
+  @JsonKey(name: 'co_checkitemid')
+  int? get checkItemId => throw _privateConstructorUsedError;
+
+  /// 任务ID
+  @JsonKey(name: 'checktaskid')
+  int? get checkTaskId => throw _privateConstructorUsedError;
+
+  /// 任务号
+  @JsonKey(name: 'checktaskno')
+  String? get checkTaskNo => throw _privateConstructorUsedError;
+
+  /// 盘库单号
+  @JsonKey(name: 'taskcomment')
+  String? get taskComment => throw _privateConstructorUsedError;
+
+  /// 库房编码
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 库房名称
+  @JsonKey(name: 'storeroomname')
+  String? get storeRoomName => throw _privateConstructorUsedError;
+
+  /// 库位编码
+  @JsonKey(name: 'storesiteno')
+  String? get storeSiteNo => throw _privateConstructorUsedError;
+
+  /// 库位描述
+  @JsonKey(name: 'storesite')
+  String? get storeSiteName => throw _privateConstructorUsedError;
+
+  /// 托盘号
+  @JsonKey(name: 'palletno')
+  String? get palletNo => throw _privateConstructorUsedError;
+
+  /// 物料编码
+  @JsonKey(name: 'matcode2')
+  String? get materialCode => throw _privateConstructorUsedError;
+
+  /// 物料名称
+  @JsonKey(name: 'matname')
+  String? get materialName => throw _privateConstructorUsedError;
+
+  /// 计划数量
+  @JsonKey(name: 'qty')
+  double get planQty => throw _privateConstructorUsedError;
+
+  /// 已采集数量
+  @JsonKey(name: 'collectdataqty')
+  double get collectedQty => throw _privateConstructorUsedError;
+
+  /// 盘点类型
+  @JsonKey(name: 'checkmethod_nm')
+  String? get checkMethodName => throw _privateConstructorUsedError;
+
+  /// 批次号
+  @JsonKey(name: 'batchno')
+  String? get batchNo => throw _privateConstructorUsedError;
+
+  /// 序列号
+  @JsonKey(name: 'sn')
+  String? get serialNo => throw _privateConstructorUsedError;
+
+  /// 供应商编码
+  @JsonKey(name: 'suppliercode')
+  String? get supplierCode => throw _privateConstructorUsedError;
+
+  /// 拣选位置/终点地址
+  @JsonKey(name: 'endaddr')
+  String? get endAddr => throw _privateConstructorUsedError;
+
+  /// ERP 子库
+  @JsonKey(name: 'erpstoreroom')
+  String? get erpStoreRoom => throw _privateConstructorUsedError;
+
+  /// ERP 库位
+  @JsonKey(name: 'erpstoresite')
+  String? get erpStoreSite => throw _privateConstructorUsedError;
+
+  /// 物料控制标识
+  @JsonKey(name: 'matcontrolflag')
+  String? get materialControlFlag => throw _privateConstructorUsedError;
+
+  /// 是否完成
+  @JsonKey(name: 'isfinish')
+  bool get isFinished => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskItemCopyWith<InventoryTaskItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskItemCopyWith<$Res> {
+  factory $InventoryTaskItemCopyWith(
+          InventoryTaskItem value, $Res Function(InventoryTaskItem) then) =
+      _$InventoryTaskItemCopyWithImpl<$Res, InventoryTaskItem>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'co_checkitemid') int? checkItemId,
+      @JsonKey(name: 'checktaskid') int? checkTaskId,
+      @JsonKey(name: 'checktaskno') String? checkTaskNo,
+      @JsonKey(name: 'taskcomment') String? taskComment,
+      @JsonKey(name: 'storeroomno') String? storeRoomNo,
+      @JsonKey(name: 'storeroomname') String? storeRoomName,
+      @JsonKey(name: 'storesiteno') String? storeSiteNo,
+      @JsonKey(name: 'storesite') String? storeSiteName,
+      @JsonKey(name: 'palletno') String? palletNo,
+      @JsonKey(name: 'matcode2') String? materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'qty') double planQty,
+      @JsonKey(name: 'collectdataqty') double collectedQty,
+      @JsonKey(name: 'checkmethod_nm') String? checkMethodName,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'suppliercode') String? supplierCode,
+      @JsonKey(name: 'endaddr') String? endAddr,
+      @JsonKey(name: 'erpstoreroom') String? erpStoreRoom,
+      @JsonKey(name: 'erpstoresite') String? erpStoreSite,
+      @JsonKey(name: 'matcontrolflag') String? materialControlFlag,
+      @JsonKey(name: 'isfinish') bool isFinished});
+}
+
+/// @nodoc
+class _$InventoryTaskItemCopyWithImpl<$Res, $Val extends InventoryTaskItem>
+    implements $InventoryTaskItemCopyWith<$Res> {
+  _$InventoryTaskItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? checkItemId = freezed,
+    Object? checkTaskId = freezed,
+    Object? checkTaskNo = freezed,
+    Object? taskComment = freezed,
+    Object? storeRoomNo = freezed,
+    Object? storeRoomName = freezed,
+    Object? storeSiteNo = freezed,
+    Object? storeSiteName = freezed,
+    Object? palletNo = freezed,
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? planQty = null,
+    Object? collectedQty = null,
+    Object? checkMethodName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? supplierCode = freezed,
+    Object? endAddr = freezed,
+    Object? erpStoreRoom = freezed,
+    Object? erpStoreSite = freezed,
+    Object? materialControlFlag = freezed,
+    Object? isFinished = null,
+  }) {
+    return _then(_value.copyWith(
+      checkItemId: freezed == checkItemId
+          ? _value.checkItemId
+          : checkItemId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      checkTaskId: freezed == checkTaskId
+          ? _value.checkTaskId
+          : checkTaskId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      checkTaskNo: freezed == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      taskComment: freezed == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomName: freezed == storeRoomName
+          ? _value.storeRoomName
+          : storeRoomName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: freezed == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteName: freezed == storeSiteName
+          ? _value.storeSiteName
+          : storeSiteName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      palletNo: freezed == palletNo
+          ? _value.palletNo
+          : palletNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: freezed == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      planQty: null == planQty
+          ? _value.planQty
+          : planQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      collectedQty: null == collectedQty
+          ? _value.collectedQty
+          : collectedQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      checkMethodName: freezed == checkMethodName
+          ? _value.checkMethodName
+          : checkMethodName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      supplierCode: freezed == supplierCode
+          ? _value.supplierCode
+          : supplierCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      endAddr: freezed == endAddr
+          ? _value.endAddr
+          : endAddr // ignore: cast_nullable_to_non_nullable
+              as String?,
+      erpStoreRoom: freezed == erpStoreRoom
+          ? _value.erpStoreRoom
+          : erpStoreRoom // ignore: cast_nullable_to_non_nullable
+              as String?,
+      erpStoreSite: freezed == erpStoreSite
+          ? _value.erpStoreSite
+          : erpStoreSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialControlFlag: freezed == materialControlFlag
+          ? _value.materialControlFlag
+          : materialControlFlag // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isFinished: null == isFinished
+          ? _value.isFinished
+          : isFinished // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskItemImplCopyWith<$Res>
+    implements $InventoryTaskItemCopyWith<$Res> {
+  factory _$$InventoryTaskItemImplCopyWith(_$InventoryTaskItemImpl value,
+          $Res Function(_$InventoryTaskItemImpl) then) =
+      __$$InventoryTaskItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'co_checkitemid') int? checkItemId,
+      @JsonKey(name: 'checktaskid') int? checkTaskId,
+      @JsonKey(name: 'checktaskno') String? checkTaskNo,
+      @JsonKey(name: 'taskcomment') String? taskComment,
+      @JsonKey(name: 'storeroomno') String? storeRoomNo,
+      @JsonKey(name: 'storeroomname') String? storeRoomName,
+      @JsonKey(name: 'storesiteno') String? storeSiteNo,
+      @JsonKey(name: 'storesite') String? storeSiteName,
+      @JsonKey(name: 'palletno') String? palletNo,
+      @JsonKey(name: 'matcode2') String? materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'qty') double planQty,
+      @JsonKey(name: 'collectdataqty') double collectedQty,
+      @JsonKey(name: 'checkmethod_nm') String? checkMethodName,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'suppliercode') String? supplierCode,
+      @JsonKey(name: 'endaddr') String? endAddr,
+      @JsonKey(name: 'erpstoreroom') String? erpStoreRoom,
+      @JsonKey(name: 'erpstoresite') String? erpStoreSite,
+      @JsonKey(name: 'matcontrolflag') String? materialControlFlag,
+      @JsonKey(name: 'isfinish') bool isFinished});
+}
+
+/// @nodoc
+class __$$InventoryTaskItemImplCopyWithImpl<$Res>
+    extends _$InventoryTaskItemCopyWithImpl<$Res, _$InventoryTaskItemImpl>
+    implements _$$InventoryTaskItemImplCopyWith<$Res> {
+  __$$InventoryTaskItemImplCopyWithImpl(_$InventoryTaskItemImpl _value,
+      $Res Function(_$InventoryTaskItemImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? checkItemId = freezed,
+    Object? checkTaskId = freezed,
+    Object? checkTaskNo = freezed,
+    Object? taskComment = freezed,
+    Object? storeRoomNo = freezed,
+    Object? storeRoomName = freezed,
+    Object? storeSiteNo = freezed,
+    Object? storeSiteName = freezed,
+    Object? palletNo = freezed,
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? planQty = null,
+    Object? collectedQty = null,
+    Object? checkMethodName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? supplierCode = freezed,
+    Object? endAddr = freezed,
+    Object? erpStoreRoom = freezed,
+    Object? erpStoreSite = freezed,
+    Object? materialControlFlag = freezed,
+    Object? isFinished = null,
+  }) {
+    return _then(_$InventoryTaskItemImpl(
+      checkItemId: freezed == checkItemId
+          ? _value.checkItemId
+          : checkItemId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      checkTaskId: freezed == checkTaskId
+          ? _value.checkTaskId
+          : checkTaskId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      checkTaskNo: freezed == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      taskComment: freezed == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomName: freezed == storeRoomName
+          ? _value.storeRoomName
+          : storeRoomName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: freezed == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteName: freezed == storeSiteName
+          ? _value.storeSiteName
+          : storeSiteName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      palletNo: freezed == palletNo
+          ? _value.palletNo
+          : palletNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: freezed == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      planQty: null == planQty
+          ? _value.planQty
+          : planQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      collectedQty: null == collectedQty
+          ? _value.collectedQty
+          : collectedQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      checkMethodName: freezed == checkMethodName
+          ? _value.checkMethodName
+          : checkMethodName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      supplierCode: freezed == supplierCode
+          ? _value.supplierCode
+          : supplierCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      endAddr: freezed == endAddr
+          ? _value.endAddr
+          : endAddr // ignore: cast_nullable_to_non_nullable
+              as String?,
+      erpStoreRoom: freezed == erpStoreRoom
+          ? _value.erpStoreRoom
+          : erpStoreRoom // ignore: cast_nullable_to_non_nullable
+              as String?,
+      erpStoreSite: freezed == erpStoreSite
+          ? _value.erpStoreSite
+          : erpStoreSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialControlFlag: freezed == materialControlFlag
+          ? _value.materialControlFlag
+          : materialControlFlag // ignore: cast_nullable_to_non_nullable
+              as String?,
+      isFinished: null == isFinished
+          ? _value.isFinished
+          : isFinished // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskItemImpl extends _InventoryTaskItem {
+  const _$InventoryTaskItemImpl(
+      {@JsonKey(name: 'co_checkitemid') this.checkItemId,
+      @JsonKey(name: 'checktaskid') this.checkTaskId,
+      @JsonKey(name: 'checktaskno') this.checkTaskNo,
+      @JsonKey(name: 'taskcomment') this.taskComment,
+      @JsonKey(name: 'storeroomno') this.storeRoomNo,
+      @JsonKey(name: 'storeroomname') this.storeRoomName,
+      @JsonKey(name: 'storesiteno') this.storeSiteNo,
+      @JsonKey(name: 'storesite') this.storeSiteName,
+      @JsonKey(name: 'palletno') this.palletNo,
+      @JsonKey(name: 'matcode2') this.materialCode,
+      @JsonKey(name: 'matname') this.materialName,
+      @JsonKey(name: 'qty') this.planQty = 0,
+      @JsonKey(name: 'collectdataqty') this.collectedQty = 0,
+      @JsonKey(name: 'checkmethod_nm') this.checkMethodName,
+      @JsonKey(name: 'batchno') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNo,
+      @JsonKey(name: 'suppliercode') this.supplierCode,
+      @JsonKey(name: 'endaddr') this.endAddr,
+      @JsonKey(name: 'erpstoreroom') this.erpStoreRoom,
+      @JsonKey(name: 'erpstoresite') this.erpStoreSite,
+      @JsonKey(name: 'matcontrolflag') this.materialControlFlag,
+      @JsonKey(name: 'isfinish') this.isFinished = false})
+      : super._();
+
+  factory _$InventoryTaskItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskItemImplFromJson(json);
+
+  /// 明细主键
+  @override
+  @JsonKey(name: 'co_checkitemid')
+  final int? checkItemId;
+
+  /// 任务ID
+  @override
+  @JsonKey(name: 'checktaskid')
+  final int? checkTaskId;
+
+  /// 任务号
+  @override
+  @JsonKey(name: 'checktaskno')
+  final String? checkTaskNo;
+
+  /// 盘库单号
+  @override
+  @JsonKey(name: 'taskcomment')
+  final String? taskComment;
+
+  /// 库房编码
+  @override
+  @JsonKey(name: 'storeroomno')
+  final String? storeRoomNo;
+
+  /// 库房名称
+  @override
+  @JsonKey(name: 'storeroomname')
+  final String? storeRoomName;
+
+  /// 库位编码
+  @override
+  @JsonKey(name: 'storesiteno')
+  final String? storeSiteNo;
+
+  /// 库位描述
+  @override
+  @JsonKey(name: 'storesite')
+  final String? storeSiteName;
+
+  /// 托盘号
+  @override
+  @JsonKey(name: 'palletno')
+  final String? palletNo;
+
+  /// 物料编码
+  @override
+  @JsonKey(name: 'matcode2')
+  final String? materialCode;
+
+  /// 物料名称
+  @override
+  @JsonKey(name: 'matname')
+  final String? materialName;
+
+  /// 计划数量
+  @override
+  @JsonKey(name: 'qty')
+  final double planQty;
+
+  /// 已采集数量
+  @override
+  @JsonKey(name: 'collectdataqty')
+  final double collectedQty;
+
+  /// 盘点类型
+  @override
+  @JsonKey(name: 'checkmethod_nm')
+  final String? checkMethodName;
+
+  /// 批次号
+  @override
+  @JsonKey(name: 'batchno')
+  final String? batchNo;
+
+  /// 序列号
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNo;
+
+  /// 供应商编码
+  @override
+  @JsonKey(name: 'suppliercode')
+  final String? supplierCode;
+
+  /// 拣选位置/终点地址
+  @override
+  @JsonKey(name: 'endaddr')
+  final String? endAddr;
+
+  /// ERP 子库
+  @override
+  @JsonKey(name: 'erpstoreroom')
+  final String? erpStoreRoom;
+
+  /// ERP 库位
+  @override
+  @JsonKey(name: 'erpstoresite')
+  final String? erpStoreSite;
+
+  /// 物料控制标识
+  @override
+  @JsonKey(name: 'matcontrolflag')
+  final String? materialControlFlag;
+
+  /// 是否完成
+  @override
+  @JsonKey(name: 'isfinish')
+  final bool isFinished;
+
+  @override
+  String toString() {
+    return 'InventoryTaskItem(checkItemId: $checkItemId, checkTaskId: $checkTaskId, checkTaskNo: $checkTaskNo, taskComment: $taskComment, storeRoomNo: $storeRoomNo, storeRoomName: $storeRoomName, storeSiteNo: $storeSiteNo, storeSiteName: $storeSiteName, palletNo: $palletNo, materialCode: $materialCode, materialName: $materialName, planQty: $planQty, collectedQty: $collectedQty, checkMethodName: $checkMethodName, batchNo: $batchNo, serialNo: $serialNo, supplierCode: $supplierCode, endAddr: $endAddr, erpStoreRoom: $erpStoreRoom, erpStoreSite: $erpStoreSite, materialControlFlag: $materialControlFlag, isFinished: $isFinished)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskItemImpl &&
+            (identical(other.checkItemId, checkItemId) ||
+                other.checkItemId == checkItemId) &&
+            (identical(other.checkTaskId, checkTaskId) ||
+                other.checkTaskId == checkTaskId) &&
+            (identical(other.checkTaskNo, checkTaskNo) ||
+                other.checkTaskNo == checkTaskNo) &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeRoomName, storeRoomName) ||
+                other.storeRoomName == storeRoomName) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.storeSiteName, storeSiteName) ||
+                other.storeSiteName == storeSiteName) &&
+            (identical(other.palletNo, palletNo) ||
+                other.palletNo == palletNo) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.planQty, planQty) || other.planQty == planQty) &&
+            (identical(other.collectedQty, collectedQty) ||
+                other.collectedQty == collectedQty) &&
+            (identical(other.checkMethodName, checkMethodName) ||
+                other.checkMethodName == checkMethodName) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo) &&
+            (identical(other.supplierCode, supplierCode) ||
+                other.supplierCode == supplierCode) &&
+            (identical(other.endAddr, endAddr) || other.endAddr == endAddr) &&
+            (identical(other.erpStoreRoom, erpStoreRoom) ||
+                other.erpStoreRoom == erpStoreRoom) &&
+            (identical(other.erpStoreSite, erpStoreSite) ||
+                other.erpStoreSite == erpStoreSite) &&
+            (identical(other.materialControlFlag, materialControlFlag) ||
+                other.materialControlFlag == materialControlFlag) &&
+            (identical(other.isFinished, isFinished) ||
+                other.isFinished == isFinished));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        checkItemId,
+        checkTaskId,
+        checkTaskNo,
+        taskComment,
+        storeRoomNo,
+        storeRoomName,
+        storeSiteNo,
+        storeSiteName,
+        palletNo,
+        materialCode,
+        materialName,
+        planQty,
+        collectedQty,
+        checkMethodName,
+        batchNo,
+        serialNo,
+        supplierCode,
+        endAddr,
+        erpStoreRoom,
+        erpStoreSite,
+        materialControlFlag,
+        isFinished
+      ]);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskItemImplCopyWith<_$InventoryTaskItemImpl> get copyWith =>
+      __$$InventoryTaskItemImplCopyWithImpl<_$InventoryTaskItemImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskItemImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskItem extends InventoryTaskItem {
+  const factory _InventoryTaskItem(
+          {@JsonKey(name: 'co_checkitemid') final int? checkItemId,
+          @JsonKey(name: 'checktaskid') final int? checkTaskId,
+          @JsonKey(name: 'checktaskno') final String? checkTaskNo,
+          @JsonKey(name: 'taskcomment') final String? taskComment,
+          @JsonKey(name: 'storeroomno') final String? storeRoomNo,
+          @JsonKey(name: 'storeroomname') final String? storeRoomName,
+          @JsonKey(name: 'storesiteno') final String? storeSiteNo,
+          @JsonKey(name: 'storesite') final String? storeSiteName,
+          @JsonKey(name: 'palletno') final String? palletNo,
+          @JsonKey(name: 'matcode2') final String? materialCode,
+          @JsonKey(name: 'matname') final String? materialName,
+          @JsonKey(name: 'qty') final double planQty,
+          @JsonKey(name: 'collectdataqty') final double collectedQty,
+          @JsonKey(name: 'checkmethod_nm') final String? checkMethodName,
+          @JsonKey(name: 'batchno') final String? batchNo,
+          @JsonKey(name: 'sn') final String? serialNo,
+          @JsonKey(name: 'suppliercode') final String? supplierCode,
+          @JsonKey(name: 'endaddr') final String? endAddr,
+          @JsonKey(name: 'erpstoreroom') final String? erpStoreRoom,
+          @JsonKey(name: 'erpstoresite') final String? erpStoreSite,
+          @JsonKey(name: 'matcontrolflag') final String? materialControlFlag,
+          @JsonKey(name: 'isfinish') final bool isFinished}) =
+      _$InventoryTaskItemImpl;
+  const _InventoryTaskItem._() : super._();
+
+  factory _InventoryTaskItem.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskItemImpl.fromJson;
+
+  @override
+
+  /// 明细主键
+  @JsonKey(name: 'co_checkitemid')
+  int? get checkItemId;
+  @override
+
+  /// 任务ID
+  @JsonKey(name: 'checktaskid')
+  int? get checkTaskId;
+  @override
+
+  /// 任务号
+  @JsonKey(name: 'checktaskno')
+  String? get checkTaskNo;
+  @override
+
+  /// 盘库单号
+  @JsonKey(name: 'taskcomment')
+  String? get taskComment;
+  @override
+
+  /// 库房编码
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoomNo;
+  @override
+
+  /// 库房名称
+  @JsonKey(name: 'storeroomname')
+  String? get storeRoomName;
+  @override
+
+  /// 库位编码
+  @JsonKey(name: 'storesiteno')
+  String? get storeSiteNo;
+  @override
+
+  /// 库位描述
+  @JsonKey(name: 'storesite')
+  String? get storeSiteName;
+  @override
+
+  /// 托盘号
+  @JsonKey(name: 'palletno')
+  String? get palletNo;
+  @override
+
+  /// 物料编码
+  @JsonKey(name: 'matcode2')
+  String? get materialCode;
+  @override
+
+  /// 物料名称
+  @JsonKey(name: 'matname')
+  String? get materialName;
+  @override
+
+  /// 计划数量
+  @JsonKey(name: 'qty')
+  double get planQty;
+  @override
+
+  /// 已采集数量
+  @JsonKey(name: 'collectdataqty')
+  double get collectedQty;
+  @override
+
+  /// 盘点类型
+  @JsonKey(name: 'checkmethod_nm')
+  String? get checkMethodName;
+  @override
+
+  /// 批次号
+  @JsonKey(name: 'batchno')
+  String? get batchNo;
+  @override
+
+  /// 序列号
+  @JsonKey(name: 'sn')
+  String? get serialNo;
+  @override
+
+  /// 供应商编码
+  @JsonKey(name: 'suppliercode')
+  String? get supplierCode;
+  @override
+
+  /// 拣选位置/终点地址
+  @JsonKey(name: 'endaddr')
+  String? get endAddr;
+  @override
+
+  /// ERP 子库
+  @JsonKey(name: 'erpstoreroom')
+  String? get erpStoreRoom;
+  @override
+
+  /// ERP 库位
+  @JsonKey(name: 'erpstoresite')
+  String? get erpStoreSite;
+  @override
+
+  /// 物料控制标识
+  @JsonKey(name: 'matcontrolflag')
+  String? get materialControlFlag;
+  @override
+
+  /// 是否完成
+  @JsonKey(name: 'isfinish')
+  bool get isFinished;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskItemImplCopyWith<_$InventoryTaskItemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventoryCollectingRecord _$InventoryCollectingRecordFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryCollectingRecord.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryCollectingRecord {
+  /// 盘库单号
+  @JsonKey(name: 'TaskComment')
+  String get taskComment => throw _privateConstructorUsedError;
+
+  /// 任务明细 ID
+  @JsonKey(name: 'invTaskItemid')
+  String get taskItemId => throw _privateConstructorUsedError;
+
+  /// 物料编码
+  @JsonKey(name: 'matCode')
+  String get materialCode => throw _privateConstructorUsedError;
+
+  /// 物料主数据 ID
+  @JsonKey(name: 'materialId')
+  String? get materialId => throw _privateConstructorUsedError;
+
+  /// 库房编码
+  @JsonKey(name: 'storeRoomNo')
+  String get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 库位编码
+  @JsonKey(name: 'storeSiteNo')
+  String get storeSiteNo => throw _privateConstructorUsedError;
+
+  /// 采集数量
+  @JsonKey(name: 'collectQty')
+  double get collectQty => throw _privateConstructorUsedError;
+
+  /// 批次号
+  @JsonKey(name: 'batchNo')
+  String? get batchNo => throw _privateConstructorUsedError;
+
+  /// 序列号
+  @JsonKey(name: 'sn')
+  String? get serialNo => throw _privateConstructorUsedError;
+
+  /// 托盘号
+  @JsonKey(name: 'trayNo')
+  String? get trayNo => throw _privateConstructorUsedError;
+
+  /// 采集时间
+  @JsonKey(
+      name: 'collectedAt', fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  DateTime? get collectedAt => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryCollectingRecordCopyWith<InventoryCollectingRecord> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryCollectingRecordCopyWith<$Res> {
+  factory $InventoryCollectingRecordCopyWith(InventoryCollectingRecord value,
+          $Res Function(InventoryCollectingRecord) then) =
+      _$InventoryCollectingRecordCopyWithImpl<$Res, InventoryCollectingRecord>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'TaskComment') String taskComment,
+      @JsonKey(name: 'invTaskItemid') String taskItemId,
+      @JsonKey(name: 'matCode') String materialCode,
+      @JsonKey(name: 'materialId') String? materialId,
+      @JsonKey(name: 'storeRoomNo') String storeRoomNo,
+      @JsonKey(name: 'storeSiteNo') String storeSiteNo,
+      @JsonKey(name: 'collectQty') double collectQty,
+      @JsonKey(name: 'batchNo') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'trayNo') String? trayNo,
+      @JsonKey(
+          name: 'collectedAt',
+          fromJson: _dateTimeFromJson,
+          toJson: _dateTimeToJson)
+      DateTime? collectedAt});
+}
+
+/// @nodoc
+class _$InventoryCollectingRecordCopyWithImpl<$Res,
+        $Val extends InventoryCollectingRecord>
+    implements $InventoryCollectingRecordCopyWith<$Res> {
+  _$InventoryCollectingRecordCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskComment = null,
+    Object? taskItemId = null,
+    Object? materialCode = null,
+    Object? materialId = freezed,
+    Object? storeRoomNo = null,
+    Object? storeSiteNo = null,
+    Object? collectQty = null,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? trayNo = freezed,
+    Object? collectedAt = freezed,
+  }) {
+    return _then(_value.copyWith(
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      taskItemId: null == taskItemId
+          ? _value.taskItemId
+          : taskItemId // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialId: freezed == materialId
+          ? _value.materialId
+          : materialId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomNo: null == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      collectQty: null == collectQty
+          ? _value.collectQty
+          : collectQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      trayNo: freezed == trayNo
+          ? _value.trayNo
+          : trayNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      collectedAt: freezed == collectedAt
+          ? _value.collectedAt
+          : collectedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryCollectingRecordImplCopyWith<$Res>
+    implements $InventoryCollectingRecordCopyWith<$Res> {
+  factory _$$InventoryCollectingRecordImplCopyWith(
+          _$InventoryCollectingRecordImpl value,
+          $Res Function(_$InventoryCollectingRecordImpl) then) =
+      __$$InventoryCollectingRecordImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'TaskComment') String taskComment,
+      @JsonKey(name: 'invTaskItemid') String taskItemId,
+      @JsonKey(name: 'matCode') String materialCode,
+      @JsonKey(name: 'materialId') String? materialId,
+      @JsonKey(name: 'storeRoomNo') String storeRoomNo,
+      @JsonKey(name: 'storeSiteNo') String storeSiteNo,
+      @JsonKey(name: 'collectQty') double collectQty,
+      @JsonKey(name: 'batchNo') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'trayNo') String? trayNo,
+      @JsonKey(
+          name: 'collectedAt',
+          fromJson: _dateTimeFromJson,
+          toJson: _dateTimeToJson)
+      DateTime? collectedAt});
+}
+
+/// @nodoc
+class __$$InventoryCollectingRecordImplCopyWithImpl<$Res>
+    extends _$InventoryCollectingRecordCopyWithImpl<$Res,
+        _$InventoryCollectingRecordImpl>
+    implements _$$InventoryCollectingRecordImplCopyWith<$Res> {
+  __$$InventoryCollectingRecordImplCopyWithImpl(
+      _$InventoryCollectingRecordImpl _value,
+      $Res Function(_$InventoryCollectingRecordImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskComment = null,
+    Object? taskItemId = null,
+    Object? materialCode = null,
+    Object? materialId = freezed,
+    Object? storeRoomNo = null,
+    Object? storeSiteNo = null,
+    Object? collectQty = null,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? trayNo = freezed,
+    Object? collectedAt = freezed,
+  }) {
+    return _then(_$InventoryCollectingRecordImpl(
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      taskItemId: null == taskItemId
+          ? _value.taskItemId
+          : taskItemId // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialId: freezed == materialId
+          ? _value.materialId
+          : materialId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomNo: null == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      collectQty: null == collectQty
+          ? _value.collectQty
+          : collectQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      trayNo: freezed == trayNo
+          ? _value.trayNo
+          : trayNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      collectedAt: freezed == collectedAt
+          ? _value.collectedAt
+          : collectedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryCollectingRecordImpl implements _InventoryCollectingRecord {
+  const _$InventoryCollectingRecordImpl(
+      {@JsonKey(name: 'TaskComment') required this.taskComment,
+      @JsonKey(name: 'invTaskItemid') required this.taskItemId,
+      @JsonKey(name: 'matCode') required this.materialCode,
+      @JsonKey(name: 'materialId') this.materialId,
+      @JsonKey(name: 'storeRoomNo') required this.storeRoomNo,
+      @JsonKey(name: 'storeSiteNo') required this.storeSiteNo,
+      @JsonKey(name: 'collectQty') this.collectQty = 0,
+      @JsonKey(name: 'batchNo') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNo,
+      @JsonKey(name: 'trayNo') this.trayNo,
+      @JsonKey(
+          name: 'collectedAt',
+          fromJson: _dateTimeFromJson,
+          toJson: _dateTimeToJson)
+      this.collectedAt});
+
+  factory _$InventoryCollectingRecordImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryCollectingRecordImplFromJson(json);
+
+  /// 盘库单号
+  @override
+  @JsonKey(name: 'TaskComment')
+  final String taskComment;
+
+  /// 任务明细 ID
+  @override
+  @JsonKey(name: 'invTaskItemid')
+  final String taskItemId;
+
+  /// 物料编码
+  @override
+  @JsonKey(name: 'matCode')
+  final String materialCode;
+
+  /// 物料主数据 ID
+  @override
+  @JsonKey(name: 'materialId')
+  final String? materialId;
+
+  /// 库房编码
+  @override
+  @JsonKey(name: 'storeRoomNo')
+  final String storeRoomNo;
+
+  /// 库位编码
+  @override
+  @JsonKey(name: 'storeSiteNo')
+  final String storeSiteNo;
+
+  /// 采集数量
+  @override
+  @JsonKey(name: 'collectQty')
+  final double collectQty;
+
+  /// 批次号
+  @override
+  @JsonKey(name: 'batchNo')
+  final String? batchNo;
+
+  /// 序列号
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNo;
+
+  /// 托盘号
+  @override
+  @JsonKey(name: 'trayNo')
+  final String? trayNo;
+
+  /// 采集时间
+  @override
+  @JsonKey(
+      name: 'collectedAt', fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  final DateTime? collectedAt;
+
+  @override
+  String toString() {
+    return 'InventoryCollectingRecord(taskComment: $taskComment, taskItemId: $taskItemId, materialCode: $materialCode, materialId: $materialId, storeRoomNo: $storeRoomNo, storeSiteNo: $storeSiteNo, collectQty: $collectQty, batchNo: $batchNo, serialNo: $serialNo, trayNo: $trayNo, collectedAt: $collectedAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryCollectingRecordImpl &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment) &&
+            (identical(other.taskItemId, taskItemId) ||
+                other.taskItemId == taskItemId) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialId, materialId) ||
+                other.materialId == materialId) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.collectQty, collectQty) ||
+                other.collectQty == collectQty) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo) &&
+            (identical(other.trayNo, trayNo) || other.trayNo == trayNo) &&
+            (identical(other.collectedAt, collectedAt) ||
+                other.collectedAt == collectedAt));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      taskComment,
+      taskItemId,
+      materialCode,
+      materialId,
+      storeRoomNo,
+      storeSiteNo,
+      collectQty,
+      batchNo,
+      serialNo,
+      trayNo,
+      collectedAt);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryCollectingRecordImplCopyWith<_$InventoryCollectingRecordImpl>
+      get copyWith => __$$InventoryCollectingRecordImplCopyWithImpl<
+          _$InventoryCollectingRecordImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryCollectingRecordImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryCollectingRecord implements InventoryCollectingRecord {
+  const factory _InventoryCollectingRecord(
+      {@JsonKey(name: 'TaskComment') required final String taskComment,
+      @JsonKey(name: 'invTaskItemid') required final String taskItemId,
+      @JsonKey(name: 'matCode') required final String materialCode,
+      @JsonKey(name: 'materialId') final String? materialId,
+      @JsonKey(name: 'storeRoomNo') required final String storeRoomNo,
+      @JsonKey(name: 'storeSiteNo') required final String storeSiteNo,
+      @JsonKey(name: 'collectQty') final double collectQty,
+      @JsonKey(name: 'batchNo') final String? batchNo,
+      @JsonKey(name: 'sn') final String? serialNo,
+      @JsonKey(name: 'trayNo') final String? trayNo,
+      @JsonKey(
+          name: 'collectedAt',
+          fromJson: _dateTimeFromJson,
+          toJson: _dateTimeToJson)
+      final DateTime? collectedAt}) = _$InventoryCollectingRecordImpl;
+
+  factory _InventoryCollectingRecord.fromJson(Map<String, dynamic> json) =
+      _$InventoryCollectingRecordImpl.fromJson;
+
+  @override
+
+  /// 盘库单号
+  @JsonKey(name: 'TaskComment')
+  String get taskComment;
+  @override
+
+  /// 任务明细 ID
+  @JsonKey(name: 'invTaskItemid')
+  String get taskItemId;
+  @override
+
+  /// 物料编码
+  @JsonKey(name: 'matCode')
+  String get materialCode;
+  @override
+
+  /// 物料主数据 ID
+  @JsonKey(name: 'materialId')
+  String? get materialId;
+  @override
+
+  /// 库房编码
+  @JsonKey(name: 'storeRoomNo')
+  String get storeRoomNo;
+  @override
+
+  /// 库位编码
+  @JsonKey(name: 'storeSiteNo')
+  String get storeSiteNo;
+  @override
+
+  /// 采集数量
+  @JsonKey(name: 'collectQty')
+  double get collectQty;
+  @override
+
+  /// 批次号
+  @JsonKey(name: 'batchNo')
+  String? get batchNo;
+  @override
+
+  /// 序列号
+  @JsonKey(name: 'sn')
+  String? get serialNo;
+  @override
+
+  /// 托盘号
+  @JsonKey(name: 'trayNo')
+  String? get trayNo;
+  @override
+
+  /// 采集时间
+  @JsonKey(
+      name: 'collectedAt', fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  DateTime? get collectedAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryCollectingRecordImplCopyWith<_$InventoryCollectingRecordImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+InventoryCollectCommand _$InventoryCollectCommandFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryCollectCommand.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryCollectCommand {
+  /// 任务 ID
+  @JsonKey(name: 'taskId')
+  String get taskId => throw _privateConstructorUsedError;
+
+  /// 任务号
+  @JsonKey(name: 'taskNo')
+  String get taskNo => throw _privateConstructorUsedError;
+
+  /// 托盘号
+  @JsonKey(name: 'trayNo')
+  String get trayNo => throw _privateConstructorUsedError;
+
+  /// 起始地址
+  @JsonKey(name: 'startAddr')
+  String get startAddr => throw _privateConstructorUsedError;
+
+  /// 目标地址
+  @JsonKey(name: 'endAddr')
+  String get endAddr => throw _privateConstructorUsedError;
+
+  /// 单托盘标识
+  @JsonKey(name: 'singleFlag')
+  String get singleFlag => throw _privateConstructorUsedError;
+
+  /// 指令类型（用于区分调用的接口）
+  @JsonKey(name: 'action')
+  InventoryCollectCommandAction get action =>
+      throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryCollectCommandCopyWith<InventoryCollectCommand> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryCollectCommandCopyWith<$Res> {
+  factory $InventoryCollectCommandCopyWith(InventoryCollectCommand value,
+          $Res Function(InventoryCollectCommand) then) =
+      _$InventoryCollectCommandCopyWithImpl<$Res, InventoryCollectCommand>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskId') String taskId,
+      @JsonKey(name: 'taskNo') String taskNo,
+      @JsonKey(name: 'trayNo') String trayNo,
+      @JsonKey(name: 'startAddr') String startAddr,
+      @JsonKey(name: 'endAddr') String endAddr,
+      @JsonKey(name: 'singleFlag') String singleFlag,
+      @JsonKey(name: 'action') InventoryCollectCommandAction action});
+}
+
+/// @nodoc
+class _$InventoryCollectCommandCopyWithImpl<$Res,
+        $Val extends InventoryCollectCommand>
+    implements $InventoryCollectCommandCopyWith<$Res> {
+  _$InventoryCollectCommandCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskId = null,
+    Object? taskNo = null,
+    Object? trayNo = null,
+    Object? startAddr = null,
+    Object? endAddr = null,
+    Object? singleFlag = null,
+    Object? action = null,
+  }) {
+    return _then(_value.copyWith(
+      taskId: null == taskId
+          ? _value.taskId
+          : taskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      taskNo: null == taskNo
+          ? _value.taskNo
+          : taskNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      trayNo: null == trayNo
+          ? _value.trayNo
+          : trayNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      startAddr: null == startAddr
+          ? _value.startAddr
+          : startAddr // ignore: cast_nullable_to_non_nullable
+              as String,
+      endAddr: null == endAddr
+          ? _value.endAddr
+          : endAddr // ignore: cast_nullable_to_non_nullable
+              as String,
+      singleFlag: null == singleFlag
+          ? _value.singleFlag
+          : singleFlag // ignore: cast_nullable_to_non_nullable
+              as String,
+      action: null == action
+          ? _value.action
+          : action // ignore: cast_nullable_to_non_nullable
+              as InventoryCollectCommandAction,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryCollectCommandImplCopyWith<$Res>
+    implements $InventoryCollectCommandCopyWith<$Res> {
+  factory _$$InventoryCollectCommandImplCopyWith(
+          _$InventoryCollectCommandImpl value,
+          $Res Function(_$InventoryCollectCommandImpl) then) =
+      __$$InventoryCollectCommandImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskId') String taskId,
+      @JsonKey(name: 'taskNo') String taskNo,
+      @JsonKey(name: 'trayNo') String trayNo,
+      @JsonKey(name: 'startAddr') String startAddr,
+      @JsonKey(name: 'endAddr') String endAddr,
+      @JsonKey(name: 'singleFlag') String singleFlag,
+      @JsonKey(name: 'action') InventoryCollectCommandAction action});
+}
+
+/// @nodoc
+class __$$InventoryCollectCommandImplCopyWithImpl<$Res>
+    extends _$InventoryCollectCommandCopyWithImpl<$Res,
+        _$InventoryCollectCommandImpl>
+    implements _$$InventoryCollectCommandImplCopyWith<$Res> {
+  __$$InventoryCollectCommandImplCopyWithImpl(
+      _$InventoryCollectCommandImpl _value,
+      $Res Function(_$InventoryCollectCommandImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskId = null,
+    Object? taskNo = null,
+    Object? trayNo = null,
+    Object? startAddr = null,
+    Object? endAddr = null,
+    Object? singleFlag = null,
+    Object? action = null,
+  }) {
+    return _then(_$InventoryCollectCommandImpl(
+      taskId: null == taskId
+          ? _value.taskId
+          : taskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      taskNo: null == taskNo
+          ? _value.taskNo
+          : taskNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      trayNo: null == trayNo
+          ? _value.trayNo
+          : trayNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      startAddr: null == startAddr
+          ? _value.startAddr
+          : startAddr // ignore: cast_nullable_to_non_nullable
+              as String,
+      endAddr: null == endAddr
+          ? _value.endAddr
+          : endAddr // ignore: cast_nullable_to_non_nullable
+              as String,
+      singleFlag: null == singleFlag
+          ? _value.singleFlag
+          : singleFlag // ignore: cast_nullable_to_non_nullable
+              as String,
+      action: null == action
+          ? _value.action
+          : action // ignore: cast_nullable_to_non_nullable
+              as InventoryCollectCommandAction,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryCollectCommandImpl implements _InventoryCollectCommand {
+  const _$InventoryCollectCommandImpl(
+      {@JsonKey(name: 'taskId') required this.taskId,
+      @JsonKey(name: 'taskNo') required this.taskNo,
+      @JsonKey(name: 'trayNo') required this.trayNo,
+      @JsonKey(name: 'startAddr') required this.startAddr,
+      @JsonKey(name: 'endAddr') required this.endAddr,
+      @JsonKey(name: 'singleFlag') this.singleFlag = '0',
+      @JsonKey(name: 'action')
+      this.action = InventoryCollectCommandAction.inventoryDown});
+
+  factory _$InventoryCollectCommandImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryCollectCommandImplFromJson(json);
+
+  /// 任务 ID
+  @override
+  @JsonKey(name: 'taskId')
+  final String taskId;
+
+  /// 任务号
+  @override
+  @JsonKey(name: 'taskNo')
+  final String taskNo;
+
+  /// 托盘号
+  @override
+  @JsonKey(name: 'trayNo')
+  final String trayNo;
+
+  /// 起始地址
+  @override
+  @JsonKey(name: 'startAddr')
+  final String startAddr;
+
+  /// 目标地址
+  @override
+  @JsonKey(name: 'endAddr')
+  final String endAddr;
+
+  /// 单托盘标识
+  @override
+  @JsonKey(name: 'singleFlag')
+  final String singleFlag;
+
+  /// 指令类型（用于区分调用的接口）
+  @override
+  @JsonKey(name: 'action')
+  final InventoryCollectCommandAction action;
+
+  @override
+  String toString() {
+    return 'InventoryCollectCommand(taskId: $taskId, taskNo: $taskNo, trayNo: $trayNo, startAddr: $startAddr, endAddr: $endAddr, singleFlag: $singleFlag, action: $action)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryCollectCommandImpl &&
+            (identical(other.taskId, taskId) || other.taskId == taskId) &&
+            (identical(other.taskNo, taskNo) || other.taskNo == taskNo) &&
+            (identical(other.trayNo, trayNo) || other.trayNo == trayNo) &&
+            (identical(other.startAddr, startAddr) ||
+                other.startAddr == startAddr) &&
+            (identical(other.endAddr, endAddr) || other.endAddr == endAddr) &&
+            (identical(other.singleFlag, singleFlag) ||
+                other.singleFlag == singleFlag) &&
+            (identical(other.action, action) || other.action == action));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, taskId, taskNo, trayNo,
+      startAddr, endAddr, singleFlag, action);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryCollectCommandImplCopyWith<_$InventoryCollectCommandImpl>
+      get copyWith => __$$InventoryCollectCommandImplCopyWithImpl<
+          _$InventoryCollectCommandImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryCollectCommandImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryCollectCommand implements InventoryCollectCommand {
+  const factory _InventoryCollectCommand(
+          {@JsonKey(name: 'taskId') required final String taskId,
+          @JsonKey(name: 'taskNo') required final String taskNo,
+          @JsonKey(name: 'trayNo') required final String trayNo,
+          @JsonKey(name: 'startAddr') required final String startAddr,
+          @JsonKey(name: 'endAddr') required final String endAddr,
+          @JsonKey(name: 'singleFlag') final String singleFlag,
+          @JsonKey(name: 'action')
+          final InventoryCollectCommandAction action}) =
+      _$InventoryCollectCommandImpl;
+
+  factory _InventoryCollectCommand.fromJson(Map<String, dynamic> json) =
+      _$InventoryCollectCommandImpl.fromJson;
+
+  @override
+
+  /// 任务 ID
+  @JsonKey(name: 'taskId')
+  String get taskId;
+  @override
+
+  /// 任务号
+  @JsonKey(name: 'taskNo')
+  String get taskNo;
+  @override
+
+  /// 托盘号
+  @JsonKey(name: 'trayNo')
+  String get trayNo;
+  @override
+
+  /// 起始地址
+  @JsonKey(name: 'startAddr')
+  String get startAddr;
+  @override
+
+  /// 目标地址
+  @JsonKey(name: 'endAddr')
+  String get endAddr;
+  @override
+
+  /// 单托盘标识
+  @JsonKey(name: 'singleFlag')
+  String get singleFlag;
+  @override
+
+  /// 指令类型（用于区分调用的接口）
+  @JsonKey(name: 'action')
+  InventoryCollectCommandAction get action;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryCollectCommandImplCopyWith<_$InventoryCollectCommandImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+InventoryCollectStateSnapshot _$InventoryCollectStateSnapshotFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryCollectStateSnapshot.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryCollectStateSnapshot {
+  /// 任务 ID
+  @JsonKey(name: 'taskId')
+  String get taskId => throw _privateConstructorUsedError;
+
+  /// 盘库单号
+  @JsonKey(name: 'taskComment')
+  String get taskComment => throw _privateConstructorUsedError;
+
+  /// 当前托盘号
+  @JsonKey(name: 'activeTrayNo')
+  String? get activeTrayNo => throw _privateConstructorUsedError;
+
+  /// 当前库位
+  @JsonKey(name: 'activeStoreSiteNo')
+  String? get activeStoreSiteNo => throw _privateConstructorUsedError;
+
+  /// 最近一次扫描内容
+  @JsonKey(name: 'lastScannedCode')
+  String? get lastScannedCode => throw _privateConstructorUsedError;
+
+  /// 采集中任务明细
+  @JsonKey(name: 'taskItems')
+  List<InventoryTaskItem> get taskItems => throw _privateConstructorUsedError;
+
+  /// 已采集记录
+  @JsonKey(name: 'collectedRecords')
+  List<InventoryCollectingRecord> get collectedRecords =>
+      throw _privateConstructorUsedError;
+
+  /// 快照更新时间
+  @JsonKey(
+      name: 'updatedAt', fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  DateTime? get updatedAt => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryCollectStateSnapshotCopyWith<InventoryCollectStateSnapshot>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryCollectStateSnapshotCopyWith<$Res> {
+  factory $InventoryCollectStateSnapshotCopyWith(
+          InventoryCollectStateSnapshot value,
+          $Res Function(InventoryCollectStateSnapshot) then) =
+      _$InventoryCollectStateSnapshotCopyWithImpl<$Res,
+          InventoryCollectStateSnapshot>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskId') String taskId,
+      @JsonKey(name: 'taskComment') String taskComment,
+      @JsonKey(name: 'activeTrayNo') String? activeTrayNo,
+      @JsonKey(name: 'activeStoreSiteNo') String? activeStoreSiteNo,
+      @JsonKey(name: 'lastScannedCode') String? lastScannedCode,
+      @JsonKey(name: 'taskItems') List<InventoryTaskItem> taskItems,
+      @JsonKey(name: 'collectedRecords')
+      List<InventoryCollectingRecord> collectedRecords,
+      @JsonKey(
+          name: 'updatedAt',
+          fromJson: _dateTimeFromJson,
+          toJson: _dateTimeToJson)
+      DateTime? updatedAt});
+}
+
+/// @nodoc
+class _$InventoryCollectStateSnapshotCopyWithImpl<$Res,
+        $Val extends InventoryCollectStateSnapshot>
+    implements $InventoryCollectStateSnapshotCopyWith<$Res> {
+  _$InventoryCollectStateSnapshotCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskId = null,
+    Object? taskComment = null,
+    Object? activeTrayNo = freezed,
+    Object? activeStoreSiteNo = freezed,
+    Object? lastScannedCode = freezed,
+    Object? taskItems = null,
+    Object? collectedRecords = null,
+    Object? updatedAt = freezed,
+  }) {
+    return _then(_value.copyWith(
+      taskId: null == taskId
+          ? _value.taskId
+          : taskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      activeTrayNo: freezed == activeTrayNo
+          ? _value.activeTrayNo
+          : activeTrayNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      activeStoreSiteNo: freezed == activeStoreSiteNo
+          ? _value.activeStoreSiteNo
+          : activeStoreSiteNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lastScannedCode: freezed == lastScannedCode
+          ? _value.lastScannedCode
+          : lastScannedCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      taskItems: null == taskItems
+          ? _value.taskItems
+          : taskItems // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTaskItem>,
+      collectedRecords: null == collectedRecords
+          ? _value.collectedRecords
+          : collectedRecords // ignore: cast_nullable_to_non_nullable
+              as List<InventoryCollectingRecord>,
+      updatedAt: freezed == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryCollectStateSnapshotImplCopyWith<$Res>
+    implements $InventoryCollectStateSnapshotCopyWith<$Res> {
+  factory _$$InventoryCollectStateSnapshotImplCopyWith(
+          _$InventoryCollectStateSnapshotImpl value,
+          $Res Function(_$InventoryCollectStateSnapshotImpl) then) =
+      __$$InventoryCollectStateSnapshotImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskId') String taskId,
+      @JsonKey(name: 'taskComment') String taskComment,
+      @JsonKey(name: 'activeTrayNo') String? activeTrayNo,
+      @JsonKey(name: 'activeStoreSiteNo') String? activeStoreSiteNo,
+      @JsonKey(name: 'lastScannedCode') String? lastScannedCode,
+      @JsonKey(name: 'taskItems') List<InventoryTaskItem> taskItems,
+      @JsonKey(name: 'collectedRecords')
+      List<InventoryCollectingRecord> collectedRecords,
+      @JsonKey(
+          name: 'updatedAt',
+          fromJson: _dateTimeFromJson,
+          toJson: _dateTimeToJson)
+      DateTime? updatedAt});
+}
+
+/// @nodoc
+class __$$InventoryCollectStateSnapshotImplCopyWithImpl<$Res>
+    extends _$InventoryCollectStateSnapshotCopyWithImpl<$Res,
+        _$InventoryCollectStateSnapshotImpl>
+    implements _$$InventoryCollectStateSnapshotImplCopyWith<$Res> {
+  __$$InventoryCollectStateSnapshotImplCopyWithImpl(
+      _$InventoryCollectStateSnapshotImpl _value,
+      $Res Function(_$InventoryCollectStateSnapshotImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskId = null,
+    Object? taskComment = null,
+    Object? activeTrayNo = freezed,
+    Object? activeStoreSiteNo = freezed,
+    Object? lastScannedCode = freezed,
+    Object? taskItems = null,
+    Object? collectedRecords = null,
+    Object? updatedAt = freezed,
+  }) {
+    return _then(_$InventoryCollectStateSnapshotImpl(
+      taskId: null == taskId
+          ? _value.taskId
+          : taskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      activeTrayNo: freezed == activeTrayNo
+          ? _value.activeTrayNo
+          : activeTrayNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      activeStoreSiteNo: freezed == activeStoreSiteNo
+          ? _value.activeStoreSiteNo
+          : activeStoreSiteNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      lastScannedCode: freezed == lastScannedCode
+          ? _value.lastScannedCode
+          : lastScannedCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      taskItems: null == taskItems
+          ? _value._taskItems
+          : taskItems // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTaskItem>,
+      collectedRecords: null == collectedRecords
+          ? _value._collectedRecords
+          : collectedRecords // ignore: cast_nullable_to_non_nullable
+              as List<InventoryCollectingRecord>,
+      updatedAt: freezed == updatedAt
+          ? _value.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryCollectStateSnapshotImpl
+    implements _InventoryCollectStateSnapshot {
+  const _$InventoryCollectStateSnapshotImpl(
+      {@JsonKey(name: 'taskId') required this.taskId,
+      @JsonKey(name: 'taskComment') required this.taskComment,
+      @JsonKey(name: 'activeTrayNo') this.activeTrayNo,
+      @JsonKey(name: 'activeStoreSiteNo') this.activeStoreSiteNo,
+      @JsonKey(name: 'lastScannedCode') this.lastScannedCode,
+      @JsonKey(name: 'taskItems')
+      final List<InventoryTaskItem> taskItems = const <InventoryTaskItem>[],
+      @JsonKey(name: 'collectedRecords')
+      final List<InventoryCollectingRecord> collectedRecords =
+          const <InventoryCollectingRecord>[],
+      @JsonKey(
+          name: 'updatedAt',
+          fromJson: _dateTimeFromJson,
+          toJson: _dateTimeToJson)
+      this.updatedAt})
+      : _taskItems = taskItems,
+        _collectedRecords = collectedRecords;
+
+  factory _$InventoryCollectStateSnapshotImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$InventoryCollectStateSnapshotImplFromJson(json);
+
+  /// 任务 ID
+  @override
+  @JsonKey(name: 'taskId')
+  final String taskId;
+
+  /// 盘库单号
+  @override
+  @JsonKey(name: 'taskComment')
+  final String taskComment;
+
+  /// 当前托盘号
+  @override
+  @JsonKey(name: 'activeTrayNo')
+  final String? activeTrayNo;
+
+  /// 当前库位
+  @override
+  @JsonKey(name: 'activeStoreSiteNo')
+  final String? activeStoreSiteNo;
+
+  /// 最近一次扫描内容
+  @override
+  @JsonKey(name: 'lastScannedCode')
+  final String? lastScannedCode;
+
+  /// 采集中任务明细
+  final List<InventoryTaskItem> _taskItems;
+
+  /// 采集中任务明细
+  @override
+  @JsonKey(name: 'taskItems')
+  List<InventoryTaskItem> get taskItems {
+    if (_taskItems is EqualUnmodifiableListView) return _taskItems;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_taskItems);
+  }
+
+  /// 已采集记录
+  final List<InventoryCollectingRecord> _collectedRecords;
+
+  /// 已采集记录
+  @override
+  @JsonKey(name: 'collectedRecords')
+  List<InventoryCollectingRecord> get collectedRecords {
+    if (_collectedRecords is EqualUnmodifiableListView)
+      return _collectedRecords;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_collectedRecords);
+  }
+
+  /// 快照更新时间
+  @override
+  @JsonKey(
+      name: 'updatedAt', fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  final DateTime? updatedAt;
+
+  @override
+  String toString() {
+    return 'InventoryCollectStateSnapshot(taskId: $taskId, taskComment: $taskComment, activeTrayNo: $activeTrayNo, activeStoreSiteNo: $activeStoreSiteNo, lastScannedCode: $lastScannedCode, taskItems: $taskItems, collectedRecords: $collectedRecords, updatedAt: $updatedAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryCollectStateSnapshotImpl &&
+            (identical(other.taskId, taskId) || other.taskId == taskId) &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment) &&
+            (identical(other.activeTrayNo, activeTrayNo) ||
+                other.activeTrayNo == activeTrayNo) &&
+            (identical(other.activeStoreSiteNo, activeStoreSiteNo) ||
+                other.activeStoreSiteNo == activeStoreSiteNo) &&
+            (identical(other.lastScannedCode, lastScannedCode) ||
+                other.lastScannedCode == lastScannedCode) &&
+            const DeepCollectionEquality()
+                .equals(other._taskItems, _taskItems) &&
+            const DeepCollectionEquality()
+                .equals(other._collectedRecords, _collectedRecords) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      taskId,
+      taskComment,
+      activeTrayNo,
+      activeStoreSiteNo,
+      lastScannedCode,
+      const DeepCollectionEquality().hash(_taskItems),
+      const DeepCollectionEquality().hash(_collectedRecords),
+      updatedAt);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryCollectStateSnapshotImplCopyWith<
+          _$InventoryCollectStateSnapshotImpl>
+      get copyWith => __$$InventoryCollectStateSnapshotImplCopyWithImpl<
+          _$InventoryCollectStateSnapshotImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryCollectStateSnapshotImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryCollectStateSnapshot
+    implements InventoryCollectStateSnapshot {
+  const factory _InventoryCollectStateSnapshot(
+      {@JsonKey(name: 'taskId') required final String taskId,
+      @JsonKey(name: 'taskComment') required final String taskComment,
+      @JsonKey(name: 'activeTrayNo') final String? activeTrayNo,
+      @JsonKey(name: 'activeStoreSiteNo') final String? activeStoreSiteNo,
+      @JsonKey(name: 'lastScannedCode') final String? lastScannedCode,
+      @JsonKey(name: 'taskItems') final List<InventoryTaskItem> taskItems,
+      @JsonKey(name: 'collectedRecords')
+      final List<InventoryCollectingRecord> collectedRecords,
+      @JsonKey(
+          name: 'updatedAt',
+          fromJson: _dateTimeFromJson,
+          toJson: _dateTimeToJson)
+      final DateTime? updatedAt}) = _$InventoryCollectStateSnapshotImpl;
+
+  factory _InventoryCollectStateSnapshot.fromJson(Map<String, dynamic> json) =
+      _$InventoryCollectStateSnapshotImpl.fromJson;
+
+  @override
+
+  /// 任务 ID
+  @JsonKey(name: 'taskId')
+  String get taskId;
+  @override
+
+  /// 盘库单号
+  @JsonKey(name: 'taskComment')
+  String get taskComment;
+  @override
+
+  /// 当前托盘号
+  @JsonKey(name: 'activeTrayNo')
+  String? get activeTrayNo;
+  @override
+
+  /// 当前库位
+  @JsonKey(name: 'activeStoreSiteNo')
+  String? get activeStoreSiteNo;
+  @override
+
+  /// 最近一次扫描内容
+  @JsonKey(name: 'lastScannedCode')
+  String? get lastScannedCode;
+  @override
+
+  /// 采集中任务明细
+  @JsonKey(name: 'taskItems')
+  List<InventoryTaskItem> get taskItems;
+  @override
+
+  /// 已采集记录
+  @JsonKey(name: 'collectedRecords')
+  List<InventoryCollectingRecord> get collectedRecords;
+  @override
+
+  /// 快照更新时间
+  @JsonKey(
+      name: 'updatedAt', fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  DateTime? get updatedAt;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryCollectStateSnapshotImplCopyWith<
+          _$InventoryCollectStateSnapshotImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+InventoryPalletInfo _$InventoryPalletInfoFromJson(Map<String, dynamic> json) {
+  return _InventoryPalletInfo.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryPalletInfo {
+  /// 托盘号
+  @JsonKey(name: 'palletNo')
+  String? get palletNo => throw _privateConstructorUsedError;
+
+  /// 库位编码
+  @JsonKey(name: 'storeSite')
+  String? get storeSite => throw _privateConstructorUsedError;
+
+  /// 库房编码
+  @JsonKey(name: 'storeRoom')
+  String? get storeRoom => throw _privateConstructorUsedError;
+
+  /// 物料编码
+  @JsonKey(name: 'matCode')
+  String? get materialCode => throw _privateConstructorUsedError;
+
+  /// 物料名称
+  @JsonKey(name: 'matName')
+  String? get materialName => throw _privateConstructorUsedError;
+
+  /// 库存数量
+  @JsonKey(name: 'InventoryQty')
+  double get inventoryQty => throw _privateConstructorUsedError;
+
+  /// ERP 子库
+  @JsonKey(name: 'erpStoreRoom')
+  String? get erpStoreRoom => throw _privateConstructorUsedError;
+
+  /// ERP 库位
+  @JsonKey(name: 'erpStoreSite')
+  String? get erpStoreSite => throw _privateConstructorUsedError;
+
+  /// 批次号
+  @JsonKey(name: 'batchNo')
+  String? get batchNo => throw _privateConstructorUsedError;
+
+  /// 序列号
+  @JsonKey(name: 'sn')
+  String? get serialNo => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryPalletInfoCopyWith<InventoryPalletInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryPalletInfoCopyWith<$Res> {
+  factory $InventoryPalletInfoCopyWith(
+          InventoryPalletInfo value, $Res Function(InventoryPalletInfo) then) =
+      _$InventoryPalletInfoCopyWithImpl<$Res, InventoryPalletInfo>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'palletNo') String? palletNo,
+      @JsonKey(name: 'storeSite') String? storeSite,
+      @JsonKey(name: 'storeRoom') String? storeRoom,
+      @JsonKey(name: 'matCode') String? materialCode,
+      @JsonKey(name: 'matName') String? materialName,
+      @JsonKey(name: 'InventoryQty') double inventoryQty,
+      @JsonKey(name: 'erpStoreRoom') String? erpStoreRoom,
+      @JsonKey(name: 'erpStoreSite') String? erpStoreSite,
+      @JsonKey(name: 'batchNo') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo});
+}
+
+/// @nodoc
+class _$InventoryPalletInfoCopyWithImpl<$Res, $Val extends InventoryPalletInfo>
+    implements $InventoryPalletInfoCopyWith<$Res> {
+  _$InventoryPalletInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? palletNo = freezed,
+    Object? storeSite = freezed,
+    Object? storeRoom = freezed,
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? inventoryQty = null,
+    Object? erpStoreRoom = freezed,
+    Object? erpStoreSite = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+  }) {
+    return _then(_value.copyWith(
+      palletNo: freezed == palletNo
+          ? _value.palletNo
+          : palletNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSite: freezed == storeSite
+          ? _value.storeSite
+          : storeSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoom: freezed == storeRoom
+          ? _value.storeRoom
+          : storeRoom // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: freezed == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      inventoryQty: null == inventoryQty
+          ? _value.inventoryQty
+          : inventoryQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      erpStoreRoom: freezed == erpStoreRoom
+          ? _value.erpStoreRoom
+          : erpStoreRoom // ignore: cast_nullable_to_non_nullable
+              as String?,
+      erpStoreSite: freezed == erpStoreSite
+          ? _value.erpStoreSite
+          : erpStoreSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryPalletInfoImplCopyWith<$Res>
+    implements $InventoryPalletInfoCopyWith<$Res> {
+  factory _$$InventoryPalletInfoImplCopyWith(_$InventoryPalletInfoImpl value,
+          $Res Function(_$InventoryPalletInfoImpl) then) =
+      __$$InventoryPalletInfoImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'palletNo') String? palletNo,
+      @JsonKey(name: 'storeSite') String? storeSite,
+      @JsonKey(name: 'storeRoom') String? storeRoom,
+      @JsonKey(name: 'matCode') String? materialCode,
+      @JsonKey(name: 'matName') String? materialName,
+      @JsonKey(name: 'InventoryQty') double inventoryQty,
+      @JsonKey(name: 'erpStoreRoom') String? erpStoreRoom,
+      @JsonKey(name: 'erpStoreSite') String? erpStoreSite,
+      @JsonKey(name: 'batchNo') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo});
+}
+
+/// @nodoc
+class __$$InventoryPalletInfoImplCopyWithImpl<$Res>
+    extends _$InventoryPalletInfoCopyWithImpl<$Res, _$InventoryPalletInfoImpl>
+    implements _$$InventoryPalletInfoImplCopyWith<$Res> {
+  __$$InventoryPalletInfoImplCopyWithImpl(_$InventoryPalletInfoImpl _value,
+      $Res Function(_$InventoryPalletInfoImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? palletNo = freezed,
+    Object? storeSite = freezed,
+    Object? storeRoom = freezed,
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? inventoryQty = null,
+    Object? erpStoreRoom = freezed,
+    Object? erpStoreSite = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+  }) {
+    return _then(_$InventoryPalletInfoImpl(
+      palletNo: freezed == palletNo
+          ? _value.palletNo
+          : palletNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSite: freezed == storeSite
+          ? _value.storeSite
+          : storeSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoom: freezed == storeRoom
+          ? _value.storeRoom
+          : storeRoom // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: freezed == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      inventoryQty: null == inventoryQty
+          ? _value.inventoryQty
+          : inventoryQty // ignore: cast_nullable_to_non_nullable
+              as double,
+      erpStoreRoom: freezed == erpStoreRoom
+          ? _value.erpStoreRoom
+          : erpStoreRoom // ignore: cast_nullable_to_non_nullable
+              as String?,
+      erpStoreSite: freezed == erpStoreSite
+          ? _value.erpStoreSite
+          : erpStoreSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryPalletInfoImpl implements _InventoryPalletInfo {
+  const _$InventoryPalletInfoImpl(
+      {@JsonKey(name: 'palletNo') this.palletNo,
+      @JsonKey(name: 'storeSite') this.storeSite,
+      @JsonKey(name: 'storeRoom') this.storeRoom,
+      @JsonKey(name: 'matCode') this.materialCode,
+      @JsonKey(name: 'matName') this.materialName,
+      @JsonKey(name: 'InventoryQty') this.inventoryQty = 0,
+      @JsonKey(name: 'erpStoreRoom') this.erpStoreRoom,
+      @JsonKey(name: 'erpStoreSite') this.erpStoreSite,
+      @JsonKey(name: 'batchNo') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNo});
+
+  factory _$InventoryPalletInfoImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryPalletInfoImplFromJson(json);
+
+  /// 托盘号
+  @override
+  @JsonKey(name: 'palletNo')
+  final String? palletNo;
+
+  /// 库位编码
+  @override
+  @JsonKey(name: 'storeSite')
+  final String? storeSite;
+
+  /// 库房编码
+  @override
+  @JsonKey(name: 'storeRoom')
+  final String? storeRoom;
+
+  /// 物料编码
+  @override
+  @JsonKey(name: 'matCode')
+  final String? materialCode;
+
+  /// 物料名称
+  @override
+  @JsonKey(name: 'matName')
+  final String? materialName;
+
+  /// 库存数量
+  @override
+  @JsonKey(name: 'InventoryQty')
+  final double inventoryQty;
+
+  /// ERP 子库
+  @override
+  @JsonKey(name: 'erpStoreRoom')
+  final String? erpStoreRoom;
+
+  /// ERP 库位
+  @override
+  @JsonKey(name: 'erpStoreSite')
+  final String? erpStoreSite;
+
+  /// 批次号
+  @override
+  @JsonKey(name: 'batchNo')
+  final String? batchNo;
+
+  /// 序列号
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNo;
+
+  @override
+  String toString() {
+    return 'InventoryPalletInfo(palletNo: $palletNo, storeSite: $storeSite, storeRoom: $storeRoom, materialCode: $materialCode, materialName: $materialName, inventoryQty: $inventoryQty, erpStoreRoom: $erpStoreRoom, erpStoreSite: $erpStoreSite, batchNo: $batchNo, serialNo: $serialNo)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryPalletInfoImpl &&
+            (identical(other.palletNo, palletNo) ||
+                other.palletNo == palletNo) &&
+            (identical(other.storeSite, storeSite) ||
+                other.storeSite == storeSite) &&
+            (identical(other.storeRoom, storeRoom) ||
+                other.storeRoom == storeRoom) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.inventoryQty, inventoryQty) ||
+                other.inventoryQty == inventoryQty) &&
+            (identical(other.erpStoreRoom, erpStoreRoom) ||
+                other.erpStoreRoom == erpStoreRoom) &&
+            (identical(other.erpStoreSite, erpStoreSite) ||
+                other.erpStoreSite == erpStoreSite) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      palletNo,
+      storeSite,
+      storeRoom,
+      materialCode,
+      materialName,
+      inventoryQty,
+      erpStoreRoom,
+      erpStoreSite,
+      batchNo,
+      serialNo);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryPalletInfoImplCopyWith<_$InventoryPalletInfoImpl> get copyWith =>
+      __$$InventoryPalletInfoImplCopyWithImpl<_$InventoryPalletInfoImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryPalletInfoImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryPalletInfo implements InventoryPalletInfo {
+  const factory _InventoryPalletInfo(
+      {@JsonKey(name: 'palletNo') final String? palletNo,
+      @JsonKey(name: 'storeSite') final String? storeSite,
+      @JsonKey(name: 'storeRoom') final String? storeRoom,
+      @JsonKey(name: 'matCode') final String? materialCode,
+      @JsonKey(name: 'matName') final String? materialName,
+      @JsonKey(name: 'InventoryQty') final double inventoryQty,
+      @JsonKey(name: 'erpStoreRoom') final String? erpStoreRoom,
+      @JsonKey(name: 'erpStoreSite') final String? erpStoreSite,
+      @JsonKey(name: 'batchNo') final String? batchNo,
+      @JsonKey(name: 'sn') final String? serialNo}) = _$InventoryPalletInfoImpl;
+
+  factory _InventoryPalletInfo.fromJson(Map<String, dynamic> json) =
+      _$InventoryPalletInfoImpl.fromJson;
+
+  @override
+
+  /// 托盘号
+  @JsonKey(name: 'palletNo')
+  String? get palletNo;
+  @override
+
+  /// 库位编码
+  @JsonKey(name: 'storeSite')
+  String? get storeSite;
+  @override
+
+  /// 库房编码
+  @JsonKey(name: 'storeRoom')
+  String? get storeRoom;
+  @override
+
+  /// 物料编码
+  @JsonKey(name: 'matCode')
+  String? get materialCode;
+  @override
+
+  /// 物料名称
+  @JsonKey(name: 'matName')
+  String? get materialName;
+  @override
+
+  /// 库存数量
+  @JsonKey(name: 'InventoryQty')
+  double get inventoryQty;
+  @override
+
+  /// ERP 子库
+  @JsonKey(name: 'erpStoreRoom')
+  String? get erpStoreRoom;
+  @override
+
+  /// ERP 库位
+  @JsonKey(name: 'erpStoreSite')
+  String? get erpStoreSite;
+  @override
+
+  /// 批次号
+  @JsonKey(name: 'batchNo')
+  String? get batchNo;
+  @override
+
+  /// 序列号
+  @JsonKey(name: 'sn')
+  String? get serialNo;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryPalletInfoImplCopyWith<_$InventoryPalletInfoImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventoryMatControl _$InventoryMatControlFromJson(Map<String, dynamic> json) {
+  return _InventoryMatControl.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryMatControl {
+  /// 物料编码
+  @JsonKey(name: 'matCode')
+  String? get materialCode => throw _privateConstructorUsedError;
+
+  /// 批次管控
+  @JsonKey(name: 'batchFlag')
+  bool get batchRequired => throw _privateConstructorUsedError;
+
+  /// 供应商校验
+  @JsonKey(name: 'supplierFlag')
+  bool get supplierRequired => throw _privateConstructorUsedError;
+
+  /// 序列号管控
+  @JsonKey(name: 'snFlag')
+  bool get serialRequired => throw _privateConstructorUsedError;
+
+  /// 有效期校验
+  @JsonKey(name: 'validFlag')
+  bool get validityRequired => throw _privateConstructorUsedError;
+
+  /// 控制标记
+  @JsonKey(name: 'matControlFlag')
+  String? get controlFlag => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryMatControlCopyWith<InventoryMatControl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryMatControlCopyWith<$Res> {
+  factory $InventoryMatControlCopyWith(
+          InventoryMatControl value, $Res Function(InventoryMatControl) then) =
+      _$InventoryMatControlCopyWithImpl<$Res, InventoryMatControl>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'matCode') String? materialCode,
+      @JsonKey(name: 'batchFlag') bool batchRequired,
+      @JsonKey(name: 'supplierFlag') bool supplierRequired,
+      @JsonKey(name: 'snFlag') bool serialRequired,
+      @JsonKey(name: 'validFlag') bool validityRequired,
+      @JsonKey(name: 'matControlFlag') String? controlFlag});
+}
+
+/// @nodoc
+class _$InventoryMatControlCopyWithImpl<$Res, $Val extends InventoryMatControl>
+    implements $InventoryMatControlCopyWith<$Res> {
+  _$InventoryMatControlCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = freezed,
+    Object? batchRequired = null,
+    Object? supplierRequired = null,
+    Object? serialRequired = null,
+    Object? validityRequired = null,
+    Object? controlFlag = freezed,
+  }) {
+    return _then(_value.copyWith(
+      materialCode: freezed == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchRequired: null == batchRequired
+          ? _value.batchRequired
+          : batchRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      supplierRequired: null == supplierRequired
+          ? _value.supplierRequired
+          : supplierRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      serialRequired: null == serialRequired
+          ? _value.serialRequired
+          : serialRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      validityRequired: null == validityRequired
+          ? _value.validityRequired
+          : validityRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      controlFlag: freezed == controlFlag
+          ? _value.controlFlag
+          : controlFlag // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryMatControlImplCopyWith<$Res>
+    implements $InventoryMatControlCopyWith<$Res> {
+  factory _$$InventoryMatControlImplCopyWith(_$InventoryMatControlImpl value,
+          $Res Function(_$InventoryMatControlImpl) then) =
+      __$$InventoryMatControlImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'matCode') String? materialCode,
+      @JsonKey(name: 'batchFlag') bool batchRequired,
+      @JsonKey(name: 'supplierFlag') bool supplierRequired,
+      @JsonKey(name: 'snFlag') bool serialRequired,
+      @JsonKey(name: 'validFlag') bool validityRequired,
+      @JsonKey(name: 'matControlFlag') String? controlFlag});
+}
+
+/// @nodoc
+class __$$InventoryMatControlImplCopyWithImpl<$Res>
+    extends _$InventoryMatControlCopyWithImpl<$Res, _$InventoryMatControlImpl>
+    implements _$$InventoryMatControlImplCopyWith<$Res> {
+  __$$InventoryMatControlImplCopyWithImpl(_$InventoryMatControlImpl _value,
+      $Res Function(_$InventoryMatControlImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = freezed,
+    Object? batchRequired = null,
+    Object? supplierRequired = null,
+    Object? serialRequired = null,
+    Object? validityRequired = null,
+    Object? controlFlag = freezed,
+  }) {
+    return _then(_$InventoryMatControlImpl(
+      materialCode: freezed == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchRequired: null == batchRequired
+          ? _value.batchRequired
+          : batchRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      supplierRequired: null == supplierRequired
+          ? _value.supplierRequired
+          : supplierRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      serialRequired: null == serialRequired
+          ? _value.serialRequired
+          : serialRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      validityRequired: null == validityRequired
+          ? _value.validityRequired
+          : validityRequired // ignore: cast_nullable_to_non_nullable
+              as bool,
+      controlFlag: freezed == controlFlag
+          ? _value.controlFlag
+          : controlFlag // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryMatControlImpl implements _InventoryMatControl {
+  const _$InventoryMatControlImpl(
+      {@JsonKey(name: 'matCode') this.materialCode,
+      @JsonKey(name: 'batchFlag') this.batchRequired = true,
+      @JsonKey(name: 'supplierFlag') this.supplierRequired = true,
+      @JsonKey(name: 'snFlag') this.serialRequired = false,
+      @JsonKey(name: 'validFlag') this.validityRequired = false,
+      @JsonKey(name: 'matControlFlag') this.controlFlag});
+
+  factory _$InventoryMatControlImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryMatControlImplFromJson(json);
+
+  /// 物料编码
+  @override
+  @JsonKey(name: 'matCode')
+  final String? materialCode;
+
+  /// 批次管控
+  @override
+  @JsonKey(name: 'batchFlag')
+  final bool batchRequired;
+
+  /// 供应商校验
+  @override
+  @JsonKey(name: 'supplierFlag')
+  final bool supplierRequired;
+
+  /// 序列号管控
+  @override
+  @JsonKey(name: 'snFlag')
+  final bool serialRequired;
+
+  /// 有效期校验
+  @override
+  @JsonKey(name: 'validFlag')
+  final bool validityRequired;
+
+  /// 控制标记
+  @override
+  @JsonKey(name: 'matControlFlag')
+  final String? controlFlag;
+
+  @override
+  String toString() {
+    return 'InventoryMatControl(materialCode: $materialCode, batchRequired: $batchRequired, supplierRequired: $supplierRequired, serialRequired: $serialRequired, validityRequired: $validityRequired, controlFlag: $controlFlag)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryMatControlImpl &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.batchRequired, batchRequired) ||
+                other.batchRequired == batchRequired) &&
+            (identical(other.supplierRequired, supplierRequired) ||
+                other.supplierRequired == supplierRequired) &&
+            (identical(other.serialRequired, serialRequired) ||
+                other.serialRequired == serialRequired) &&
+            (identical(other.validityRequired, validityRequired) ||
+                other.validityRequired == validityRequired) &&
+            (identical(other.controlFlag, controlFlag) ||
+                other.controlFlag == controlFlag));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, materialCode, batchRequired,
+      supplierRequired, serialRequired, validityRequired, controlFlag);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryMatControlImplCopyWith<_$InventoryMatControlImpl> get copyWith =>
+      __$$InventoryMatControlImplCopyWithImpl<_$InventoryMatControlImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryMatControlImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryMatControl implements InventoryMatControl {
+  const factory _InventoryMatControl(
+          {@JsonKey(name: 'matCode') final String? materialCode,
+          @JsonKey(name: 'batchFlag') final bool batchRequired,
+          @JsonKey(name: 'supplierFlag') final bool supplierRequired,
+          @JsonKey(name: 'snFlag') final bool serialRequired,
+          @JsonKey(name: 'validFlag') final bool validityRequired,
+          @JsonKey(name: 'matControlFlag') final String? controlFlag}) =
+      _$InventoryMatControlImpl;
+
+  factory _InventoryMatControl.fromJson(Map<String, dynamic> json) =
+      _$InventoryMatControlImpl.fromJson;
+
+  @override
+
+  /// 物料编码
+  @JsonKey(name: 'matCode')
+  String? get materialCode;
+  @override
+
+  /// 批次管控
+  @JsonKey(name: 'batchFlag')
+  bool get batchRequired;
+  @override
+
+  /// 供应商校验
+  @JsonKey(name: 'supplierFlag')
+  bool get supplierRequired;
+  @override
+
+  /// 序列号管控
+  @JsonKey(name: 'snFlag')
+  bool get serialRequired;
+  @override
+
+  /// 有效期校验
+  @JsonKey(name: 'validFlag')
+  bool get validityRequired;
+  @override
+
+  /// 控制标记
+  @JsonKey(name: 'matControlFlag')
+  String? get controlFlag;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryMatControlImplCopyWith<_$InventoryMatControlImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventorySiteInfo _$InventorySiteInfoFromJson(Map<String, dynamic> json) {
+  return _InventorySiteInfo.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventorySiteInfo {
+  /// 库房编码
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 库位编码
+  @JsonKey(name: 'storesiteno')
+  String? get storeSiteNo => throw _privateConstructorUsedError;
+
+  /// 库位名称
+  @JsonKey(name: 'storesite')
+  String? get storeSiteName => throw _privateConstructorUsedError;
+
+  /// 锁定状态（0-正常）
+  @JsonKey(name: 'isfrozen')
+  String? get frozenFlag => throw _privateConstructorUsedError;
+
+  /// ERP 库位
+  @JsonKey(name: 'erpstoresite')
+  String? get erpStoreSite => throw _privateConstructorUsedError;
+
+  /// 库位属性
+  @JsonKey(name: 'siteflag')
+  String? get siteFlag => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventorySiteInfoCopyWith<InventorySiteInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventorySiteInfoCopyWith<$Res> {
+  factory $InventorySiteInfoCopyWith(
+          InventorySiteInfo value, $Res Function(InventorySiteInfo) then) =
+      _$InventorySiteInfoCopyWithImpl<$Res, InventorySiteInfo>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'storeroomno') String? storeRoomNo,
+      @JsonKey(name: 'storesiteno') String? storeSiteNo,
+      @JsonKey(name: 'storesite') String? storeSiteName,
+      @JsonKey(name: 'isfrozen') String? frozenFlag,
+      @JsonKey(name: 'erpstoresite') String? erpStoreSite,
+      @JsonKey(name: 'siteflag') String? siteFlag});
+}
+
+/// @nodoc
+class _$InventorySiteInfoCopyWithImpl<$Res, $Val extends InventorySiteInfo>
+    implements $InventorySiteInfoCopyWith<$Res> {
+  _$InventorySiteInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeRoomNo = freezed,
+    Object? storeSiteNo = freezed,
+    Object? storeSiteName = freezed,
+    Object? frozenFlag = freezed,
+    Object? erpStoreSite = freezed,
+    Object? siteFlag = freezed,
+  }) {
+    return _then(_value.copyWith(
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: freezed == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteName: freezed == storeSiteName
+          ? _value.storeSiteName
+          : storeSiteName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      frozenFlag: freezed == frozenFlag
+          ? _value.frozenFlag
+          : frozenFlag // ignore: cast_nullable_to_non_nullable
+              as String?,
+      erpStoreSite: freezed == erpStoreSite
+          ? _value.erpStoreSite
+          : erpStoreSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      siteFlag: freezed == siteFlag
+          ? _value.siteFlag
+          : siteFlag // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventorySiteInfoImplCopyWith<$Res>
+    implements $InventorySiteInfoCopyWith<$Res> {
+  factory _$$InventorySiteInfoImplCopyWith(_$InventorySiteInfoImpl value,
+          $Res Function(_$InventorySiteInfoImpl) then) =
+      __$$InventorySiteInfoImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'storeroomno') String? storeRoomNo,
+      @JsonKey(name: 'storesiteno') String? storeSiteNo,
+      @JsonKey(name: 'storesite') String? storeSiteName,
+      @JsonKey(name: 'isfrozen') String? frozenFlag,
+      @JsonKey(name: 'erpstoresite') String? erpStoreSite,
+      @JsonKey(name: 'siteflag') String? siteFlag});
+}
+
+/// @nodoc
+class __$$InventorySiteInfoImplCopyWithImpl<$Res>
+    extends _$InventorySiteInfoCopyWithImpl<$Res, _$InventorySiteInfoImpl>
+    implements _$$InventorySiteInfoImplCopyWith<$Res> {
+  __$$InventorySiteInfoImplCopyWithImpl(_$InventorySiteInfoImpl _value,
+      $Res Function(_$InventorySiteInfoImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeRoomNo = freezed,
+    Object? storeSiteNo = freezed,
+    Object? storeSiteName = freezed,
+    Object? frozenFlag = freezed,
+    Object? erpStoreSite = freezed,
+    Object? siteFlag = freezed,
+  }) {
+    return _then(_$InventorySiteInfoImpl(
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: freezed == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteName: freezed == storeSiteName
+          ? _value.storeSiteName
+          : storeSiteName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      frozenFlag: freezed == frozenFlag
+          ? _value.frozenFlag
+          : frozenFlag // ignore: cast_nullable_to_non_nullable
+              as String?,
+      erpStoreSite: freezed == erpStoreSite
+          ? _value.erpStoreSite
+          : erpStoreSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      siteFlag: freezed == siteFlag
+          ? _value.siteFlag
+          : siteFlag // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventorySiteInfoImpl implements _InventorySiteInfo {
+  const _$InventorySiteInfoImpl(
+      {@JsonKey(name: 'storeroomno') this.storeRoomNo,
+      @JsonKey(name: 'storesiteno') this.storeSiteNo,
+      @JsonKey(name: 'storesite') this.storeSiteName,
+      @JsonKey(name: 'isfrozen') this.frozenFlag,
+      @JsonKey(name: 'erpstoresite') this.erpStoreSite,
+      @JsonKey(name: 'siteflag') this.siteFlag});
+
+  factory _$InventorySiteInfoImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventorySiteInfoImplFromJson(json);
+
+  /// 库房编码
+  @override
+  @JsonKey(name: 'storeroomno')
+  final String? storeRoomNo;
+
+  /// 库位编码
+  @override
+  @JsonKey(name: 'storesiteno')
+  final String? storeSiteNo;
+
+  /// 库位名称
+  @override
+  @JsonKey(name: 'storesite')
+  final String? storeSiteName;
+
+  /// 锁定状态（0-正常）
+  @override
+  @JsonKey(name: 'isfrozen')
+  final String? frozenFlag;
+
+  /// ERP 库位
+  @override
+  @JsonKey(name: 'erpstoresite')
+  final String? erpStoreSite;
+
+  /// 库位属性
+  @override
+  @JsonKey(name: 'siteflag')
+  final String? siteFlag;
+
+  @override
+  String toString() {
+    return 'InventorySiteInfo(storeRoomNo: $storeRoomNo, storeSiteNo: $storeSiteNo, storeSiteName: $storeSiteName, frozenFlag: $frozenFlag, erpStoreSite: $erpStoreSite, siteFlag: $siteFlag)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventorySiteInfoImpl &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.storeSiteName, storeSiteName) ||
+                other.storeSiteName == storeSiteName) &&
+            (identical(other.frozenFlag, frozenFlag) ||
+                other.frozenFlag == frozenFlag) &&
+            (identical(other.erpStoreSite, erpStoreSite) ||
+                other.erpStoreSite == erpStoreSite) &&
+            (identical(other.siteFlag, siteFlag) ||
+                other.siteFlag == siteFlag));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, storeRoomNo, storeSiteNo,
+      storeSiteName, frozenFlag, erpStoreSite, siteFlag);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventorySiteInfoImplCopyWith<_$InventorySiteInfoImpl> get copyWith =>
+      __$$InventorySiteInfoImplCopyWithImpl<_$InventorySiteInfoImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventorySiteInfoImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventorySiteInfo implements InventorySiteInfo {
+  const factory _InventorySiteInfo(
+          {@JsonKey(name: 'storeroomno') final String? storeRoomNo,
+          @JsonKey(name: 'storesiteno') final String? storeSiteNo,
+          @JsonKey(name: 'storesite') final String? storeSiteName,
+          @JsonKey(name: 'isfrozen') final String? frozenFlag,
+          @JsonKey(name: 'erpstoresite') final String? erpStoreSite,
+          @JsonKey(name: 'siteflag') final String? siteFlag}) =
+      _$InventorySiteInfoImpl;
+
+  factory _InventorySiteInfo.fromJson(Map<String, dynamic> json) =
+      _$InventorySiteInfoImpl.fromJson;
+
+  @override
+
+  /// 库房编码
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoomNo;
+  @override
+
+  /// 库位编码
+  @JsonKey(name: 'storesiteno')
+  String? get storeSiteNo;
+  @override
+
+  /// 库位名称
+  @JsonKey(name: 'storesite')
+  String? get storeSiteName;
+  @override
+
+  /// 锁定状态（0-正常）
+  @JsonKey(name: 'isfrozen')
+  String? get frozenFlag;
+  @override
+
+  /// ERP 库位
+  @JsonKey(name: 'erpstoresite')
+  String? get erpStoreSite;
+  @override
+
+  /// 库位属性
+  @JsonKey(name: 'siteflag')
+  String? get siteFlag;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventorySiteInfoImplCopyWith<_$InventorySiteInfoImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventoryTaskItemQuery _$InventoryTaskItemQueryFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryTaskItemQuery.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskItemQuery {
+  @JsonKey(name: 'taskcomment')
+  String get taskComment => throw _privateConstructorUsedError;
+  @JsonKey(name: 'checktaskno')
+  String get checkTaskNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'checktaskid')
+  String? get checkTaskId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'roomTag')
+  String get roomTag => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sortType')
+  String? get sortType => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sortColumn')
+  String? get sortColumn => throw _privateConstructorUsedError;
+  @JsonKey(name: 'searchKey')
+  String? get searchKey => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskItemQueryCopyWith<InventoryTaskItemQuery> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskItemQueryCopyWith<$Res> {
+  factory $InventoryTaskItemQueryCopyWith(InventoryTaskItemQuery value,
+          $Res Function(InventoryTaskItemQuery) then) =
+      _$InventoryTaskItemQueryCopyWithImpl<$Res, InventoryTaskItemQuery>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskcomment') String taskComment,
+      @JsonKey(name: 'checktaskno') String checkTaskNo,
+      @JsonKey(name: 'checktaskid') String? checkTaskId,
+      @JsonKey(name: 'roomTag') String roomTag,
+      @JsonKey(name: 'sortType') String? sortType,
+      @JsonKey(name: 'sortColumn') String? sortColumn,
+      @JsonKey(name: 'searchKey') String? searchKey});
+}
+
+/// @nodoc
+class _$InventoryTaskItemQueryCopyWithImpl<$Res,
+        $Val extends InventoryTaskItemQuery>
+    implements $InventoryTaskItemQueryCopyWith<$Res> {
+  _$InventoryTaskItemQueryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskComment = null,
+    Object? checkTaskNo = null,
+    Object? checkTaskId = freezed,
+    Object? roomTag = null,
+    Object? sortType = freezed,
+    Object? sortColumn = freezed,
+    Object? searchKey = freezed,
+  }) {
+    return _then(_value.copyWith(
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskNo: null == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskId: freezed == checkTaskId
+          ? _value.checkTaskId
+          : checkTaskId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      roomTag: null == roomTag
+          ? _value.roomTag
+          : roomTag // ignore: cast_nullable_to_non_nullable
+              as String,
+      sortType: freezed == sortType
+          ? _value.sortType
+          : sortType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      sortColumn: freezed == sortColumn
+          ? _value.sortColumn
+          : sortColumn // ignore: cast_nullable_to_non_nullable
+              as String?,
+      searchKey: freezed == searchKey
+          ? _value.searchKey
+          : searchKey // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskItemQueryImplCopyWith<$Res>
+    implements $InventoryTaskItemQueryCopyWith<$Res> {
+  factory _$$InventoryTaskItemQueryImplCopyWith(
+          _$InventoryTaskItemQueryImpl value,
+          $Res Function(_$InventoryTaskItemQueryImpl) then) =
+      __$$InventoryTaskItemQueryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskcomment') String taskComment,
+      @JsonKey(name: 'checktaskno') String checkTaskNo,
+      @JsonKey(name: 'checktaskid') String? checkTaskId,
+      @JsonKey(name: 'roomTag') String roomTag,
+      @JsonKey(name: 'sortType') String? sortType,
+      @JsonKey(name: 'sortColumn') String? sortColumn,
+      @JsonKey(name: 'searchKey') String? searchKey});
+}
+
+/// @nodoc
+class __$$InventoryTaskItemQueryImplCopyWithImpl<$Res>
+    extends _$InventoryTaskItemQueryCopyWithImpl<$Res,
+        _$InventoryTaskItemQueryImpl>
+    implements _$$InventoryTaskItemQueryImplCopyWith<$Res> {
+  __$$InventoryTaskItemQueryImplCopyWithImpl(
+      _$InventoryTaskItemQueryImpl _value,
+      $Res Function(_$InventoryTaskItemQueryImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskComment = null,
+    Object? checkTaskNo = null,
+    Object? checkTaskId = freezed,
+    Object? roomTag = null,
+    Object? sortType = freezed,
+    Object? sortColumn = freezed,
+    Object? searchKey = freezed,
+  }) {
+    return _then(_$InventoryTaskItemQueryImpl(
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskNo: null == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskId: freezed == checkTaskId
+          ? _value.checkTaskId
+          : checkTaskId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      roomTag: null == roomTag
+          ? _value.roomTag
+          : roomTag // ignore: cast_nullable_to_non_nullable
+              as String,
+      sortType: freezed == sortType
+          ? _value.sortType
+          : sortType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      sortColumn: freezed == sortColumn
+          ? _value.sortColumn
+          : sortColumn // ignore: cast_nullable_to_non_nullable
+              as String?,
+      searchKey: freezed == searchKey
+          ? _value.searchKey
+          : searchKey // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskItemQueryImpl implements _InventoryTaskItemQuery {
+  const _$InventoryTaskItemQueryImpl(
+      {@JsonKey(name: 'taskcomment') required this.taskComment,
+      @JsonKey(name: 'checktaskno') required this.checkTaskNo,
+      @JsonKey(name: 'checktaskid') this.checkTaskId,
+      @JsonKey(name: 'roomTag') this.roomTag = '1',
+      @JsonKey(name: 'sortType') this.sortType,
+      @JsonKey(name: 'sortColumn') this.sortColumn,
+      @JsonKey(name: 'searchKey') this.searchKey});
+
+  factory _$InventoryTaskItemQueryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskItemQueryImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'taskcomment')
+  final String taskComment;
+  @override
+  @JsonKey(name: 'checktaskno')
+  final String checkTaskNo;
+  @override
+  @JsonKey(name: 'checktaskid')
+  final String? checkTaskId;
+  @override
+  @JsonKey(name: 'roomTag')
+  final String roomTag;
+  @override
+  @JsonKey(name: 'sortType')
+  final String? sortType;
+  @override
+  @JsonKey(name: 'sortColumn')
+  final String? sortColumn;
+  @override
+  @JsonKey(name: 'searchKey')
+  final String? searchKey;
+
+  @override
+  String toString() {
+    return 'InventoryTaskItemQuery(taskComment: $taskComment, checkTaskNo: $checkTaskNo, checkTaskId: $checkTaskId, roomTag: $roomTag, sortType: $sortType, sortColumn: $sortColumn, searchKey: $searchKey)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskItemQueryImpl &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment) &&
+            (identical(other.checkTaskNo, checkTaskNo) ||
+                other.checkTaskNo == checkTaskNo) &&
+            (identical(other.checkTaskId, checkTaskId) ||
+                other.checkTaskId == checkTaskId) &&
+            (identical(other.roomTag, roomTag) || other.roomTag == roomTag) &&
+            (identical(other.sortType, sortType) ||
+                other.sortType == sortType) &&
+            (identical(other.sortColumn, sortColumn) ||
+                other.sortColumn == sortColumn) &&
+            (identical(other.searchKey, searchKey) ||
+                other.searchKey == searchKey));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, taskComment, checkTaskNo,
+      checkTaskId, roomTag, sortType, sortColumn, searchKey);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskItemQueryImplCopyWith<_$InventoryTaskItemQueryImpl>
+      get copyWith => __$$InventoryTaskItemQueryImplCopyWithImpl<
+          _$InventoryTaskItemQueryImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskItemQueryImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskItemQuery implements InventoryTaskItemQuery {
+  const factory _InventoryTaskItemQuery(
+          {@JsonKey(name: 'taskcomment') required final String taskComment,
+          @JsonKey(name: 'checktaskno') required final String checkTaskNo,
+          @JsonKey(name: 'checktaskid') final String? checkTaskId,
+          @JsonKey(name: 'roomTag') final String roomTag,
+          @JsonKey(name: 'sortType') final String? sortType,
+          @JsonKey(name: 'sortColumn') final String? sortColumn,
+          @JsonKey(name: 'searchKey') final String? searchKey}) =
+      _$InventoryTaskItemQueryImpl;
+
+  factory _InventoryTaskItemQuery.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskItemQueryImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'taskcomment')
+  String get taskComment;
+  @override
+  @JsonKey(name: 'checktaskno')
+  String get checkTaskNo;
+  @override
+  @JsonKey(name: 'checktaskid')
+  String? get checkTaskId;
+  @override
+  @JsonKey(name: 'roomTag')
+  String get roomTag;
+  @override
+  @JsonKey(name: 'sortType')
+  String? get sortType;
+  @override
+  @JsonKey(name: 'sortColumn')
+  String? get sortColumn;
+  @override
+  @JsonKey(name: 'searchKey')
+  String? get searchKey;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskItemQueryImplCopyWith<_$InventoryTaskItemQueryImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/aswh_inventory/collection_task/models/inventory_collect_models.g.dart
+++ b/lib/modules/aswh_inventory/collection_task/models/inventory_collect_models.g.dart
@@ -1,0 +1,257 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_collect_models.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryTaskItemImpl _$$InventoryTaskItemImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskItemImpl(
+      checkItemId: (json['co_checkitemid'] as num?)?.toInt(),
+      checkTaskId: (json['checktaskid'] as num?)?.toInt(),
+      checkTaskNo: json['checktaskno'] as String?,
+      taskComment: json['taskcomment'] as String?,
+      storeRoomNo: json['storeroomno'] as String?,
+      storeRoomName: json['storeroomname'] as String?,
+      storeSiteNo: json['storesiteno'] as String?,
+      storeSiteName: json['storesite'] as String?,
+      palletNo: json['palletno'] as String?,
+      materialCode: json['matcode2'] as String?,
+      materialName: json['matname'] as String?,
+      planQty: (json['qty'] as num?)?.toDouble() ?? 0,
+      collectedQty: (json['collectdataqty'] as num?)?.toDouble() ?? 0,
+      checkMethodName: json['checkmethod_nm'] as String?,
+      batchNo: json['batchno'] as String?,
+      serialNo: json['sn'] as String?,
+      supplierCode: json['suppliercode'] as String?,
+      endAddr: json['endaddr'] as String?,
+      erpStoreRoom: json['erpstoreroom'] as String?,
+      erpStoreSite: json['erpstoresite'] as String?,
+      materialControlFlag: json['matcontrolflag'] as String?,
+      isFinished: json['isfinish'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$$InventoryTaskItemImplToJson(
+        _$InventoryTaskItemImpl instance) =>
+    <String, dynamic>{
+      'co_checkitemid': instance.checkItemId,
+      'checktaskid': instance.checkTaskId,
+      'checktaskno': instance.checkTaskNo,
+      'taskcomment': instance.taskComment,
+      'storeroomno': instance.storeRoomNo,
+      'storeroomname': instance.storeRoomName,
+      'storesiteno': instance.storeSiteNo,
+      'storesite': instance.storeSiteName,
+      'palletno': instance.palletNo,
+      'matcode2': instance.materialCode,
+      'matname': instance.materialName,
+      'qty': instance.planQty,
+      'collectdataqty': instance.collectedQty,
+      'checkmethod_nm': instance.checkMethodName,
+      'batchno': instance.batchNo,
+      'sn': instance.serialNo,
+      'suppliercode': instance.supplierCode,
+      'endaddr': instance.endAddr,
+      'erpstoreroom': instance.erpStoreRoom,
+      'erpstoresite': instance.erpStoreSite,
+      'matcontrolflag': instance.materialControlFlag,
+      'isfinish': instance.isFinished,
+    };
+
+_$InventoryCollectingRecordImpl _$$InventoryCollectingRecordImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryCollectingRecordImpl(
+      taskComment: json['TaskComment'] as String,
+      taskItemId: json['invTaskItemid'] as String,
+      materialCode: json['matCode'] as String,
+      materialId: json['materialId'] as String?,
+      storeRoomNo: json['storeRoomNo'] as String,
+      storeSiteNo: json['storeSiteNo'] as String,
+      collectQty: (json['collectQty'] as num?)?.toDouble() ?? 0,
+      batchNo: json['batchNo'] as String?,
+      serialNo: json['sn'] as String?,
+      trayNo: json['trayNo'] as String?,
+      collectedAt: _dateTimeFromJson(json['collectedAt'] as String?),
+    );
+
+Map<String, dynamic> _$$InventoryCollectingRecordImplToJson(
+        _$InventoryCollectingRecordImpl instance) =>
+    <String, dynamic>{
+      'TaskComment': instance.taskComment,
+      'invTaskItemid': instance.taskItemId,
+      'matCode': instance.materialCode,
+      'materialId': instance.materialId,
+      'storeRoomNo': instance.storeRoomNo,
+      'storeSiteNo': instance.storeSiteNo,
+      'collectQty': instance.collectQty,
+      'batchNo': instance.batchNo,
+      'sn': instance.serialNo,
+      'trayNo': instance.trayNo,
+      'collectedAt': _dateTimeToJson(instance.collectedAt),
+    };
+
+_$InventoryCollectCommandImpl _$$InventoryCollectCommandImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryCollectCommandImpl(
+      taskId: json['taskId'] as String,
+      taskNo: json['taskNo'] as String,
+      trayNo: json['trayNo'] as String,
+      startAddr: json['startAddr'] as String,
+      endAddr: json['endAddr'] as String,
+      singleFlag: json['singleFlag'] as String? ?? '0',
+      action: $enumDecodeNullable(
+              _$InventoryCollectCommandActionEnumMap, json['action']) ??
+          InventoryCollectCommandAction.inventoryDown,
+    );
+
+Map<String, dynamic> _$$InventoryCollectCommandImplToJson(
+        _$InventoryCollectCommandImpl instance) =>
+    <String, dynamic>{
+      'taskId': instance.taskId,
+      'taskNo': instance.taskNo,
+      'trayNo': instance.trayNo,
+      'startAddr': instance.startAddr,
+      'endAddr': instance.endAddr,
+      'singleFlag': instance.singleFlag,
+      'action': _$InventoryCollectCommandActionEnumMap[instance.action]!,
+    };
+
+const _$InventoryCollectCommandActionEnumMap = {
+  InventoryCollectCommandAction.inventoryDown: 'inventoryDown',
+  InventoryCollectCommandAction.inventoryReset: 'inventoryReset',
+  InventoryCollectCommandAction.emptyTray: 'emptyTray',
+};
+
+_$InventoryCollectStateSnapshotImpl
+    _$$InventoryCollectStateSnapshotImplFromJson(Map<String, dynamic> json) =>
+        _$InventoryCollectStateSnapshotImpl(
+          taskId: json['taskId'] as String,
+          taskComment: json['taskComment'] as String,
+          activeTrayNo: json['activeTrayNo'] as String?,
+          activeStoreSiteNo: json['activeStoreSiteNo'] as String?,
+          lastScannedCode: json['lastScannedCode'] as String?,
+          taskItems: (json['taskItems'] as List<dynamic>?)
+                  ?.map((e) =>
+                      InventoryTaskItem.fromJson(e as Map<String, dynamic>))
+                  .toList() ??
+              const <InventoryTaskItem>[],
+          collectedRecords: (json['collectedRecords'] as List<dynamic>?)
+                  ?.map((e) => InventoryCollectingRecord.fromJson(
+                      e as Map<String, dynamic>))
+                  .toList() ??
+              const <InventoryCollectingRecord>[],
+          updatedAt: _dateTimeFromJson(json['updatedAt'] as String?),
+        );
+
+Map<String, dynamic> _$$InventoryCollectStateSnapshotImplToJson(
+        _$InventoryCollectStateSnapshotImpl instance) =>
+    <String, dynamic>{
+      'taskId': instance.taskId,
+      'taskComment': instance.taskComment,
+      'activeTrayNo': instance.activeTrayNo,
+      'activeStoreSiteNo': instance.activeStoreSiteNo,
+      'lastScannedCode': instance.lastScannedCode,
+      'taskItems': instance.taskItems,
+      'collectedRecords': instance.collectedRecords,
+      'updatedAt': _dateTimeToJson(instance.updatedAt),
+    };
+
+_$InventoryPalletInfoImpl _$$InventoryPalletInfoImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryPalletInfoImpl(
+      palletNo: json['palletNo'] as String?,
+      storeSite: json['storeSite'] as String?,
+      storeRoom: json['storeRoom'] as String?,
+      materialCode: json['matCode'] as String?,
+      materialName: json['matName'] as String?,
+      inventoryQty: (json['InventoryQty'] as num?)?.toDouble() ?? 0,
+      erpStoreRoom: json['erpStoreRoom'] as String?,
+      erpStoreSite: json['erpStoreSite'] as String?,
+      batchNo: json['batchNo'] as String?,
+      serialNo: json['sn'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryPalletInfoImplToJson(
+        _$InventoryPalletInfoImpl instance) =>
+    <String, dynamic>{
+      'palletNo': instance.palletNo,
+      'storeSite': instance.storeSite,
+      'storeRoom': instance.storeRoom,
+      'matCode': instance.materialCode,
+      'matName': instance.materialName,
+      'InventoryQty': instance.inventoryQty,
+      'erpStoreRoom': instance.erpStoreRoom,
+      'erpStoreSite': instance.erpStoreSite,
+      'batchNo': instance.batchNo,
+      'sn': instance.serialNo,
+    };
+
+_$InventoryMatControlImpl _$$InventoryMatControlImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryMatControlImpl(
+      materialCode: json['matCode'] as String?,
+      batchRequired: json['batchFlag'] as bool? ?? true,
+      supplierRequired: json['supplierFlag'] as bool? ?? true,
+      serialRequired: json['snFlag'] as bool? ?? false,
+      validityRequired: json['validFlag'] as bool? ?? false,
+      controlFlag: json['matControlFlag'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryMatControlImplToJson(
+        _$InventoryMatControlImpl instance) =>
+    <String, dynamic>{
+      'matCode': instance.materialCode,
+      'batchFlag': instance.batchRequired,
+      'supplierFlag': instance.supplierRequired,
+      'snFlag': instance.serialRequired,
+      'validFlag': instance.validityRequired,
+      'matControlFlag': instance.controlFlag,
+    };
+
+_$InventorySiteInfoImpl _$$InventorySiteInfoImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventorySiteInfoImpl(
+      storeRoomNo: json['storeroomno'] as String?,
+      storeSiteNo: json['storesiteno'] as String?,
+      storeSiteName: json['storesite'] as String?,
+      frozenFlag: json['isfrozen'] as String?,
+      erpStoreSite: json['erpstoresite'] as String?,
+      siteFlag: json['siteflag'] as String?,
+    );
+
+Map<String, dynamic> _$$InventorySiteInfoImplToJson(
+        _$InventorySiteInfoImpl instance) =>
+    <String, dynamic>{
+      'storeroomno': instance.storeRoomNo,
+      'storesiteno': instance.storeSiteNo,
+      'storesite': instance.storeSiteName,
+      'isfrozen': instance.frozenFlag,
+      'erpstoresite': instance.erpStoreSite,
+      'siteflag': instance.siteFlag,
+    };
+
+_$InventoryTaskItemQueryImpl _$$InventoryTaskItemQueryImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskItemQueryImpl(
+      taskComment: json['taskcomment'] as String,
+      checkTaskNo: json['checktaskno'] as String,
+      checkTaskId: json['checktaskid'] as String?,
+      roomTag: json['roomTag'] as String? ?? '1',
+      sortType: json['sortType'] as String?,
+      sortColumn: json['sortColumn'] as String?,
+      searchKey: json['searchKey'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryTaskItemQueryImplToJson(
+        _$InventoryTaskItemQueryImpl instance) =>
+    <String, dynamic>{
+      'taskcomment': instance.taskComment,
+      'checktaskno': instance.checkTaskNo,
+      'checktaskid': instance.checkTaskId,
+      'roomTag': instance.roomTag,
+      'sortType': instance.sortType,
+      'sortColumn': instance.sortColumn,
+      'searchKey': instance.searchKey,
+    };

--- a/lib/modules/aswh_inventory/collection_task/repositories/inventory_collect_cache_repository.dart
+++ b/lib/modules/aswh_inventory/collection_task/repositories/inventory_collect_cache_repository.dart
@@ -1,0 +1,51 @@
+import 'package:hive/hive.dart';
+
+import '../models/inventory_collect_models.dart';
+
+class InventoryCollectCacheRepository {
+  InventoryCollectCacheRepository({HiveInterface? hive}) : _hive = hive ?? Hive;
+
+  final HiveInterface _hive;
+
+  Box<dynamic>? _cacheBox;
+  String? _cacheKey;
+
+  bool get isReady => _cacheBox != null;
+
+  Future<void> initialize(String taskKey) async {
+    if (_cacheKey == taskKey && _cacheBox != null) {
+      return;
+    }
+
+    await _cacheBox?.close();
+    _cacheKey = taskKey;
+    _cacheBox = await _hive.openBox<dynamic>('aswh_inventory_collect_\$taskKey');
+  }
+
+  Future<void> persistSnapshot(InventoryCollectStateSnapshot snapshot) async {
+    if (_cacheBox == null) return;
+
+    await _cacheBox!.put('snapshot', snapshot.toJson());
+  }
+
+  Future<InventoryCollectStateSnapshot?> readSnapshot() async {
+    if (_cacheBox == null) return null;
+
+    final snapshot = _cacheBox!.get('snapshot');
+    if (snapshot == null) return null;
+
+    return InventoryCollectStateSnapshot.fromJson(
+      Map<String, dynamic>.from(snapshot as Map),
+    );
+  }
+
+  Future<void> clear() async {
+    await _cacheBox?.clear();
+  }
+
+  Future<void> dispose() async {
+    await _cacheBox?.close();
+    _cacheBox = null;
+    _cacheKey = null;
+  }
+}

--- a/lib/modules/aswh_inventory/collection_task/services/aswh_inventory_collect_service.dart
+++ b/lib/modules/aswh_inventory/collection_task/services/aswh_inventory_collect_service.dart
@@ -1,0 +1,224 @@
+import 'package:dio/dio.dart';
+
+import '../../../../services/api_response_handler.dart';
+import '../models/inventory_collect_models.dart';
+
+/// 立库盘点采集服务
+class AswhInventoryCollectService {
+  AswhInventoryCollectService(this._dio);
+
+  final Dio _dio;
+
+  /// 查询盘点任务明细
+  Future<List<InventoryTaskItem>> fetchTaskItems({
+    required InventoryTaskItemQuery query,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getInventoryTaskItem',
+      queryParameters: query.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          return data
+              .map((e) =>
+                  InventoryTaskItem.fromJson(e as Map<String, dynamic>))
+              .toList();
+        }
+        throw Exception('盘点任务明细返回格式异常');
+      },
+    );
+  }
+
+  /// 提交盘点采集结果
+  Future<void> submitCollectionRecords({
+    required List<InventoryCollectingRecord> records,
+    required String taskComment,
+  }) async {
+    final payload = {
+      'inventoryInfos': records
+          .map((record) => record.copyWith(taskComment: taskComment).toJson())
+          .toList(),
+      'taskComment': taskComment,
+    };
+
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/commitInventoryInfos',
+      data: payload,
+      options: Options(
+        headers: const {
+          'content-type': 'application/json;charset=UTF-8',
+        },
+      ),
+    );
+
+    ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => data,
+    );
+  }
+
+  /// 校验库位
+  Future<List<InventorySiteInfo>> validateStoreSite({
+    required String storeRoomNo,
+    required String storeSiteNo,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getStoreSite',
+      queryParameters: {
+        'storeRoomNo': storeRoomNo,
+        'storeSiteNo': storeSiteNo,
+      },
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          return data
+              .map((e) =>
+                  InventorySiteInfo.fromJson(e as Map<String, dynamic>))
+              .toList();
+        }
+        throw Exception('库位校验返回格式异常');
+      },
+    );
+  }
+
+  /// 查询库位库存
+  Future<List<InventoryPalletInfo>> fetchInventoryBySite({
+    required String storeSiteNo,
+    required String materialCode,
+    String? erpStoreRoom,
+    String? batchNo,
+    String? serialNo,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getRepertoryByStoresiteNo',
+      queryParameters: {
+        'storesiteno': storeSiteNo,
+        'matcode': materialCode,
+        if (erpStoreRoom != null) 'erpStoreroom': erpStoreRoom,
+        if (batchNo != null) 'batchno': batchNo,
+        if (serialNo != null) 'sn': serialNo,
+      },
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          return data
+              .map((e) =>
+                  InventoryPalletInfo.fromJson(e as Map<String, dynamic>))
+              .toList();
+        }
+        throw Exception('库存查询返回格式异常');
+      },
+    );
+  }
+
+  /// 查询拣选口位置
+  Future<List<InventoryPickLocation>> fetchPickLocations({
+    String locationType = '1',
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getInOutLocation',
+      queryParameters: {'locationType': locationType},
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          return data
+              .map(
+                (e) => InventoryPickLocation.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList();
+        }
+        throw Exception('拣选口位置返回格式异常');
+      },
+    );
+  }
+
+  /// 查询物料控制参数
+  Future<InventoryMatControl?> fetchMaterialControl(String materialCode) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getMatControl',
+      queryParameters: {'matCode': materialCode},
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          if (data.isEmpty) return null;
+          return InventoryMatControl.fromJson(
+            data.first as Map<String, dynamic>,
+          );
+        }
+        if (data is Map<String, dynamic>) {
+          return InventoryMatControl.fromJson(data);
+        }
+        throw Exception('物料控制参数返回格式异常');
+      },
+    );
+  }
+
+  /// 查询任务对应的物料控制参数
+  Future<List<InventoryMatControl>> fetchRoomMaterialControls(
+    String taskId,
+  ) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getRoomMatControl',
+      queryParameters: {'taskId': taskId},
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          return data
+              .map((e) =>
+                  InventoryMatControl.fromJson(e as Map<String, dynamic>))
+              .toList();
+        }
+        throw Exception('任务物料控制返回格式异常');
+      },
+    );
+  }
+
+  /// 下发 WCS 指令
+  Future<void> dispatchCommand(InventoryCollectCommand command) async {
+    final endpoint = switch (command.action) {
+      InventoryCollectCommandAction.inventoryDown =>
+        '/system/terminal/commitInvDownWmsToWcs',
+      InventoryCollectCommandAction.inventoryReset =>
+        '/system/terminal/commitInvResetWmsToWcs',
+      InventoryCollectCommandAction.emptyTray =>
+        '/system/terminal/commitEmptyTrayWmsToWcs',
+    };
+
+    final response = await _dio.get<Map<String, dynamic>>(
+      endpoint,
+      queryParameters: {
+        'taskId': command.taskId,
+        'taskNo': command.taskNo,
+        'trayNo': command.trayNo,
+        'startAddr': command.startAddr,
+        'endAddr': command.endAddr,
+        'singleFlag': command.singleFlag,
+      },
+    );
+
+    ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => data,
+    );
+  }
+}

--- a/lib/modules/aswh_inventory/command_list/aswh_inventory_command_page.dart
+++ b/lib/modules/aswh_inventory/command_list/aswh_inventory_command_page.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../../common_widgets/common_grid/common_data_grid.dart';
+import '../../../common_widgets/custom_app_bar.dart';
+import '../../../common_widgets/loading_dialog_manager.dart';
+import 'bloc/aswh_inventory_command_bloc.dart';
+import 'bloc/aswh_inventory_command_event.dart';
+import 'bloc/aswh_inventory_command_state.dart';
+import 'config/aswh_inventory_command_grid_config.dart';
+import 'models/inventory_command_models.dart';
+
+class AswhInventoryCommandPage extends StatefulWidget {
+  const AswhInventoryCommandPage({super.key});
+
+  @override
+  State<AswhInventoryCommandPage> createState() =>
+      _AswhInventoryCommandPageState();
+}
+
+class _AswhInventoryCommandPageState extends State<AswhInventoryCommandPage> {
+  late final AswhInventoryCommandBloc _bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<AswhInventoryCommandBloc>(context);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final args = Modular.args.data as Map<String, dynamic>? ?? {};
+      final taskComment = args['taskComment']?.toString() ?? '';
+      final taskId = args['taskId']?.toString();
+      final taskNo = args['taskNo']?.toString();
+      final taskType = args['taskType']?.toString();
+      final categoryParam = args['category']?.toString();
+      final category = categoryParam == 'checkOrder'
+          ? InventoryCommandCategory.checkOrder
+          : InventoryCommandCategory.inventory;
+
+      if (taskComment.isNotEmpty) {
+        _bloc.add(
+          AswhInventoryCommandStarted(
+            taskComment: taskComment,
+            taskId: taskId,
+            taskNo: taskNo,
+            taskType: taskType,
+            category: category,
+          ),
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AswhInventoryCommandBloc, AswhInventoryCommandState>(
+      listener: (context, state) {
+        if (state.status == AswhInventoryCommandStatus.loading ||
+            state.status == AswhInventoryCommandStatus.actionInProgress) {
+          LoadingDialogManager.instance.showLoadingDialog(
+            context,
+            text: state.status == AswhInventoryCommandStatus.loading
+                ? '正在加载指令...'
+                : '正在撤销指令...',
+          );
+        } else {
+          LoadingDialogManager.instance.hideLoadingDialog(context);
+        }
+
+        if (state.status == AswhInventoryCommandStatus.failure &&
+            state.message != null) {
+          LoadingDialogManager.instance.showErrorDialog(
+            context,
+            state.message!,
+          );
+        } else if (state.message != null && state.message!.isNotEmpty) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              SnackBar(content: Text(state.message!)),
+            );
+        }
+      },
+      child: Scaffold(
+        appBar: CustomAppBar(
+          title: context.select(
+            (AswhInventoryCommandBloc bloc) => bloc.state.title,
+          ),
+          onBackPressed: () => Modular.to.pop(),
+        ).appBar,
+        body: Column(
+          children: [
+            Expanded(child: _buildDataGrid()),
+            _buildActions(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDataGrid() {
+    return BlocBuilder<AswhInventoryCommandBloc, AswhInventoryCommandState>(
+      builder: (context, state) {
+        return CommonDataGrid<InventoryWcsCommand>(
+          columns: AswhInventoryCommandGridConfig.columns(),
+          datas: state.commands,
+          currentPage: 1,
+          totalPages: 1,
+          allowPager: false,
+          allowSelect: true,
+          selectedRows: state.selectedRows,
+          onSelectionChanged: (rows) {
+            _bloc.add(AswhInventoryCommandSelectionChanged(rows));
+          },
+          onLoadData: (index) async {},
+        );
+      },
+    );
+  }
+
+  Widget _buildActions() {
+    return BlocBuilder<AswhInventoryCommandBloc, AswhInventoryCommandState>(
+      builder: (context, state) {
+        final disableActions =
+            state.status == AswhInventoryCommandStatus.loading ||
+                state.status == AswhInventoryCommandStatus.actionInProgress;
+        return Container(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surface,
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.05),
+                offset: const Offset(0, -2),
+                blurRadius: 4,
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: disableActions
+                      ? null
+                      : () => _confirmAndDispatch(
+                            context,
+                            InventoryCommandAction.revokeBack,
+                            '撤销回指令',
+                          ),
+                  child: const Text('撤销回指令'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: disableActions
+                      ? null
+                      : () => _confirmAndDispatch(
+                            context,
+                            InventoryCommandAction.revokeOutbound,
+                            '撤销出库指令',
+                          ),
+                  child: const Text('撤销出库指令'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: disableActions
+                      ? null
+                      : () =>
+                          _bloc.add(const AswhInventoryCommandRefreshRequested()),
+                  child: const Text('刷新'),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _confirmAndDispatch(
+    BuildContext context,
+    InventoryCommandAction action,
+    String label,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('指令确认'),
+          content: Text('是否确认$label?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('确认'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed == true) {
+      _bloc.add(AswhInventoryCommandActionRequested(action));
+    }
+  }
+}

--- a/lib/modules/aswh_inventory/command_list/bloc/aswh_inventory_command_bloc.dart
+++ b/lib/modules/aswh_inventory/command_list/bloc/aswh_inventory_command_bloc.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../models/inventory_command_models.dart';
+import '../services/aswh_inventory_command_service.dart';
+import 'aswh_inventory_command_event.dart';
+import 'aswh_inventory_command_state.dart';
+
+class AswhInventoryCommandBloc
+    extends Bloc<AswhInventoryCommandEvent, AswhInventoryCommandState> {
+  AswhInventoryCommandBloc({
+    required AswhInventoryCommandService commandService,
+  })  : _commandService = commandService,
+        super(const AswhInventoryCommandState()) {
+    on<AswhInventoryCommandStarted>(_onStarted);
+    on<AswhInventoryCommandRefreshRequested>(_onRefreshRequested);
+    on<AswhInventoryCommandSelectionChanged>(_onSelectionChanged);
+    on<AswhInventoryCommandActionRequested>(_onActionRequested);
+  }
+
+  final AswhInventoryCommandService _commandService;
+
+  Future<void> _onStarted(
+    AswhInventoryCommandStarted event,
+    Emitter<AswhInventoryCommandState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        status: AswhInventoryCommandStatus.loading,
+        category: event.category,
+        taskComment: event.taskComment,
+        taskId: event.taskId,
+        taskNo: event.taskNo,
+        taskType: event.taskType,
+        clearMessage: true,
+      ),
+    );
+
+    await _loadCommands(emit);
+  }
+
+  Future<void> _onRefreshRequested(
+    AswhInventoryCommandRefreshRequested event,
+    Emitter<AswhInventoryCommandState> emit,
+  ) async {
+    emit(state.copyWith(status: AswhInventoryCommandStatus.loading, clearMessage: true));
+    await _loadCommands(emit);
+  }
+
+  void _onSelectionChanged(
+    AswhInventoryCommandSelectionChanged event,
+    Emitter<AswhInventoryCommandState> emit,
+  ) {
+    emit(state.copyWith(selectedRows: event.selectedRows, clearMessage: true));
+  }
+
+  Future<void> _onActionRequested(
+    AswhInventoryCommandActionRequested event,
+    Emitter<AswhInventoryCommandState> emit,
+  ) async {
+    final command = state.selectedCommand;
+    if (command == null) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryCommandStatus.success,
+          message: '请选择需要撤销的指令',
+        ),
+      );
+      return;
+    }
+
+    final taskComment = state.taskComment;
+    final taskNo = state.taskNo ?? command.taskNo ?? command.palletNo ?? '';
+    if (taskComment == null || taskComment.isEmpty) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryCommandStatus.failure,
+          message: '缺少任务参数，无法撤销指令',
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: AswhInventoryCommandStatus.actionInProgress,
+        clearMessage: true,
+      ),
+    );
+
+    try {
+      await _commandService.revokeCommand(
+        action: event.action,
+        command: command,
+        taskId: state.taskId,
+        taskNo: taskNo,
+      );
+
+      emit(
+        state.copyWith(
+          status: AswhInventoryCommandStatus.success,
+          message: '指令撤销成功',
+        ),
+      );
+
+      await _loadCommands(emit, preserveMessage: true);
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryCommandStatus.failure,
+          message: '指令撤销失败：${error.toString()}',
+        ),
+      );
+    }
+  }
+
+  Future<void> _loadCommands(
+    Emitter<AswhInventoryCommandState> emit, {
+    bool preserveMessage = false,
+  }) async {
+    final taskComment = state.taskComment;
+    final taskType = state.taskType ??
+        (state.category == InventoryCommandCategory.checkOrder ? '03' : '03');
+    if (taskComment == null || taskComment.isEmpty) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryCommandStatus.failure,
+          message: '缺少任务信息，无法加载指令列表',
+        ),
+      );
+      return;
+    }
+
+    try {
+      final commands = await _commandService.fetchCommands(
+        taskComment: taskComment,
+        taskId: state.taskId,
+        taskType: taskType,
+      );
+
+      emit(
+        state.copyWith(
+          status: AswhInventoryCommandStatus.success,
+          commands: commands,
+          selectedRows: const [],
+          clearMessage: preserveMessage ? false : true,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryCommandStatus.failure,
+          message: '指令列表加载失败：${error.toString()}',
+        ),
+      );
+    }
+  }
+}

--- a/lib/modules/aswh_inventory/command_list/bloc/aswh_inventory_command_event.dart
+++ b/lib/modules/aswh_inventory/command_list/bloc/aswh_inventory_command_event.dart
@@ -1,0 +1,51 @@
+import 'package:equatable/equatable.dart';
+
+import '../models/inventory_command_models.dart';
+
+abstract class AswhInventoryCommandEvent extends Equatable {
+  const AswhInventoryCommandEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AswhInventoryCommandStarted extends AswhInventoryCommandEvent {
+  const AswhInventoryCommandStarted({
+    required this.taskComment,
+    this.taskId,
+    this.taskNo,
+    this.taskType,
+    this.category = InventoryCommandCategory.inventory,
+  });
+
+  final String taskComment;
+  final String? taskId;
+  final String? taskNo;
+  final String? taskType;
+  final InventoryCommandCategory category;
+
+  @override
+  List<Object?> get props => [taskComment, taskId, taskNo, taskType, category];
+}
+
+class AswhInventoryCommandRefreshRequested extends AswhInventoryCommandEvent {
+  const AswhInventoryCommandRefreshRequested();
+}
+
+class AswhInventoryCommandSelectionChanged extends AswhInventoryCommandEvent {
+  const AswhInventoryCommandSelectionChanged(this.selectedRows);
+
+  final List<int> selectedRows;
+
+  @override
+  List<Object?> get props => [selectedRows];
+}
+
+class AswhInventoryCommandActionRequested extends AswhInventoryCommandEvent {
+  const AswhInventoryCommandActionRequested(this.action);
+
+  final InventoryCommandAction action;
+
+  @override
+  List<Object?> get props => [action];
+}

--- a/lib/modules/aswh_inventory/command_list/bloc/aswh_inventory_command_state.dart
+++ b/lib/modules/aswh_inventory/command_list/bloc/aswh_inventory_command_state.dart
@@ -1,0 +1,83 @@
+import 'package:equatable/equatable.dart';
+
+import '../models/inventory_command_models.dart';
+
+enum AswhInventoryCommandStatus {
+  initial,
+  loading,
+  success,
+  failure,
+  actionInProgress,
+}
+
+class AswhInventoryCommandState extends Equatable {
+  const AswhInventoryCommandState({
+    this.status = AswhInventoryCommandStatus.initial,
+    this.commands = const [],
+    this.selectedRows = const [],
+    this.message,
+    this.category = InventoryCommandCategory.inventory,
+    this.taskComment,
+    this.taskId,
+    this.taskNo,
+    this.taskType,
+  });
+
+  final AswhInventoryCommandStatus status;
+  final List<InventoryWcsCommand> commands;
+  final List<int> selectedRows;
+  final String? message;
+  final InventoryCommandCategory category;
+  final String? taskComment;
+  final String? taskId;
+  final String? taskNo;
+  final String? taskType;
+
+  String get title =>
+      category == InventoryCommandCategory.checkOrder ? '立库盘点采集结果' : '在线拣选采集结果';
+
+  InventoryWcsCommand? get selectedCommand {
+    if (selectedRows.isEmpty || selectedRows.first >= commands.length) {
+      return null;
+    }
+    return commands[selectedRows.first];
+  }
+
+  AswhInventoryCommandState copyWith({
+    AswhInventoryCommandStatus? status,
+    List<InventoryWcsCommand>? commands,
+    List<int>? selectedRows,
+    String? message,
+    bool clearMessage = false,
+    InventoryCommandCategory? category,
+    String? taskComment,
+    String? taskId,
+    String? taskNo,
+    String? taskType,
+  }) {
+    return AswhInventoryCommandState(
+      status: status ?? this.status,
+      commands: commands ?? this.commands,
+      selectedRows: selectedRows ?? this.selectedRows,
+      message: clearMessage ? null : message ?? this.message,
+      category: category ?? this.category,
+      taskComment: taskComment ?? this.taskComment,
+      taskId: taskId ?? this.taskId,
+      taskNo: taskNo ?? this.taskNo,
+      taskType: taskType ?? this.taskType,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        commands,
+        selectedRows,
+        message,
+        category,
+        taskComment,
+        taskId,
+        taskNo,
+        taskType,
+      ];
+}

--- a/lib/modules/aswh_inventory/command_list/config/aswh_inventory_command_grid_config.dart
+++ b/lib/modules/aswh_inventory/command_list/config/aswh_inventory_command_grid_config.dart
@@ -1,0 +1,111 @@
+import '../../../../common_widgets/common_grid/common_data_grid.dart';
+import '../models/inventory_command_models.dart';
+
+class AswhInventoryCommandGridConfig {
+  static List<GridColumnConfig<InventoryWcsCommand>> columns() {
+    return [
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'palletNo',
+        headerText: '托盘号',
+        width: 140,
+        valueGetter: (row) => row.palletNo,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'startAddr',
+        headerText: '起始地址',
+        width: 140,
+        valueGetter: (row) => row.startAddr,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'destAddr',
+        headerText: '目标地址',
+        width: 140,
+        valueGetter: (row) => row.destAddr,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'stackerNo',
+        headerText: '堆垛机号',
+        width: 120,
+        valueGetter: (row) => row.stackerNo,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'sendTime',
+        headerText: '发送时间',
+        width: 180,
+        valueGetter: (row) => row.sendTime,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'state',
+        headerText: '状态',
+        width: 120,
+        valueGetter: (row) => row.state,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'weightGrade',
+        headerText: '重量等级',
+        width: 120,
+        valueGetter: (row) => row.weightGrade,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'highGrade',
+        headerText: '高度等级',
+        width: 120,
+        valueGetter: (row) => row.highGrade,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'taskNo',
+        headerText: '任务号',
+        width: 160,
+        valueGetter: (row) => row.taskNo,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'proofNo',
+        headerText: '凭证号',
+        width: 160,
+        valueGetter: (row) => row.proofNo,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'taskType',
+        headerText: '任务类型',
+        width: 120,
+        valueGetter: (row) => row.taskType,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'changeType',
+        headerText: '更改类型',
+        width: 120,
+        valueGetter: (row) => row.changeType,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'ioType',
+        headerText: '出入库',
+        width: 100,
+        valueGetter: (row) => row.ioType,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'wcsError',
+        headerText: 'WCS 错误',
+        width: 220,
+        valueGetter: (row) => row.wcsError,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'taskId',
+        headerText: '任务 ID',
+        width: 160,
+        valueGetter: (row) => row.taskId,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'proofId',
+        headerText: '凭证 ID',
+        width: 160,
+        valueGetter: (row) => row.proofId,
+      ),
+      GridColumnConfig<InventoryWcsCommand>(
+        name: 'interfaceId',
+        headerText: '指令 ID',
+        width: 180,
+        valueGetter: (row) => row.interfaceId,
+      ),
+    ];
+  }
+}

--- a/lib/modules/aswh_inventory/command_list/models/inventory_command_models.dart
+++ b/lib/modules/aswh_inventory/command_list/models/inventory_command_models.dart
@@ -1,0 +1,119 @@
+import 'package:equatable/equatable.dart';
+
+/// WMS -> WCS 指令记录
+class InventoryWcsCommand extends Equatable {
+  const InventoryWcsCommand({
+    this.interfaceId,
+    this.palletNo,
+    this.startAddr,
+    this.destAddr,
+    this.stackerNo,
+    this.sendTime,
+    this.state,
+    this.weightGrade,
+    this.highGrade,
+    this.taskNo,
+    this.proofNo,
+    this.taskType,
+    this.changeType,
+    this.ioType,
+    this.wcsError,
+    this.taskId,
+    this.proofId,
+  });
+
+  factory InventoryWcsCommand.fromJson(Map<String, dynamic> json) {
+    return InventoryWcsCommand(
+      interfaceId: json['interfaceWmsToWcsId']?.toString(),
+      palletNo: json['palno']?.toString(),
+      startAddr: json['saddr']?.toString(),
+      destAddr: json['daddr']?.toString(),
+      stackerNo: json['dvno']?.toString(),
+      sendTime: json['sendtime2']?.toString(),
+      state: json['state2']?.toString(),
+      weightGrade: json['weightGrade2']?.toString(),
+      highGrade: json['highGrade2']?.toString(),
+      taskNo: json['taskNo']?.toString(),
+      proofNo: json['proofno']?.toString(),
+      taskType: json['tasktype2']?.toString(),
+      changeType: json['changetype2']?.toString(),
+      ioType: json['typ2']?.toString(),
+      wcsError: json['wcsErrMessage2']?.toString(),
+      taskId: json['taskId']?.toString(),
+      proofId: json['proofid']?.toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'interfaceWmsToWcsId': interfaceId,
+      'palno': palletNo,
+      'saddr': startAddr,
+      'daddr': destAddr,
+      'dvno': stackerNo,
+      'sendtime2': sendTime,
+      'state2': state,
+      'weightGrade2': weightGrade,
+      'highGrade2': highGrade,
+      'taskNo': taskNo,
+      'proofno': proofNo,
+      'tasktype2': taskType,
+      'changetype2': changeType,
+      'typ2': ioType,
+      'wcsErrMessage2': wcsError,
+      'taskId': taskId,
+      'proofid': proofId,
+    };
+  }
+
+  final String? interfaceId;
+  final String? palletNo;
+  final String? startAddr;
+  final String? destAddr;
+  final String? stackerNo;
+  final String? sendTime;
+  final String? state;
+  final String? weightGrade;
+  final String? highGrade;
+  final String? taskNo;
+  final String? proofNo;
+  final String? taskType;
+  final String? changeType;
+  final String? ioType;
+  final String? wcsError;
+  final String? taskId;
+  final String? proofId;
+
+  @override
+  List<Object?> get props => [
+        interfaceId,
+        palletNo,
+        startAddr,
+        destAddr,
+        stackerNo,
+        sendTime,
+        state,
+        weightGrade,
+        highGrade,
+        taskNo,
+        proofNo,
+        taskType,
+        changeType,
+        ioType,
+        wcsError,
+        taskId,
+        proofId,
+      ];
+}
+
+/// 指令类别：在线拣选 or 盘点采集结果
+enum InventoryCommandCategory {
+  inventory,
+  checkOrder,
+}
+
+/// 页面底部操作类型
+enum InventoryCommandAction {
+  revokeBack,
+  revokeOutbound,
+}

--- a/lib/modules/aswh_inventory/command_list/services/aswh_inventory_command_service.dart
+++ b/lib/modules/aswh_inventory/command_list/services/aswh_inventory_command_service.dart
@@ -1,0 +1,75 @@
+import 'package:dio/dio.dart';
+
+import '../../../../services/api_response_handler.dart';
+import '../models/inventory_command_models.dart';
+
+/// 指令查询与撤销服务
+class AswhInventoryCommandService {
+  AswhInventoryCommandService(this._dio);
+
+  final Dio _dio;
+
+  Future<List<InventoryWcsCommand>> fetchCommands({
+    required String taskComment,
+    String? taskId,
+    required String taskType,
+    String? query,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getWmsToWcsByTaskID',
+      queryParameters: {
+        'taskComment': taskComment,
+        if (taskId != null) 'taskId': taskId,
+        'TaskType': taskType,
+        if (query != null && query.isNotEmpty) 'queryStr': query,
+      },
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          return data
+              .map(
+                (item) => InventoryWcsCommand.fromJson(
+                  Map<String, dynamic>.from(item as Map),
+                ),
+              )
+              .toList();
+        }
+        throw Exception('指令列表返回格式异常');
+      },
+    );
+  }
+
+  Future<void> revokeCommand({
+    required InventoryCommandAction action,
+    required InventoryWcsCommand command,
+    String? taskId,
+    required String taskNo,
+  }) async {
+    final endpoint = switch (action) {
+      InventoryCommandAction.revokeBack =>
+        '/system/terminal/commitInvResetWmsToWcs',
+      InventoryCommandAction.revokeOutbound =>
+        '/system/terminal/commitInvDownWmsToWcs',
+    };
+
+    final response = await _dio.get<Map<String, dynamic>>(
+      endpoint,
+      queryParameters: {
+        'taskId': taskId ?? command.taskId ?? taskNo,
+        'taskNo': taskNo,
+        'trayNo': command.palletNo ?? '',
+        'startAddr': command.startAddr ?? '',
+        'endAddr': command.destAddr ?? '',
+        'singleFlag': '1',
+      },
+    );
+
+    ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => data,
+    );
+  }
+}

--- a/lib/modules/aswh_inventory/pallet_item/aswh_inventory_pallet_item_page.dart
+++ b/lib/modules/aswh_inventory/pallet_item/aswh_inventory_pallet_item_page.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../../common_widgets/custom_app_bar.dart';
+import '../../../common_widgets/loading_dialog_manager.dart';
+import '../../../common_widgets/scanner_widget/scanner_config.dart';
+import '../../../common_widgets/scanner_widget/scanner_widget.dart';
+import 'bloc/aswh_inventory_pallet_item_bloc.dart';
+import 'bloc/aswh_inventory_pallet_item_event.dart';
+import 'bloc/aswh_inventory_pallet_item_state.dart';
+import 'models/inventory_pallet_item.dart';
+
+class AswhInventoryPalletItemPage extends StatefulWidget {
+  const AswhInventoryPalletItemPage({super.key});
+
+  @override
+  State<AswhInventoryPalletItemPage> createState() =>
+      _AswhInventoryPalletItemPageState();
+}
+
+class _AswhInventoryPalletItemPageState
+    extends State<AswhInventoryPalletItemPage> {
+  late final AswhInventoryPalletItemBloc _bloc;
+  final ScannerController _scannerController = ScannerController();
+  final Set<int> _expandedIndexes = <int>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<AswhInventoryPalletItemBloc>(context);
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final args = Modular.args;
+      final params = args.params;
+      final data = args.data as Map<String, dynamic>?;
+      final trayNoParam = params['trayNo']?.toString();
+      final trayNoData = data != null ? data['trayNo']?.toString() : null;
+      final trayNo = trayNoParam?.isNotEmpty == true
+          ? trayNoParam
+          : (trayNoData?.isNotEmpty == true ? trayNoData : null);
+
+      if (trayNo != null && trayNo.isNotEmpty) {
+        _bloc.add(AswhInventoryPalletItemStarted(trayNo: trayNo));
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AswhInventoryPalletItemBloc, AswhInventoryPalletItemState>(
+      listener: (context, state) {
+        if (state.status == AswhInventoryPalletItemStatus.loading) {
+          LoadingDialogManager.instance.showLoadingDialog(
+            context,
+            text: '正在加载托盘明细...',
+          );
+        } else {
+          LoadingDialogManager.instance.hideLoadingDialog(context);
+        }
+
+        if (state.message != null && state.message!.isNotEmpty) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(SnackBar(content: Text(state.message!)));
+        }
+      },
+      child: Scaffold(
+        appBar: BlocBuilder<AswhInventoryPalletItemBloc,
+            AswhInventoryPalletItemState>(
+          builder: (context, state) {
+            final trayNo = state.trayNo ?? '托盘明细';
+            return CustomAppBar(
+              title: '托盘明细($trayNo)',
+              onBackPressed: () => Modular.to.pop(),
+            ).appBar;
+          },
+        ),
+        body: Column(
+          children: [
+            _buildSearchBar(),
+            Expanded(child: _buildContent()),
+          ],
+        ),
+        bottomNavigationBar: _buildActionBar(),
+      ),
+    );
+  }
+
+  Widget _buildSearchBar() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '请输入托盘/物料/批次关键字',
+      clearOnSubmit: true,
+      autoFocus: false,
+    );
+
+    return ScannerWidget(
+      config: config,
+      controller: _scannerController,
+      onScanResult: (value) {
+        _bloc.add(AswhInventoryPalletItemKeywordChanged(value));
+      },
+      onError: (message) {
+        LoadingDialogManager.instance.showErrorDialog(context, message);
+      },
+      suffix: IconButton(
+        icon: const Icon(Icons.search),
+        onPressed: () {
+          _scannerController.requestFocus();
+        },
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    return BlocBuilder<AswhInventoryPalletItemBloc, AswhInventoryPalletItemState>(
+      builder: (context, state) {
+        switch (state.status) {
+          case AswhInventoryPalletItemStatus.initial:
+          case AswhInventoryPalletItemStatus.loading:
+            return const Center(child: CircularProgressIndicator());
+          case AswhInventoryPalletItemStatus.failure:
+            return _buildRefreshWrapper(
+              child: Center(
+                child: Text(state.message ?? '托盘明细加载失败'),
+              ),
+            );
+          case AswhInventoryPalletItemStatus.success:
+            if (state.filteredItems.isEmpty) {
+              return _buildRefreshWrapper(
+                child: const Center(child: Text('暂无托盘明细')),
+              );
+            }
+            return _buildRefreshWrapper(
+              child: ListView.separated(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: const EdgeInsets.only(bottom: 16),
+                itemCount: state.filteredItems.length + 1,
+                separatorBuilder: (_, __) => const SizedBox(height: 8),
+                itemBuilder: (context, index) {
+                  if (index == state.filteredItems.length) {
+                    return const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 12),
+                      child: Center(
+                        child: Text(
+                          '已经到底了',
+                          style: TextStyle(color: Colors.grey),
+                        ),
+                      ),
+                    );
+                  }
+
+                  final item = state.filteredItems[index];
+                  final isExpanded = _expandedIndexes.contains(index);
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: Card(
+                      child: ExpansionTile(
+                        key: PageStorageKey('pallet_${item.palletNo}_$index'),
+                        initiallyExpanded: isExpanded,
+                        title: _buildTileHeader(item),
+                        subtitle: _buildTileSubtitle(item),
+                        onExpansionChanged: (expanded) {
+                          setState(() {
+                            if (expanded) {
+                              _expandedIndexes.add(index);
+                            } else {
+                              _expandedIndexes.remove(index);
+                            }
+                          });
+                        },
+                        children: [_buildTileDetails(item)],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            );
+        }
+      },
+    );
+  }
+
+  Widget _buildRefreshWrapper({required Widget child}) {
+    return RefreshIndicator(
+      onRefresh: () async {
+        _bloc.add(const AswhInventoryPalletItemRefreshRequested());
+      },
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 24),
+        children: [child],
+      ),
+    );
+  }
+
+  Widget _buildTileHeader(InventoryPalletItem item) {
+    return Text(
+      '托盘号：${item.palletNo ?? '-'}',
+      style: const TextStyle(fontWeight: FontWeight.w600),
+    );
+  }
+
+  Widget _buildTileSubtitle(InventoryPalletItem item) {
+    final material = item.materialCode ?? '-';
+    final qty = item.quantity ?? 0;
+    return Text('物料：$material    数量：$qty');
+  }
+
+  Widget _buildTileDetails(InventoryPalletItem item) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildDetailRow('物料名称', item.materialName),
+          _buildDetailRow('批次', item.batchNo),
+          _buildDetailRow('序列', item.serialNo),
+          _buildDetailRow('凭证号', item.displayProofNo.isEmpty ? null : item.displayProofNo),
+          _buildDetailRow('库位', item.storeSite),
+          _buildDetailRow('库房', item.storeRoom),
+        ].whereType<Widget>().toList(),
+      ),
+    );
+  }
+
+  Widget? _buildDetailRow(String label, String? value) {
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 88,
+            child: Text(
+              label,
+              style: const TextStyle(color: Colors.grey),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(fontWeight: FontWeight.w500),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionBar() {
+    return BlocBuilder<AswhInventoryPalletItemBloc,
+        AswhInventoryPalletItemState>(
+      builder: (context, state) {
+        final enabled = state.filteredItems.isNotEmpty;
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+            child: ElevatedButton(
+              onPressed: enabled
+                  ? () => Navigator.of(context).pop(true)
+                  : null,
+              child: const Padding(
+                padding: EdgeInsets.symmetric(vertical: 12),
+                child: Text('获取来料托盘'),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/modules/aswh_inventory/pallet_item/bloc/aswh_inventory_pallet_item_bloc.dart
+++ b/lib/modules/aswh_inventory/pallet_item/bloc/aswh_inventory_pallet_item_bloc.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../models/inventory_pallet_item.dart';
+import '../services/aswh_inventory_pallet_service.dart';
+import 'aswh_inventory_pallet_item_event.dart';
+import 'aswh_inventory_pallet_item_state.dart';
+
+class AswhInventoryPalletItemBloc
+    extends Bloc<AswhInventoryPalletItemEvent, AswhInventoryPalletItemState> {
+  AswhInventoryPalletItemBloc({
+    required AswhInventoryPalletService service,
+  })  : _service = service,
+        super(const AswhInventoryPalletItemState()) {
+    on<AswhInventoryPalletItemStarted>(_onStarted);
+    on<AswhInventoryPalletItemKeywordChanged>(_onKeywordChanged);
+    on<AswhInventoryPalletItemRefreshRequested>(_onRefreshRequested);
+  }
+
+  final AswhInventoryPalletService _service;
+
+  Future<void> _onStarted(
+    AswhInventoryPalletItemStarted event,
+    Emitter<AswhInventoryPalletItemState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        status: AswhInventoryPalletItemStatus.loading,
+        trayNo: event.trayNo,
+        clearMessage: true,
+      ),
+    );
+    await _loadItems(event.trayNo, emit);
+  }
+
+  Future<void> _onRefreshRequested(
+    AswhInventoryPalletItemRefreshRequested event,
+    Emitter<AswhInventoryPalletItemState> emit,
+  ) async {
+    final trayNo = state.trayNo;
+    if (trayNo == null || trayNo.isEmpty) {
+      return;
+    }
+    emit(
+      state.copyWith(
+        status: AswhInventoryPalletItemStatus.loading,
+        clearMessage: true,
+      ),
+    );
+    await _loadItems(trayNo, emit);
+  }
+
+  void _onKeywordChanged(
+    AswhInventoryPalletItemKeywordChanged event,
+    Emitter<AswhInventoryPalletItemState> emit,
+  ) {
+    final keyword = event.keyword.trim();
+    final filtered = _filterItems(keyword, state.items);
+    emit(
+      state.copyWith(
+        keyword: keyword,
+        filteredItems: filtered,
+        clearMessage: true,
+      ),
+    );
+  }
+
+  Future<void> _loadItems(
+    String trayNo,
+    Emitter<AswhInventoryPalletItemState> emit,
+  ) async {
+    try {
+      final items = await _service.fetchPalletItems(trayNo: trayNo);
+      emit(
+        state.copyWith(
+          status: AswhInventoryPalletItemStatus.success,
+          items: items,
+          filteredItems: _filterItems(state.keyword, items),
+          clearMessage: true,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: AswhInventoryPalletItemStatus.failure,
+          message: '托盘明细加载失败：${error.toString()}',
+        ),
+      );
+    }
+  }
+
+  List<InventoryPalletItem> _filterItems(
+    String keyword,
+    List<InventoryPalletItem> source,
+  ) {
+    if (keyword.isEmpty) {
+      return List<InventoryPalletItem>.unmodifiable(source);
+    }
+    final lower = keyword.toLowerCase();
+    return source
+        .where((item) {
+          return (item.palletNo ?? '').toLowerCase().contains(lower) ||
+              (item.materialCode ?? '').toLowerCase().contains(lower) ||
+              (item.materialName ?? '').toLowerCase().contains(lower) ||
+              (item.batchNo ?? '').toLowerCase().contains(lower) ||
+              (item.serialNo ?? '').toLowerCase().contains(lower) ||
+              item.displayProofNo.toLowerCase().contains(lower);
+        })
+        .toList(growable: false);
+  }
+}

--- a/lib/modules/aswh_inventory/pallet_item/bloc/aswh_inventory_pallet_item_event.dart
+++ b/lib/modules/aswh_inventory/pallet_item/bloc/aswh_inventory_pallet_item_event.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+
+abstract class AswhInventoryPalletItemEvent extends Equatable {
+  const AswhInventoryPalletItemEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AswhInventoryPalletItemStarted extends AswhInventoryPalletItemEvent {
+  const AswhInventoryPalletItemStarted({required this.trayNo});
+
+  final String trayNo;
+
+  @override
+  List<Object?> get props => [trayNo];
+}
+
+class AswhInventoryPalletItemKeywordChanged
+    extends AswhInventoryPalletItemEvent {
+  const AswhInventoryPalletItemKeywordChanged(this.keyword);
+
+  final String keyword;
+
+  @override
+  List<Object?> get props => [keyword];
+}
+
+class AswhInventoryPalletItemRefreshRequested
+    extends AswhInventoryPalletItemEvent {
+  const AswhInventoryPalletItemRefreshRequested();
+}

--- a/lib/modules/aswh_inventory/pallet_item/bloc/aswh_inventory_pallet_item_state.dart
+++ b/lib/modules/aswh_inventory/pallet_item/bloc/aswh_inventory_pallet_item_state.dart
@@ -1,0 +1,55 @@
+import 'package:equatable/equatable.dart';
+
+import '../models/inventory_pallet_item.dart';
+
+enum AswhInventoryPalletItemStatus { initial, loading, success, failure }
+
+class AswhInventoryPalletItemState extends Equatable {
+  const AswhInventoryPalletItemState({
+    this.status = AswhInventoryPalletItemStatus.initial,
+    this.items = const [],
+    this.filteredItems = const [],
+    this.keyword = '',
+    this.message,
+    this.trayNo,
+  });
+
+  final AswhInventoryPalletItemStatus status;
+  final List<InventoryPalletItem> items;
+  final List<InventoryPalletItem> filteredItems;
+  final String keyword;
+  final String? message;
+  final String? trayNo;
+
+  bool get isEmpty =>
+      status == AswhInventoryPalletItemStatus.success && filteredItems.isEmpty;
+
+  AswhInventoryPalletItemState copyWith({
+    AswhInventoryPalletItemStatus? status,
+    List<InventoryPalletItem>? items,
+    List<InventoryPalletItem>? filteredItems,
+    String? keyword,
+    String? message,
+    bool clearMessage = false,
+    String? trayNo,
+  }) {
+    return AswhInventoryPalletItemState(
+      status: status ?? this.status,
+      items: items ?? this.items,
+      filteredItems: filteredItems ?? this.filteredItems,
+      keyword: keyword ?? this.keyword,
+      message: clearMessage ? null : message ?? this.message,
+      trayNo: trayNo ?? this.trayNo,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        items,
+        filteredItems,
+        keyword,
+        message,
+        trayNo,
+      ];
+}

--- a/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.dart
+++ b/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.dart
@@ -1,0 +1,40 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_pallet_item.freezed.dart';
+part 'inventory_pallet_item.g.dart';
+
+@freezed
+class InventoryPalletItem with _$InventoryPalletItem {
+  const factory InventoryPalletItem({
+    @JsonKey(name: 'palletNo') String? palletNo,
+    @JsonKey(name: 'matcode') String? materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'itemBatch') String? batchNo,
+    @JsonKey(name: 'itemSn') String? serialNo,
+    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+    double? quantity,
+    @JsonKey(name: 'proofno') String? proofNo,
+    @JsonKey(name: 'proofNo') String? proofNoAlt,
+    @JsonKey(name: 'storesite') String? storeSite,
+    @JsonKey(name: 'storeroomno') String? storeRoom,
+  }) = _InventoryPalletItem;
+
+  const InventoryPalletItem._();
+
+  String get displayProofNo => proofNo ?? proofNoAlt ?? '';
+
+  factory InventoryPalletItem.fromJson(Map<String, dynamic> json) =>
+      _$InventoryPalletItemFromJson(json);
+}
+
+double? _toDouble(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  if (value is num) {
+    return value.toDouble();
+  }
+  return double.tryParse(value.toString());
+}
+
+Object? _doubleToJson(double? value) => value;

--- a/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.freezed.dart
+++ b/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.freezed.dart
@@ -1,0 +1,354 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+part of 'inventory_pallet_item.dart';
+
+// **************************************************************************
+// FreezedGenerator (manually crafted stub)
+// **************************************************************************
+
+// ignore: unnecessary_import
+import 'package:collection/collection.dart';
+
+T _$identity<T>(T value) => value;
+
+InventoryPalletItem _$InventoryPalletItemFromJson(Map<String, dynamic> json) {
+  return _InventoryPalletItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryPalletItem {
+  @JsonKey(name: 'palletNo')
+  String? get palletNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matcode')
+  String? get materialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matname')
+  String? get materialName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'itemBatch')
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'itemSn')
+  String? get serialNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+  double? get quantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'proofno')
+  String? get proofNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'proofNo')
+  String? get proofNoAlt => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storesite')
+  String? get storeSite => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoom => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryPalletItemCopyWith<InventoryPalletItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryPalletItemCopyWith<$Res> {
+  factory $InventoryPalletItemCopyWith(InventoryPalletItem value,
+          $Res Function(InventoryPalletItem) then) =
+      _$InventoryPalletItemCopyWithImpl<$Res>;
+  $Res call({
+    @JsonKey(name: 'palletNo') String? palletNo,
+    @JsonKey(name: 'matcode') String? materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'itemBatch') String? batchNo,
+    @JsonKey(name: 'itemSn') String? serialNo,
+    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+    double? quantity,
+    @JsonKey(name: 'proofno') String? proofNo,
+    @JsonKey(name: 'proofNo') String? proofNoAlt,
+    @JsonKey(name: 'storesite') String? storeSite,
+    @JsonKey(name: 'storeroomno') String? storeRoom,
+  });
+}
+
+/// @nodoc
+class _$InventoryPalletItemCopyWithImpl<$Res>
+    implements $InventoryPalletItemCopyWith<$Res> {
+  _$InventoryPalletItemCopyWithImpl(this._value, this._then);
+
+  final InventoryPalletItem _value;
+  final $Res Function(InventoryPalletItem) _then;
+
+  @override
+  $Res call({
+    Object? palletNo = freezed,
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? quantity = freezed,
+    Object? proofNo = freezed,
+    Object? proofNoAlt = freezed,
+    Object? storeSite = freezed,
+    Object? storeRoom = freezed,
+  }) {
+    return _then(_value.copyWith(
+      palletNo: palletNo == freezed
+          ? _value.palletNo
+          : palletNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: materialCode == freezed
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialName: materialName == freezed
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: batchNo == freezed
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: serialNo == freezed
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      quantity: quantity == freezed
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double?,
+      proofNo: proofNo == freezed
+          ? _value.proofNo
+          : proofNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      proofNoAlt: proofNoAlt == freezed
+          ? _value.proofNoAlt
+          : proofNoAlt // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSite: storeSite == freezed
+          ? _value.storeSite
+          : storeSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoom: storeRoom == freezed
+          ? _value.storeRoom
+          : storeRoom // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_InventoryPalletItemCopyWith<$Res>
+    implements $InventoryPalletItemCopyWith<$Res> {
+  factory _$$_InventoryPalletItemCopyWith(_$_InventoryPalletItem value,
+          $Res Function(_$_InventoryPalletItem) then) =
+      __$$_InventoryPalletItemCopyWithImpl<$Res>;
+  @override
+  $Res call({
+    @JsonKey(name: 'palletNo') String? palletNo,
+    @JsonKey(name: 'matcode') String? materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'itemBatch') String? batchNo,
+    @JsonKey(name: 'itemSn') String? serialNo,
+    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+    double? quantity,
+    @JsonKey(name: 'proofno') String? proofNo,
+    @JsonKey(name: 'proofNo') String? proofNoAlt,
+    @JsonKey(name: 'storesite') String? storeSite,
+    @JsonKey(name: 'storeroomno') String? storeRoom,
+  });
+}
+
+/// @nodoc
+class __$$_InventoryPalletItemCopyWithImpl<$Res>
+    extends _$InventoryPalletItemCopyWithImpl<$Res>
+    implements _$$_InventoryPalletItemCopyWith<$Res> {
+  __$$_InventoryPalletItemCopyWithImpl(_$_InventoryPalletItem _value,
+      $Res Function(_$_InventoryPalletItem) _then)
+      : super(_value, (v) => _then(v as _$_InventoryPalletItem));
+
+  @override
+  _$_InventoryPalletItem get _value => super._value as _$_InventoryPalletItem;
+
+  @override
+  $Res call({
+    Object? palletNo = freezed,
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? quantity = freezed,
+    Object? proofNo = freezed,
+    Object? proofNoAlt = freezed,
+    Object? storeSite = freezed,
+    Object? storeRoom = freezed,
+  }) {
+    return _then(_$_InventoryPalletItem(
+      palletNo: palletNo == freezed
+          ? _value.palletNo
+          : palletNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: materialCode == freezed
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialName: materialName == freezed
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: batchNo == freezed
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: serialNo == freezed
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      quantity: quantity == freezed
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double?,
+      proofNo: proofNo == freezed
+          ? _value.proofNo
+          : proofNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      proofNoAlt: proofNoAlt == freezed
+          ? _value.proofNoAlt
+          : proofNoAlt // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSite: storeSite == freezed
+          ? _value.storeSite
+          : storeSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoom: storeRoom == freezed
+          ? _value.storeRoom
+          : storeRoom // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_InventoryPalletItem extends _InventoryPalletItem {
+  const _$_InventoryPalletItem({
+    @JsonKey(name: 'palletNo') this.palletNo,
+    @JsonKey(name: 'matcode') this.materialCode,
+    @JsonKey(name: 'matname') this.materialName,
+    @JsonKey(name: 'itemBatch') this.batchNo,
+    @JsonKey(name: 'itemSn') this.serialNo,
+    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+    this.quantity,
+    @JsonKey(name: 'proofno') this.proofNo,
+    @JsonKey(name: 'proofNo') this.proofNoAlt,
+    @JsonKey(name: 'storesite') this.storeSite,
+    @JsonKey(name: 'storeroomno') this.storeRoom,
+  }) : super._();
+
+  factory _$_InventoryPalletItem.fromJson(Map<String, dynamic> json) =>
+      _$$_InventoryPalletItemFromJson(json);
+
+  @override
+  @JsonKey(name: 'palletNo')
+  final String? palletNo;
+  @override
+  @JsonKey(name: 'matcode')
+  final String? materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  final String? materialName;
+  @override
+  @JsonKey(name: 'itemBatch')
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'itemSn')
+  final String? serialNo;
+  @override
+  @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+  final double? quantity;
+  @override
+  @JsonKey(name: 'proofno')
+  final String? proofNo;
+  @override
+  @JsonKey(name: 'proofNo')
+  final String? proofNoAlt;
+  @override
+  @JsonKey(name: 'storesite')
+  final String? storeSite;
+  @override
+  @JsonKey(name: 'storeroomno')
+  final String? storeRoom;
+
+  @override
+  String toString() {
+    return 'InventoryPalletItem(palletNo: $palletNo, materialCode: $materialCode, materialName: $materialName, batchNo: $batchNo, serialNo: $serialNo, quantity: $quantity, proofNo: $proofNo, proofNoAlt: $proofNoAlt, storeSite: $storeSite, storeRoom: $storeRoom)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_InventoryPalletItem &&
+            const DeepCollectionEquality().equals(other.palletNo, palletNo) &&
+            const DeepCollectionEquality()
+                .equals(other.materialCode, materialCode) &&
+            const DeepCollectionEquality()
+                .equals(other.materialName, materialName) &&
+            const DeepCollectionEquality().equals(other.batchNo, batchNo) &&
+            const DeepCollectionEquality().equals(other.serialNo, serialNo) &&
+            const DeepCollectionEquality().equals(other.quantity, quantity) &&
+            const DeepCollectionEquality().equals(other.proofNo, proofNo) &&
+            const DeepCollectionEquality().equals(other.proofNoAlt, proofNoAlt) &&
+            const DeepCollectionEquality().equals(other.storeSite, storeSite) &&
+            const DeepCollectionEquality().equals(other.storeRoom, storeRoom));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        const DeepCollectionEquality().hash(palletNo),
+        const DeepCollectionEquality().hash(materialCode),
+        const DeepCollectionEquality().hash(materialName),
+        const DeepCollectionEquality().hash(batchNo),
+        const DeepCollectionEquality().hash(serialNo),
+        const DeepCollectionEquality().hash(quantity),
+        const DeepCollectionEquality().hash(proofNo),
+        const DeepCollectionEquality().hash(proofNoAlt),
+        const DeepCollectionEquality().hash(storeSite),
+        const DeepCollectionEquality().hash(storeRoom),
+      );
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_InventoryPalletItemCopyWith<_$_InventoryPalletItem> get copyWith =>
+      __$$_InventoryPalletItemCopyWithImpl<_$_InventoryPalletItem>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_InventoryPalletItemToJson(
+      this,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _InventoryPalletItem extends InventoryPalletItem {
+  const factory _InventoryPalletItem({
+    @JsonKey(name: 'palletNo') final String? palletNo,
+    @JsonKey(name: 'matcode') final String? materialCode,
+    @JsonKey(name: 'matname') final String? materialName,
+    @JsonKey(name: 'itemBatch') final String? batchNo,
+    @JsonKey(name: 'itemSn') final String? serialNo,
+    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+    final double? quantity,
+    @JsonKey(name: 'proofno') final String? proofNo,
+    @JsonKey(name: 'proofNo') final String? proofNoAlt,
+    @JsonKey(name: 'storesite') final String? storeSite,
+    @JsonKey(name: 'storeroomno') final String? storeRoom,
+  }) = _$_InventoryPalletItem;
+  const _InventoryPalletItem._() : super._();
+
+  factory _InventoryPalletItem.fromJson(Map<String, dynamic> json) =
+      _$_InventoryPalletItem.fromJson;
+}
+
+const _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.
+Please check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');

--- a/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.g.dart
+++ b/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+
+part of 'inventory_pallet_item.dart';
+
+_$_InventoryPalletItem _$$_InventoryPalletItemFromJson(
+        Map<String, dynamic> json) =>
+    _$_InventoryPalletItem(
+      palletNo: json['palletNo'] as String?,
+      materialCode: json['matcode'] as String?,
+      materialName: json['matname'] as String?,
+      batchNo: json['itemBatch'] as String?,
+      serialNo: json['itemSn'] as String?,
+      quantity: _toDouble(json['itemQty']),
+      proofNo: json['proofno'] as String?,
+      proofNoAlt: json['proofNo'] as String?,
+      storeSite: json['storesite'] as String?,
+      storeRoom: json['storeroomno'] as String?,
+    );
+
+Map<String, dynamic> _$$_InventoryPalletItemToJson(
+        _$_InventoryPalletItem instance) =>
+    <String, dynamic>{
+      'palletNo': instance.palletNo,
+      'matcode': instance.materialCode,
+      'matname': instance.materialName,
+      'itemBatch': instance.batchNo,
+      'itemSn': instance.serialNo,
+      'itemQty': _doubleToJson(instance.quantity),
+      'proofno': instance.proofNo,
+      'proofNo': instance.proofNoAlt,
+      'storesite': instance.storeSite,
+      'storeroomno': instance.storeRoom,
+    };

--- a/lib/modules/aswh_inventory/pallet_item/services/aswh_inventory_pallet_service.dart
+++ b/lib/modules/aswh_inventory/pallet_item/services/aswh_inventory_pallet_service.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+
+import '../../../../services/api_response_handler.dart';
+import '../models/inventory_pallet_item.dart';
+
+class AswhInventoryPalletService {
+  AswhInventoryPalletService(this._dio);
+
+  final Dio _dio;
+
+  Future<List<InventoryPalletItem>> fetchPalletItems({
+    required String trayNo,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getPalletItemByTaskID',
+      queryParameters: {
+        'palletNo': trayNo,
+      },
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          return data
+              .map((item) => InventoryPalletItem.fromJson(
+                    Map<String, dynamic>.from(item as Map),
+                  ))
+              .toList();
+        }
+        throw Exception('托盘明细返回格式异常');
+      },
+    );
+  }
+}

--- a/lib/modules/aswh_inventory/services/aswh_inventory_task_service.dart
+++ b/lib/modules/aswh_inventory/services/aswh_inventory_task_service.dart
@@ -1,0 +1,48 @@
+import 'package:dio/dio.dart';
+
+import '../../../services/api_response_handler.dart';
+import '../task_list/models/inventory_task.dart';
+
+/// 立库盘点任务服务
+class AswhInventoryTaskService {
+  AswhInventoryTaskService(this._dio);
+
+  final Dio _dio;
+
+  /// 查询立库盘点任务
+  Future<InventoryTaskListData> fetchInventoryTasks({
+    required InventoryTaskFilter filter,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getInventoryTask',
+      queryParameters: filter.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) =>
+          InventoryTaskListData.fromJson(data as Map<String, dynamic>),
+    );
+  }
+
+  /// 撤销盘点任务
+  Future<void> cancelInventoryTask({
+    required String taskComment,
+    required String userId,
+    bool confirm = true,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/commitInventoryTask',
+      queryParameters: {
+        'taskcomment': taskComment,
+        'userId': userId,
+        'isCanel': confirm.toString(),
+      },
+    );
+
+    ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => data,
+    );
+  }
+}

--- a/lib/modules/aswh_inventory/task_list/aswh_inventory_task_list_page.dart
+++ b/lib/modules/aswh_inventory/task_list/aswh_inventory_task_list_page.dart
@@ -1,0 +1,244 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+
+import 'bloc/aswh_inventory_task_list_bloc.dart';
+import 'bloc/aswh_inventory_task_list_event.dart';
+import 'bloc/aswh_inventory_task_list_state.dart';
+import 'config/aswh_inventory_task_grid_config.dart';
+import 'models/inventory_task.dart';
+
+const _pageBackground = Color(0xFFF6F6F6);
+
+class AswhInventoryTaskListPage extends StatefulWidget {
+  const AswhInventoryTaskListPage({super.key});
+
+  @override
+  State<AswhInventoryTaskListPage> createState() =>
+      _AswhInventoryTaskListPageState();
+}
+
+class _AswhInventoryTaskListPageState extends State<AswhInventoryTaskListPage> {
+  late final AswhInventoryTaskListBloc _bloc;
+  late final CommonDataGridBloc<InventoryTaskSummary> _gridBloc;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<AswhInventoryTaskListBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+    _bloc.add(const AswhInventoryTaskListEvent.started());
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AswhInventoryTaskListBloc, AswhInventoryTaskListState>(
+      listener: (context, state) {
+        if (state.status == AswhTaskListStatus.actionInProgress) {
+          LoadingDialogManager.instance.showLoadingDialog(
+            context,
+            text: '处理中...',
+          );
+        } else {
+          LoadingDialogManager.instance.hideLoadingDialog(context);
+        }
+
+        if (state.status == AswhTaskListStatus.failure &&
+            state.message != null) {
+          LoadingDialogManager.instance.showErrorDialog(
+            context,
+            state.message!,
+          );
+        }
+
+        if (state.status == AswhTaskListStatus.success &&
+            state.message != null &&
+            state.message!.isNotEmpty) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text(state.message!)));
+        }
+      },
+      child: WillPopScope(
+        onWillPop: () async {
+          _navigateHome();
+          return false;
+        },
+        child: Scaffold(
+          backgroundColor: _pageBackground,
+          appBar: CustomAppBar(
+            title: '立库盘点',
+            onBackPressed: _navigateHome,
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.add, color: Colors.white),
+                onPressed: () => Modular.to.pushNamed('/aswh-inventory/receive'),
+              ),
+            ],
+          ).appBar,
+          body: Column(
+            children: [
+              _buildScanner(),
+              Expanded(child: _buildDataGrid()),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '请扫描单号',
+      clearOnSubmit: true,
+    );
+
+    return ScannerWidget(
+      config: config,
+      controller: _scannerController,
+      onScanResult: (value) =>
+          _bloc.add(AswhInventoryTaskListEvent.scanContentReceived(value)),
+      suffix: IconButton(
+        icon: SvgPicture.asset('assets/images/icon_filter.svg'),
+        onPressed: () async {
+          final controller = TextEditingController(
+            text: _bloc.state.filter.searchKey,
+          );
+          final searchKey = await showDialog<String>(
+            context: context,
+            builder: (context) {
+              return AlertDialog(
+                title: const Text('输入查询关键字'),
+                content: TextField(
+                  controller: controller,
+                  decoration: const InputDecoration(hintText: '请输入盘库单号/任务号'),
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('取消'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () =>
+                        Navigator.of(context).pop(controller.text.trim()),
+                    child: const Text('查询'),
+                  ),
+                ],
+              );
+            },
+          );
+          if (searchKey != null) {
+            _bloc.add(AswhInventoryTaskListEvent.filterSubmitted(searchKey));
+          }
+        },
+      ),
+      onError: (message) {
+        LoadingDialogManager.instance.showErrorDialog(context, message);
+      },
+    );
+  }
+
+  Widget _buildDataGrid() {
+    return BlocProvider.value(
+      value: _gridBloc,
+      child:
+          BlocConsumer<
+            CommonDataGridBloc<InventoryTaskSummary>,
+            CommonDataGridState<InventoryTaskSummary>
+          >(
+            listener: (context, state) {
+              if (state.status == GridStatus.loading) {
+                LoadingDialogManager.instance.showLoadingDialog(context);
+              } else {
+                LoadingDialogManager.instance.hideLoadingDialog(context);
+              }
+
+              if (state.status == GridStatus.error) {
+                LoadingDialogManager.instance.showErrorDialog(
+                  context,
+                  state.errorMessage ?? '数据加载失败',
+                );
+              }
+            },
+            builder: (context, state) {
+              return CommonDataGrid<InventoryTaskSummary>(
+                columns: AswhInventoryTaskGridConfig.columns((task, type) {
+                  if (type == 0) {
+                    _navigateToCollect(task);
+                  } else {
+                    _confirmCancel(task);
+                  }
+                }),
+                datas: state.data,
+                currentPage: state.currentPage,
+                totalPages: state.totalPages,
+                onLoadData: (pageIndex) async {
+                  _bloc.add(AswhInventoryTaskListEvent.pageChanged(pageIndex));
+                },
+                selectedRows: state.selectedRows,
+                onSelectionChanged: (rows) {
+                  _gridBloc.add(ChangeSelectedRowsEvent(rows));
+                },
+                allowPager: false,
+                allowSelect: false,
+                headerHeight: 44,
+                rowHeight: 48,
+              );
+            },
+          ),
+    );
+  }
+
+  void _navigateToCollect(InventoryTaskSummary task) {
+    Modular.to.pushNamed(
+      '/aswh-inventory/collect/${task.checkTaskNo}',
+      arguments: {'task': task.toJson()},
+    );
+  }
+
+  Future<void> _confirmCancel(InventoryTaskSummary task) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('撤销确认'),
+          content: Text('是否撤销盘库单号：${task.taskComment}?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('确认'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (result == true) {
+      _bloc.add(AswhInventoryTaskListEvent.taskCancelRequested(task));
+    }
+  }
+
+  void _navigateHome() {
+    Navigator.of(context).pushNamedAndRemoveUntil('/home', (route) => false);
+  }
+}

--- a/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_bloc.dart
+++ b/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_bloc.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:meta/meta.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+import '../../services/aswh_inventory_task_service.dart';
+import '../models/inventory_task.dart';
+import 'aswh_inventory_task_list_event.dart';
+import 'aswh_inventory_task_list_state.dart';
+
+@immutable
+class AswhInventoryTaskListBloc
+    extends Bloc<AswhInventoryTaskListEvent, AswhInventoryTaskListState> {
+  AswhInventoryTaskListBloc({
+    required AswhInventoryTaskService taskService,
+    required UserManager userManager,
+  }) : _taskService = taskService,
+       _userManager = userManager,
+       super(
+         AswhInventoryTaskListState(
+           filter: InventoryTaskFilter(
+             userId: '${userManager.userInfo?.userId ?? ''}',
+             roleOrUserId: '${userManager.userInfo?.userId ?? ''}',
+           ),
+         ),
+       ) {
+    on<_Started>(_onStarted);
+    on<_FilterSubmitted>(_onFilterSubmitted);
+    on<_ScanContentReceived>(_onScanContentReceived);
+    on<_PageChanged>(_onPageChanged);
+    on<_TaskCancelRequested>(_onTaskCancelRequested);
+    on<_RefreshRequested>(_onRefreshRequested);
+
+    _gridBloc = CommonDataGridBloc<InventoryTaskSummary>(
+      dataLoader: _createDataLoader(),
+    );
+  }
+
+  final AswhInventoryTaskService _taskService;
+  final UserManager _userManager;
+
+  late final CommonDataGridBloc<InventoryTaskSummary> _gridBloc;
+  CommonDataGridBloc<InventoryTaskSummary> get gridBloc => _gridBloc;
+
+  int _latestTotalCount = 0;
+  bool _ignoreNextPageChange = false;
+
+  DataGridLoader<InventoryTaskSummary> _createDataLoader() {
+    return (pageIndex) async {
+      final filter = state.filter.copyWith(pageIndex: pageIndex);
+      final result = await _taskService.fetchInventoryTasks(filter: filter);
+      _latestTotalCount = result.total;
+      final totalPages = result.total == 0
+          ? 1
+          : (result.total / filter.pageSize).ceil().clamp(1, 999999);
+      return DataGridResponseData<InventoryTaskSummary>(
+        totalPages: totalPages,
+        data: result.rows,
+      );
+    };
+  }
+
+  Future<void> _onStarted(
+    _Started event,
+    Emitter<AswhInventoryTaskListState> emit,
+  ) async {
+    _ignoreNextPageChange = true;
+    await _loadPage(emit, pageIndex: state.filter.pageIndex);
+  }
+
+  Future<void> _onFilterSubmitted(
+    _FilterSubmitted event,
+    Emitter<AswhInventoryTaskListState> emit,
+  ) async {
+    final updatedFilter = state.filter.copyWith(
+      searchKey: event.searchKey,
+      pageIndex: 1,
+    );
+    emit(state.copyWith(filter: updatedFilter));
+    await _loadPage(emit, pageIndex: 1);
+  }
+
+  Future<void> _onScanContentReceived(
+    _ScanContentReceived event,
+    Emitter<AswhInventoryTaskListState> emit,
+  ) async {
+    if (event.scanContent.isEmpty) {
+      return;
+    }
+    final updatedFilter = state.filter.copyWith(
+      searchKey: event.scanContent,
+      pageIndex: 1,
+    );
+    emit(state.copyWith(filter: updatedFilter));
+    await _loadPage(emit, pageIndex: 1);
+  }
+
+  Future<void> _onPageChanged(
+    _PageChanged event,
+    Emitter<AswhInventoryTaskListState> emit,
+  ) async {
+    if (_ignoreNextPageChange) {
+      _ignoreNextPageChange = false;
+      return;
+    }
+    emit(
+      state.copyWith(filter: state.filter.copyWith(pageIndex: event.pageIndex)),
+    );
+    await _loadPage(emit, pageIndex: event.pageIndex);
+  }
+
+  Future<void> _onRefreshRequested(
+    _RefreshRequested event,
+    Emitter<AswhInventoryTaskListState> emit,
+  ) async {
+    await _loadPage(emit, pageIndex: state.filter.pageIndex);
+  }
+
+  Future<void> _onTaskCancelRequested(
+    _TaskCancelRequested event,
+    Emitter<AswhInventoryTaskListState> emit,
+  ) async {
+    final userId = _userManager.userInfo?.userId;
+    if (userId == null) {
+      emit(
+        state.copyWith(
+          status: AswhTaskListStatus.failure,
+          message: '用户信息缺失，请重新登录',
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: AswhTaskListStatus.actionInProgress));
+    try {
+      await _taskService.cancelInventoryTask(
+        taskComment: event.task.taskComment,
+        userId: userId.toString(),
+      );
+      await _loadPage(
+        emit,
+        pageIndex: state.filter.pageIndex,
+        successMessage: '单据撤销成功',
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: AswhTaskListStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> _loadPage(
+    Emitter<AswhInventoryTaskListState> emit, {
+    required int pageIndex,
+    String? successMessage,
+  }) async {
+    emit(state.copyWith(status: AswhTaskListStatus.loading, message: null));
+
+    final completer = Completer<DataGridResponseData<InventoryTaskSummary>>();
+    _gridBloc.add(LoadDataEvent(pageIndex, completer: completer));
+
+    try {
+      final response = await completer.future;
+      emit(
+        state.copyWith(
+          status: AswhTaskListStatus.success,
+          tasks: response.data,
+          currentPage: pageIndex,
+          totalPages: response.totalPages,
+          total: _latestTotalCount,
+          filter: state.filter.copyWith(pageIndex: pageIndex),
+          message: successMessage,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: AswhTaskListStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _gridBloc.close();
+    return super.close();
+  }
+}

--- a/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_event.dart
+++ b/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_event.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../models/inventory_task.dart';
+
+part 'aswh_inventory_task_list_event.freezed.dart';
+
+/// 立库盘点任务列表事件定义
+@freezed
+class AswhInventoryTaskListEvent with _$AswhInventoryTaskListEvent {
+  /// 初始化页面
+  const factory AswhInventoryTaskListEvent.started() = _Started;
+
+  /// 提交筛选条件
+  const factory AswhInventoryTaskListEvent.filterSubmitted(String searchKey) =
+      _FilterSubmitted;
+
+  /// 扫码回调
+  const factory AswhInventoryTaskListEvent.scanContentReceived(
+    String scanContent,
+  ) = _ScanContentReceived;
+
+  /// 撤销任务请求
+  const factory AswhInventoryTaskListEvent.taskCancelRequested(
+    InventoryTaskSummary task,
+  ) = _TaskCancelRequested;
+
+  /// 分页切换
+  const factory AswhInventoryTaskListEvent.pageChanged(int pageIndex) =
+      _PageChanged;
+
+  /// 刷新当前页
+  const factory AswhInventoryTaskListEvent.refreshRequested() =
+      _RefreshRequested;
+}

--- a/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_event.freezed.dart
+++ b/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_event.freezed.dart
@@ -1,0 +1,1003 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'aswh_inventory_task_list_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$AswhInventoryTaskListEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String searchKey) filterSubmitted,
+    required TResult Function(String scanContent) scanContentReceived,
+    required TResult Function(InventoryTaskSummary task) taskCancelRequested,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String searchKey)? filterSubmitted,
+    TResult? Function(String scanContent)? scanContentReceived,
+    TResult? Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String searchKey)? filterSubmitted,
+    TResult Function(String scanContent)? scanContentReceived,
+    TResult Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FilterSubmitted value) filterSubmitted,
+    required TResult Function(_ScanContentReceived value) scanContentReceived,
+    required TResult Function(_TaskCancelRequested value) taskCancelRequested,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FilterSubmitted value)? filterSubmitted,
+    TResult? Function(_ScanContentReceived value)? scanContentReceived,
+    TResult? Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FilterSubmitted value)? filterSubmitted,
+    TResult Function(_ScanContentReceived value)? scanContentReceived,
+    TResult Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AswhInventoryTaskListEventCopyWith<$Res> {
+  factory $AswhInventoryTaskListEventCopyWith(AswhInventoryTaskListEvent value,
+          $Res Function(AswhInventoryTaskListEvent) then) =
+      _$AswhInventoryTaskListEventCopyWithImpl<$Res,
+          AswhInventoryTaskListEvent>;
+}
+
+/// @nodoc
+class _$AswhInventoryTaskListEventCopyWithImpl<$Res,
+        $Val extends AswhInventoryTaskListEvent>
+    implements $AswhInventoryTaskListEventCopyWith<$Res> {
+  _$AswhInventoryTaskListEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$StartedImplCopyWith<$Res> {
+  factory _$$StartedImplCopyWith(
+          _$StartedImpl value, $Res Function(_$StartedImpl) then) =
+      __$$StartedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$StartedImplCopyWithImpl<$Res>
+    extends _$AswhInventoryTaskListEventCopyWithImpl<$Res, _$StartedImpl>
+    implements _$$StartedImplCopyWith<$Res> {
+  __$$StartedImplCopyWithImpl(
+      _$StartedImpl _value, $Res Function(_$StartedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$StartedImpl implements _Started {
+  const _$StartedImpl();
+
+  @override
+  String toString() {
+    return 'AswhInventoryTaskListEvent.started()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$StartedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String searchKey) filterSubmitted,
+    required TResult Function(String scanContent) scanContentReceived,
+    required TResult Function(InventoryTaskSummary task) taskCancelRequested,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+  }) {
+    return started();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String searchKey)? filterSubmitted,
+    TResult? Function(String scanContent)? scanContentReceived,
+    TResult? Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+  }) {
+    return started?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String searchKey)? filterSubmitted,
+    TResult Function(String scanContent)? scanContentReceived,
+    TResult Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FilterSubmitted value) filterSubmitted,
+    required TResult Function(_ScanContentReceived value) scanContentReceived,
+    required TResult Function(_TaskCancelRequested value) taskCancelRequested,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return started(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FilterSubmitted value)? filterSubmitted,
+    TResult? Function(_ScanContentReceived value)? scanContentReceived,
+    TResult? Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return started?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FilterSubmitted value)? filterSubmitted,
+    TResult Function(_ScanContentReceived value)? scanContentReceived,
+    TResult Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Started implements AswhInventoryTaskListEvent {
+  const factory _Started() = _$StartedImpl;
+}
+
+/// @nodoc
+abstract class _$$FilterSubmittedImplCopyWith<$Res> {
+  factory _$$FilterSubmittedImplCopyWith(_$FilterSubmittedImpl value,
+          $Res Function(_$FilterSubmittedImpl) then) =
+      __$$FilterSubmittedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String searchKey});
+}
+
+/// @nodoc
+class __$$FilterSubmittedImplCopyWithImpl<$Res>
+    extends _$AswhInventoryTaskListEventCopyWithImpl<$Res,
+        _$FilterSubmittedImpl> implements _$$FilterSubmittedImplCopyWith<$Res> {
+  __$$FilterSubmittedImplCopyWithImpl(
+      _$FilterSubmittedImpl _value, $Res Function(_$FilterSubmittedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? searchKey = null,
+  }) {
+    return _then(_$FilterSubmittedImpl(
+      null == searchKey
+          ? _value.searchKey
+          : searchKey // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$FilterSubmittedImpl implements _FilterSubmitted {
+  const _$FilterSubmittedImpl(this.searchKey);
+
+  @override
+  final String searchKey;
+
+  @override
+  String toString() {
+    return 'AswhInventoryTaskListEvent.filterSubmitted(searchKey: $searchKey)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FilterSubmittedImpl &&
+            (identical(other.searchKey, searchKey) ||
+                other.searchKey == searchKey));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, searchKey);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FilterSubmittedImplCopyWith<_$FilterSubmittedImpl> get copyWith =>
+      __$$FilterSubmittedImplCopyWithImpl<_$FilterSubmittedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String searchKey) filterSubmitted,
+    required TResult Function(String scanContent) scanContentReceived,
+    required TResult Function(InventoryTaskSummary task) taskCancelRequested,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+  }) {
+    return filterSubmitted(searchKey);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String searchKey)? filterSubmitted,
+    TResult? Function(String scanContent)? scanContentReceived,
+    TResult? Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+  }) {
+    return filterSubmitted?.call(searchKey);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String searchKey)? filterSubmitted,
+    TResult Function(String scanContent)? scanContentReceived,
+    TResult Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (filterSubmitted != null) {
+      return filterSubmitted(searchKey);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FilterSubmitted value) filterSubmitted,
+    required TResult Function(_ScanContentReceived value) scanContentReceived,
+    required TResult Function(_TaskCancelRequested value) taskCancelRequested,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return filterSubmitted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FilterSubmitted value)? filterSubmitted,
+    TResult? Function(_ScanContentReceived value)? scanContentReceived,
+    TResult? Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return filterSubmitted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FilterSubmitted value)? filterSubmitted,
+    TResult Function(_ScanContentReceived value)? scanContentReceived,
+    TResult Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (filterSubmitted != null) {
+      return filterSubmitted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _FilterSubmitted implements AswhInventoryTaskListEvent {
+  const factory _FilterSubmitted(final String searchKey) =
+      _$FilterSubmittedImpl;
+
+  String get searchKey;
+  @JsonKey(ignore: true)
+  _$$FilterSubmittedImplCopyWith<_$FilterSubmittedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ScanContentReceivedImplCopyWith<$Res> {
+  factory _$$ScanContentReceivedImplCopyWith(_$ScanContentReceivedImpl value,
+          $Res Function(_$ScanContentReceivedImpl) then) =
+      __$$ScanContentReceivedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String scanContent});
+}
+
+/// @nodoc
+class __$$ScanContentReceivedImplCopyWithImpl<$Res>
+    extends _$AswhInventoryTaskListEventCopyWithImpl<$Res,
+        _$ScanContentReceivedImpl>
+    implements _$$ScanContentReceivedImplCopyWith<$Res> {
+  __$$ScanContentReceivedImplCopyWithImpl(_$ScanContentReceivedImpl _value,
+      $Res Function(_$ScanContentReceivedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? scanContent = null,
+  }) {
+    return _then(_$ScanContentReceivedImpl(
+      null == scanContent
+          ? _value.scanContent
+          : scanContent // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ScanContentReceivedImpl implements _ScanContentReceived {
+  const _$ScanContentReceivedImpl(this.scanContent);
+
+  @override
+  final String scanContent;
+
+  @override
+  String toString() {
+    return 'AswhInventoryTaskListEvent.scanContentReceived(scanContent: $scanContent)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ScanContentReceivedImpl &&
+            (identical(other.scanContent, scanContent) ||
+                other.scanContent == scanContent));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, scanContent);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ScanContentReceivedImplCopyWith<_$ScanContentReceivedImpl> get copyWith =>
+      __$$ScanContentReceivedImplCopyWithImpl<_$ScanContentReceivedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String searchKey) filterSubmitted,
+    required TResult Function(String scanContent) scanContentReceived,
+    required TResult Function(InventoryTaskSummary task) taskCancelRequested,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+  }) {
+    return scanContentReceived(scanContent);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String searchKey)? filterSubmitted,
+    TResult? Function(String scanContent)? scanContentReceived,
+    TResult? Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+  }) {
+    return scanContentReceived?.call(scanContent);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String searchKey)? filterSubmitted,
+    TResult Function(String scanContent)? scanContentReceived,
+    TResult Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (scanContentReceived != null) {
+      return scanContentReceived(scanContent);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FilterSubmitted value) filterSubmitted,
+    required TResult Function(_ScanContentReceived value) scanContentReceived,
+    required TResult Function(_TaskCancelRequested value) taskCancelRequested,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return scanContentReceived(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FilterSubmitted value)? filterSubmitted,
+    TResult? Function(_ScanContentReceived value)? scanContentReceived,
+    TResult? Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return scanContentReceived?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FilterSubmitted value)? filterSubmitted,
+    TResult Function(_ScanContentReceived value)? scanContentReceived,
+    TResult Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (scanContentReceived != null) {
+      return scanContentReceived(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ScanContentReceived implements AswhInventoryTaskListEvent {
+  const factory _ScanContentReceived(final String scanContent) =
+      _$ScanContentReceivedImpl;
+
+  String get scanContent;
+  @JsonKey(ignore: true)
+  _$$ScanContentReceivedImplCopyWith<_$ScanContentReceivedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$TaskCancelRequestedImplCopyWith<$Res> {
+  factory _$$TaskCancelRequestedImplCopyWith(_$TaskCancelRequestedImpl value,
+          $Res Function(_$TaskCancelRequestedImpl) then) =
+      __$$TaskCancelRequestedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({InventoryTaskSummary task});
+
+  $InventoryTaskSummaryCopyWith<$Res> get task;
+}
+
+/// @nodoc
+class __$$TaskCancelRequestedImplCopyWithImpl<$Res>
+    extends _$AswhInventoryTaskListEventCopyWithImpl<$Res,
+        _$TaskCancelRequestedImpl>
+    implements _$$TaskCancelRequestedImplCopyWith<$Res> {
+  __$$TaskCancelRequestedImplCopyWithImpl(_$TaskCancelRequestedImpl _value,
+      $Res Function(_$TaskCancelRequestedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? task = null,
+  }) {
+    return _then(_$TaskCancelRequestedImpl(
+      null == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskSummary,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryTaskSummaryCopyWith<$Res> get task {
+    return $InventoryTaskSummaryCopyWith<$Res>(_value.task, (value) {
+      return _then(_value.copyWith(task: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$TaskCancelRequestedImpl implements _TaskCancelRequested {
+  const _$TaskCancelRequestedImpl(this.task);
+
+  @override
+  final InventoryTaskSummary task;
+
+  @override
+  String toString() {
+    return 'AswhInventoryTaskListEvent.taskCancelRequested(task: $task)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TaskCancelRequestedImpl &&
+            (identical(other.task, task) || other.task == task));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, task);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TaskCancelRequestedImplCopyWith<_$TaskCancelRequestedImpl> get copyWith =>
+      __$$TaskCancelRequestedImplCopyWithImpl<_$TaskCancelRequestedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String searchKey) filterSubmitted,
+    required TResult Function(String scanContent) scanContentReceived,
+    required TResult Function(InventoryTaskSummary task) taskCancelRequested,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+  }) {
+    return taskCancelRequested(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String searchKey)? filterSubmitted,
+    TResult? Function(String scanContent)? scanContentReceived,
+    TResult? Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+  }) {
+    return taskCancelRequested?.call(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String searchKey)? filterSubmitted,
+    TResult Function(String scanContent)? scanContentReceived,
+    TResult Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (taskCancelRequested != null) {
+      return taskCancelRequested(task);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FilterSubmitted value) filterSubmitted,
+    required TResult Function(_ScanContentReceived value) scanContentReceived,
+    required TResult Function(_TaskCancelRequested value) taskCancelRequested,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return taskCancelRequested(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FilterSubmitted value)? filterSubmitted,
+    TResult? Function(_ScanContentReceived value)? scanContentReceived,
+    TResult? Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return taskCancelRequested?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FilterSubmitted value)? filterSubmitted,
+    TResult Function(_ScanContentReceived value)? scanContentReceived,
+    TResult Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (taskCancelRequested != null) {
+      return taskCancelRequested(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _TaskCancelRequested implements AswhInventoryTaskListEvent {
+  const factory _TaskCancelRequested(final InventoryTaskSummary task) =
+      _$TaskCancelRequestedImpl;
+
+  InventoryTaskSummary get task;
+  @JsonKey(ignore: true)
+  _$$TaskCancelRequestedImplCopyWith<_$TaskCancelRequestedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PageChangedImplCopyWith<$Res> {
+  factory _$$PageChangedImplCopyWith(
+          _$PageChangedImpl value, $Res Function(_$PageChangedImpl) then) =
+      __$$PageChangedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int pageIndex});
+}
+
+/// @nodoc
+class __$$PageChangedImplCopyWithImpl<$Res>
+    extends _$AswhInventoryTaskListEventCopyWithImpl<$Res, _$PageChangedImpl>
+    implements _$$PageChangedImplCopyWith<$Res> {
+  __$$PageChangedImplCopyWithImpl(
+      _$PageChangedImpl _value, $Res Function(_$PageChangedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pageIndex = null,
+  }) {
+    return _then(_$PageChangedImpl(
+      null == pageIndex
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PageChangedImpl implements _PageChanged {
+  const _$PageChangedImpl(this.pageIndex);
+
+  @override
+  final int pageIndex;
+
+  @override
+  String toString() {
+    return 'AswhInventoryTaskListEvent.pageChanged(pageIndex: $pageIndex)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageChangedImpl &&
+            (identical(other.pageIndex, pageIndex) ||
+                other.pageIndex == pageIndex));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, pageIndex);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      __$$PageChangedImplCopyWithImpl<_$PageChangedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String searchKey) filterSubmitted,
+    required TResult Function(String scanContent) scanContentReceived,
+    required TResult Function(InventoryTaskSummary task) taskCancelRequested,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+  }) {
+    return pageChanged(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String searchKey)? filterSubmitted,
+    TResult? Function(String scanContent)? scanContentReceived,
+    TResult? Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+  }) {
+    return pageChanged?.call(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String searchKey)? filterSubmitted,
+    TResult Function(String scanContent)? scanContentReceived,
+    TResult Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(pageIndex);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FilterSubmitted value) filterSubmitted,
+    required TResult Function(_ScanContentReceived value) scanContentReceived,
+    required TResult Function(_TaskCancelRequested value) taskCancelRequested,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return pageChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FilterSubmitted value)? filterSubmitted,
+    TResult? Function(_ScanContentReceived value)? scanContentReceived,
+    TResult? Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return pageChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FilterSubmitted value)? filterSubmitted,
+    TResult Function(_ScanContentReceived value)? scanContentReceived,
+    TResult Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _PageChanged implements AswhInventoryTaskListEvent {
+  const factory _PageChanged(final int pageIndex) = _$PageChangedImpl;
+
+  int get pageIndex;
+  @JsonKey(ignore: true)
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$RefreshRequestedImplCopyWith<$Res> {
+  factory _$$RefreshRequestedImplCopyWith(_$RefreshRequestedImpl value,
+          $Res Function(_$RefreshRequestedImpl) then) =
+      __$$RefreshRequestedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RefreshRequestedImplCopyWithImpl<$Res>
+    extends _$AswhInventoryTaskListEventCopyWithImpl<$Res,
+        _$RefreshRequestedImpl>
+    implements _$$RefreshRequestedImplCopyWith<$Res> {
+  __$$RefreshRequestedImplCopyWithImpl(_$RefreshRequestedImpl _value,
+      $Res Function(_$RefreshRequestedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$RefreshRequestedImpl implements _RefreshRequested {
+  const _$RefreshRequestedImpl();
+
+  @override
+  String toString() {
+    return 'AswhInventoryTaskListEvent.refreshRequested()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$RefreshRequestedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String searchKey) filterSubmitted,
+    required TResult Function(String scanContent) scanContentReceived,
+    required TResult Function(InventoryTaskSummary task) taskCancelRequested,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+  }) {
+    return refreshRequested();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String searchKey)? filterSubmitted,
+    TResult? Function(String scanContent)? scanContentReceived,
+    TResult? Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+  }) {
+    return refreshRequested?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String searchKey)? filterSubmitted,
+    TResult Function(String scanContent)? scanContentReceived,
+    TResult Function(InventoryTaskSummary task)? taskCancelRequested,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (refreshRequested != null) {
+      return refreshRequested();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_FilterSubmitted value) filterSubmitted,
+    required TResult Function(_ScanContentReceived value) scanContentReceived,
+    required TResult Function(_TaskCancelRequested value) taskCancelRequested,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return refreshRequested(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_FilterSubmitted value)? filterSubmitted,
+    TResult? Function(_ScanContentReceived value)? scanContentReceived,
+    TResult? Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return refreshRequested?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_FilterSubmitted value)? filterSubmitted,
+    TResult Function(_ScanContentReceived value)? scanContentReceived,
+    TResult Function(_TaskCancelRequested value)? taskCancelRequested,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (refreshRequested != null) {
+      return refreshRequested(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _RefreshRequested implements AswhInventoryTaskListEvent {
+  const factory _RefreshRequested() = _$RefreshRequestedImpl;
+}

--- a/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_state.dart
+++ b/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_state.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../models/inventory_task.dart';
+
+part 'aswh_inventory_task_list_state.freezed.dart';
+
+/// 列表状态枚举
+enum AswhTaskListStatus { initial, loading, success, failure, actionInProgress }
+
+/// 立库盘点任务列表状态
+@freezed
+class AswhInventoryTaskListState with _$AswhInventoryTaskListState {
+  const factory AswhInventoryTaskListState({
+    @Default(AswhTaskListStatus.initial) AswhTaskListStatus status,
+    required InventoryTaskFilter filter,
+    @Default(<InventoryTaskSummary>[]) List<InventoryTaskSummary> tasks,
+    @Default(0) int total,
+    @Default(1) int currentPage,
+    @Default(1) int totalPages,
+    String? message,
+  }) = _AswhInventoryTaskListState;
+}

--- a/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_state.freezed.dart
+++ b/lib/modules/aswh_inventory/task_list/bloc/aswh_inventory_task_list_state.freezed.dart
@@ -1,0 +1,298 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'aswh_inventory_task_list_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$AswhInventoryTaskListState {
+  AswhTaskListStatus get status => throw _privateConstructorUsedError;
+  InventoryTaskFilter get filter => throw _privateConstructorUsedError;
+  List<InventoryTaskSummary> get tasks => throw _privateConstructorUsedError;
+  int get total => throw _privateConstructorUsedError;
+  int get currentPage => throw _privateConstructorUsedError;
+  int get totalPages => throw _privateConstructorUsedError;
+  String? get message => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $AswhInventoryTaskListStateCopyWith<AswhInventoryTaskListState>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AswhInventoryTaskListStateCopyWith<$Res> {
+  factory $AswhInventoryTaskListStateCopyWith(AswhInventoryTaskListState value,
+          $Res Function(AswhInventoryTaskListState) then) =
+      _$AswhInventoryTaskListStateCopyWithImpl<$Res,
+          AswhInventoryTaskListState>;
+  @useResult
+  $Res call(
+      {AswhTaskListStatus status,
+      InventoryTaskFilter filter,
+      List<InventoryTaskSummary> tasks,
+      int total,
+      int currentPage,
+      int totalPages,
+      String? message});
+
+  $InventoryTaskFilterCopyWith<$Res> get filter;
+}
+
+/// @nodoc
+class _$AswhInventoryTaskListStateCopyWithImpl<$Res,
+        $Val extends AswhInventoryTaskListState>
+    implements $AswhInventoryTaskListStateCopyWith<$Res> {
+  _$AswhInventoryTaskListStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? filter = null,
+    Object? tasks = null,
+    Object? total = null,
+    Object? currentPage = null,
+    Object? totalPages = null,
+    Object? message = freezed,
+  }) {
+    return _then(_value.copyWith(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as AswhTaskListStatus,
+      filter: null == filter
+          ? _value.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskFilter,
+      tasks: null == tasks
+          ? _value.tasks
+          : tasks // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTaskSummary>,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      currentPage: null == currentPage
+          ? _value.currentPage
+          : currentPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryTaskFilterCopyWith<$Res> get filter {
+    return $InventoryTaskFilterCopyWith<$Res>(_value.filter, (value) {
+      return _then(_value.copyWith(filter: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$AswhInventoryTaskListStateImplCopyWith<$Res>
+    implements $AswhInventoryTaskListStateCopyWith<$Res> {
+  factory _$$AswhInventoryTaskListStateImplCopyWith(
+          _$AswhInventoryTaskListStateImpl value,
+          $Res Function(_$AswhInventoryTaskListStateImpl) then) =
+      __$$AswhInventoryTaskListStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {AswhTaskListStatus status,
+      InventoryTaskFilter filter,
+      List<InventoryTaskSummary> tasks,
+      int total,
+      int currentPage,
+      int totalPages,
+      String? message});
+
+  @override
+  $InventoryTaskFilterCopyWith<$Res> get filter;
+}
+
+/// @nodoc
+class __$$AswhInventoryTaskListStateImplCopyWithImpl<$Res>
+    extends _$AswhInventoryTaskListStateCopyWithImpl<$Res,
+        _$AswhInventoryTaskListStateImpl>
+    implements _$$AswhInventoryTaskListStateImplCopyWith<$Res> {
+  __$$AswhInventoryTaskListStateImplCopyWithImpl(
+      _$AswhInventoryTaskListStateImpl _value,
+      $Res Function(_$AswhInventoryTaskListStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? filter = null,
+    Object? tasks = null,
+    Object? total = null,
+    Object? currentPage = null,
+    Object? totalPages = null,
+    Object? message = freezed,
+  }) {
+    return _then(_$AswhInventoryTaskListStateImpl(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as AswhTaskListStatus,
+      filter: null == filter
+          ? _value.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskFilter,
+      tasks: null == tasks
+          ? _value._tasks
+          : tasks // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTaskSummary>,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      currentPage: null == currentPage
+          ? _value.currentPage
+          : currentPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$AswhInventoryTaskListStateImpl implements _AswhInventoryTaskListState {
+  const _$AswhInventoryTaskListStateImpl(
+      {this.status = AswhTaskListStatus.initial,
+      required this.filter,
+      final List<InventoryTaskSummary> tasks = const <InventoryTaskSummary>[],
+      this.total = 0,
+      this.currentPage = 1,
+      this.totalPages = 1,
+      this.message})
+      : _tasks = tasks;
+
+  @override
+  @JsonKey()
+  final AswhTaskListStatus status;
+  @override
+  final InventoryTaskFilter filter;
+  final List<InventoryTaskSummary> _tasks;
+  @override
+  @JsonKey()
+  List<InventoryTaskSummary> get tasks {
+    if (_tasks is EqualUnmodifiableListView) return _tasks;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_tasks);
+  }
+
+  @override
+  @JsonKey()
+  final int total;
+  @override
+  @JsonKey()
+  final int currentPage;
+  @override
+  @JsonKey()
+  final int totalPages;
+  @override
+  final String? message;
+
+  @override
+  String toString() {
+    return 'AswhInventoryTaskListState(status: $status, filter: $filter, tasks: $tasks, total: $total, currentPage: $currentPage, totalPages: $totalPages, message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AswhInventoryTaskListStateImpl &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.filter, filter) || other.filter == filter) &&
+            const DeepCollectionEquality().equals(other._tasks, _tasks) &&
+            (identical(other.total, total) || other.total == total) &&
+            (identical(other.currentPage, currentPage) ||
+                other.currentPage == currentPage) &&
+            (identical(other.totalPages, totalPages) ||
+                other.totalPages == totalPages) &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      status,
+      filter,
+      const DeepCollectionEquality().hash(_tasks),
+      total,
+      currentPage,
+      totalPages,
+      message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AswhInventoryTaskListStateImplCopyWith<_$AswhInventoryTaskListStateImpl>
+      get copyWith => __$$AswhInventoryTaskListStateImplCopyWithImpl<
+          _$AswhInventoryTaskListStateImpl>(this, _$identity);
+}
+
+abstract class _AswhInventoryTaskListState
+    implements AswhInventoryTaskListState {
+  const factory _AswhInventoryTaskListState(
+      {final AswhTaskListStatus status,
+      required final InventoryTaskFilter filter,
+      final List<InventoryTaskSummary> tasks,
+      final int total,
+      final int currentPage,
+      final int totalPages,
+      final String? message}) = _$AswhInventoryTaskListStateImpl;
+
+  @override
+  AswhTaskListStatus get status;
+  @override
+  InventoryTaskFilter get filter;
+  @override
+  List<InventoryTaskSummary> get tasks;
+  @override
+  int get total;
+  @override
+  int get currentPage;
+  @override
+  int get totalPages;
+  @override
+  String? get message;
+  @override
+  @JsonKey(ignore: true)
+  _$$AswhInventoryTaskListStateImplCopyWith<_$AswhInventoryTaskListStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/aswh_inventory/task_list/config/aswh_inventory_task_grid_config.dart
+++ b/lib/modules/aswh_inventory/task_list/config/aswh_inventory_task_grid_config.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+import '../../../../common_widgets/common_grid/common_data_grid.dart';
+import '../models/inventory_task.dart';
+
+typedef InventoryTaskOperation =
+    void Function(InventoryTaskSummary task, int type);
+
+class AswhInventoryTaskGridConfig {
+  static List<GridColumnConfig<InventoryTaskSummary>> columns(
+    InventoryTaskOperation? operation,
+  ) {
+    return [
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'actions',
+        headerText: '操作',
+        width: 180,
+        cellBuilder: (task, columnName, cellValue) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SizedBox(
+                height: 32,
+                child: ElevatedButton(
+                  onPressed: () => operation?.call(task, 0),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF465CFF),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                  child: const Text('采集'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              SizedBox(
+                height: 32,
+                child: OutlinedButton(
+                  onPressed: () => operation?.call(task, 1),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: const Color(0xFF465CFF),
+                    side: const BorderSide(color: Color(0xFF465CFF)),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                  child: const Text('撤销'),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'taskComment',
+        headerText: '盘库单号',
+        width: 220,
+        valueGetter: (task) => task.taskComment,
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'storeRoomNo',
+        headerText: '库房号',
+        width: 140,
+        valueGetter: (task) => task.storeRoomNo,
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'storeRoomName',
+        headerText: '库房名称',
+        width: 240,
+        valueGetter: (task) => task.storeRoomName,
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'checkTaskNo',
+        headerText: '任务号',
+        width: 200,
+        valueGetter: (task) => task.checkTaskNo,
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'status',
+        headerText: '状态',
+        width: 160,
+        cellBuilder: (task, columnName, cellValue) {
+          final status = task.status?.isNotEmpty == true ? task.status! : '待处理';
+          final isFinished = status.contains('完成');
+          return Container(
+            alignment: Alignment.center,
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: isFinished
+                  ? Colors.green.withOpacity(0.1)
+                  : Colors.orange.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(
+                color: isFinished ? Colors.green : Colors.orange,
+              ),
+            ),
+            child: Text(
+              status,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: isFinished ? Colors.green : Colors.orange,
+              ),
+            ),
+          );
+        },
+      ),
+    ];
+  }
+}

--- a/lib/modules/aswh_inventory/task_list/models/inventory_task.dart
+++ b/lib/modules/aswh_inventory/task_list/models/inventory_task.dart
@@ -1,0 +1,84 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_task.freezed.dart';
+part 'inventory_task.g.dart';
+
+/// 盘点任务查询参数
+@freezed
+class InventoryTaskFilter with _$InventoryTaskFilter {
+  const factory InventoryTaskFilter({
+    /// 排序方向
+    @JsonKey(name: 'sortType') @Default('desc') String sortType,
+
+    /// 排序字段
+    @JsonKey(name: 'sortColumn') @Default('createdate') String sortColumn,
+
+    /// 搜索关键字（支持扫码输入任务号/盘库单号）
+    @JsonKey(name: 'searchKey') @Default('') String searchKey,
+
+    /// 用户ID（字符串，兼容接口入参）
+    @JsonKey(name: 'userId') required String userId,
+
+    /// 角色或用户ID（接口字段名为 roleoRuserId）
+    @JsonKey(name: 'roleoRuserId') required String roleOrUserId,
+
+    /// 库房标签（1 表示立库）
+    @JsonKey(name: 'roomTag') @Default('1') String roomTag,
+
+    /// 完成标识（0-未完成，1-全部）
+    @JsonKey(name: 'finshFlg') @Default('0') String finishFlag,
+
+    /// 当前页码（接口使用 PageIndex 字段，1 开始）
+    @JsonKey(name: 'PageIndex') @Default(1) int pageIndex,
+
+    /// 每页条目数量
+    @JsonKey(name: 'PageSize') @Default(100) int pageSize,
+  }) = _InventoryTaskFilter;
+
+  factory InventoryTaskFilter.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskFilterFromJson(json);
+}
+
+/// 盘点任务汇总信息
+@freezed
+class InventoryTaskSummary with _$InventoryTaskSummary {
+  const factory InventoryTaskSummary({
+    /// 盘库单号
+    @JsonKey(name: 'taskcomment') required String taskComment,
+
+    /// 库房号
+    @JsonKey(name: 'storeroomno') required String storeRoomNo,
+
+    /// 库房名称
+    @JsonKey(name: 'storeroomname') required String storeRoomName,
+
+    /// 任务号
+    @JsonKey(name: 'checktaskno') required String checkTaskNo,
+
+    /// 任务ID
+    @JsonKey(name: 'checktaskid') int? checkTaskId,
+
+    /// 状态描述
+    @JsonKey(name: 'status') String? status,
+
+    /// 工位/拣选位
+    @JsonKey(name: 'workstation') String? workStation,
+  }) = _InventoryTaskSummary;
+
+  factory InventoryTaskSummary.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskSummaryFromJson(json);
+}
+
+/// 盘点任务列表响应数据
+@freezed
+class InventoryTaskListData with _$InventoryTaskListData {
+  const factory InventoryTaskListData({
+    @JsonKey(name: 'rows')
+    @Default(<InventoryTaskSummary>[])
+    List<InventoryTaskSummary> rows,
+    @JsonKey(name: 'total') @Default(0) int total,
+  }) = _InventoryTaskListData;
+
+  factory InventoryTaskListData.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskListDataFromJson(json);
+}

--- a/lib/modules/aswh_inventory/task_list/models/inventory_task.freezed.dart
+++ b/lib/modules/aswh_inventory/task_list/models/inventory_task.freezed.dart
@@ -1,0 +1,916 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_task.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+InventoryTaskFilter _$InventoryTaskFilterFromJson(Map<String, dynamic> json) {
+  return _InventoryTaskFilter.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskFilter {
+  /// 排序方向
+  @JsonKey(name: 'sortType')
+  String get sortType => throw _privateConstructorUsedError;
+
+  /// 排序字段
+  @JsonKey(name: 'sortColumn')
+  String get sortColumn => throw _privateConstructorUsedError;
+
+  /// 搜索关键字（支持扫码输入任务号/盘库单号）
+  @JsonKey(name: 'searchKey')
+  String get searchKey => throw _privateConstructorUsedError;
+
+  /// 用户ID（字符串，兼容接口入参）
+  @JsonKey(name: 'userId')
+  String get userId => throw _privateConstructorUsedError;
+
+  /// 角色或用户ID（接口字段名为 roleoRuserId）
+  @JsonKey(name: 'roleoRuserId')
+  String get roleOrUserId => throw _privateConstructorUsedError;
+
+  /// 库房标签（1 表示立库）
+  @JsonKey(name: 'roomTag')
+  String get roomTag => throw _privateConstructorUsedError;
+
+  /// 完成标识（0-未完成，1-全部）
+  @JsonKey(name: 'finshFlg')
+  String get finishFlag => throw _privateConstructorUsedError;
+
+  /// 当前页码（接口使用 PageIndex 字段，1 开始）
+  @JsonKey(name: 'PageIndex')
+  int get pageIndex => throw _privateConstructorUsedError;
+
+  /// 每页条目数量
+  @JsonKey(name: 'PageSize')
+  int get pageSize => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskFilterCopyWith<InventoryTaskFilter> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskFilterCopyWith<$Res> {
+  factory $InventoryTaskFilterCopyWith(
+          InventoryTaskFilter value, $Res Function(InventoryTaskFilter) then) =
+      _$InventoryTaskFilterCopyWithImpl<$Res, InventoryTaskFilter>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'sortType') String sortType,
+      @JsonKey(name: 'sortColumn') String sortColumn,
+      @JsonKey(name: 'searchKey') String searchKey,
+      @JsonKey(name: 'userId') String userId,
+      @JsonKey(name: 'roleoRuserId') String roleOrUserId,
+      @JsonKey(name: 'roomTag') String roomTag,
+      @JsonKey(name: 'finshFlg') String finishFlag,
+      @JsonKey(name: 'PageIndex') int pageIndex,
+      @JsonKey(name: 'PageSize') int pageSize});
+}
+
+/// @nodoc
+class _$InventoryTaskFilterCopyWithImpl<$Res, $Val extends InventoryTaskFilter>
+    implements $InventoryTaskFilterCopyWith<$Res> {
+  _$InventoryTaskFilterCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sortType = null,
+    Object? sortColumn = null,
+    Object? searchKey = null,
+    Object? userId = null,
+    Object? roleOrUserId = null,
+    Object? roomTag = null,
+    Object? finishFlag = null,
+    Object? pageIndex = null,
+    Object? pageSize = null,
+  }) {
+    return _then(_value.copyWith(
+      sortType: null == sortType
+          ? _value.sortType
+          : sortType // ignore: cast_nullable_to_non_nullable
+              as String,
+      sortColumn: null == sortColumn
+          ? _value.sortColumn
+          : sortColumn // ignore: cast_nullable_to_non_nullable
+              as String,
+      searchKey: null == searchKey
+          ? _value.searchKey
+          : searchKey // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roleOrUserId: null == roleOrUserId
+          ? _value.roleOrUserId
+          : roleOrUserId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roomTag: null == roomTag
+          ? _value.roomTag
+          : roomTag // ignore: cast_nullable_to_non_nullable
+              as String,
+      finishFlag: null == finishFlag
+          ? _value.finishFlag
+          : finishFlag // ignore: cast_nullable_to_non_nullable
+              as String,
+      pageIndex: null == pageIndex
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+      pageSize: null == pageSize
+          ? _value.pageSize
+          : pageSize // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskFilterImplCopyWith<$Res>
+    implements $InventoryTaskFilterCopyWith<$Res> {
+  factory _$$InventoryTaskFilterImplCopyWith(_$InventoryTaskFilterImpl value,
+          $Res Function(_$InventoryTaskFilterImpl) then) =
+      __$$InventoryTaskFilterImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'sortType') String sortType,
+      @JsonKey(name: 'sortColumn') String sortColumn,
+      @JsonKey(name: 'searchKey') String searchKey,
+      @JsonKey(name: 'userId') String userId,
+      @JsonKey(name: 'roleoRuserId') String roleOrUserId,
+      @JsonKey(name: 'roomTag') String roomTag,
+      @JsonKey(name: 'finshFlg') String finishFlag,
+      @JsonKey(name: 'PageIndex') int pageIndex,
+      @JsonKey(name: 'PageSize') int pageSize});
+}
+
+/// @nodoc
+class __$$InventoryTaskFilterImplCopyWithImpl<$Res>
+    extends _$InventoryTaskFilterCopyWithImpl<$Res, _$InventoryTaskFilterImpl>
+    implements _$$InventoryTaskFilterImplCopyWith<$Res> {
+  __$$InventoryTaskFilterImplCopyWithImpl(_$InventoryTaskFilterImpl _value,
+      $Res Function(_$InventoryTaskFilterImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sortType = null,
+    Object? sortColumn = null,
+    Object? searchKey = null,
+    Object? userId = null,
+    Object? roleOrUserId = null,
+    Object? roomTag = null,
+    Object? finishFlag = null,
+    Object? pageIndex = null,
+    Object? pageSize = null,
+  }) {
+    return _then(_$InventoryTaskFilterImpl(
+      sortType: null == sortType
+          ? _value.sortType
+          : sortType // ignore: cast_nullable_to_non_nullable
+              as String,
+      sortColumn: null == sortColumn
+          ? _value.sortColumn
+          : sortColumn // ignore: cast_nullable_to_non_nullable
+              as String,
+      searchKey: null == searchKey
+          ? _value.searchKey
+          : searchKey // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roleOrUserId: null == roleOrUserId
+          ? _value.roleOrUserId
+          : roleOrUserId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roomTag: null == roomTag
+          ? _value.roomTag
+          : roomTag // ignore: cast_nullable_to_non_nullable
+              as String,
+      finishFlag: null == finishFlag
+          ? _value.finishFlag
+          : finishFlag // ignore: cast_nullable_to_non_nullable
+              as String,
+      pageIndex: null == pageIndex
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+      pageSize: null == pageSize
+          ? _value.pageSize
+          : pageSize // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskFilterImpl implements _InventoryTaskFilter {
+  const _$InventoryTaskFilterImpl(
+      {@JsonKey(name: 'sortType') this.sortType = 'desc',
+      @JsonKey(name: 'sortColumn') this.sortColumn = 'createdate',
+      @JsonKey(name: 'searchKey') this.searchKey = '',
+      @JsonKey(name: 'userId') required this.userId,
+      @JsonKey(name: 'roleoRuserId') required this.roleOrUserId,
+      @JsonKey(name: 'roomTag') this.roomTag = '1',
+      @JsonKey(name: 'finshFlg') this.finishFlag = '0',
+      @JsonKey(name: 'PageIndex') this.pageIndex = 1,
+      @JsonKey(name: 'PageSize') this.pageSize = 100});
+
+  factory _$InventoryTaskFilterImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskFilterImplFromJson(json);
+
+  /// 排序方向
+  @override
+  @JsonKey(name: 'sortType')
+  final String sortType;
+
+  /// 排序字段
+  @override
+  @JsonKey(name: 'sortColumn')
+  final String sortColumn;
+
+  /// 搜索关键字（支持扫码输入任务号/盘库单号）
+  @override
+  @JsonKey(name: 'searchKey')
+  final String searchKey;
+
+  /// 用户ID（字符串，兼容接口入参）
+  @override
+  @JsonKey(name: 'userId')
+  final String userId;
+
+  /// 角色或用户ID（接口字段名为 roleoRuserId）
+  @override
+  @JsonKey(name: 'roleoRuserId')
+  final String roleOrUserId;
+
+  /// 库房标签（1 表示立库）
+  @override
+  @JsonKey(name: 'roomTag')
+  final String roomTag;
+
+  /// 完成标识（0-未完成，1-全部）
+  @override
+  @JsonKey(name: 'finshFlg')
+  final String finishFlag;
+
+  /// 当前页码（接口使用 PageIndex 字段，1 开始）
+  @override
+  @JsonKey(name: 'PageIndex')
+  final int pageIndex;
+
+  /// 每页条目数量
+  @override
+  @JsonKey(name: 'PageSize')
+  final int pageSize;
+
+  @override
+  String toString() {
+    return 'InventoryTaskFilter(sortType: $sortType, sortColumn: $sortColumn, searchKey: $searchKey, userId: $userId, roleOrUserId: $roleOrUserId, roomTag: $roomTag, finishFlag: $finishFlag, pageIndex: $pageIndex, pageSize: $pageSize)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskFilterImpl &&
+            (identical(other.sortType, sortType) ||
+                other.sortType == sortType) &&
+            (identical(other.sortColumn, sortColumn) ||
+                other.sortColumn == sortColumn) &&
+            (identical(other.searchKey, searchKey) ||
+                other.searchKey == searchKey) &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.roleOrUserId, roleOrUserId) ||
+                other.roleOrUserId == roleOrUserId) &&
+            (identical(other.roomTag, roomTag) || other.roomTag == roomTag) &&
+            (identical(other.finishFlag, finishFlag) ||
+                other.finishFlag == finishFlag) &&
+            (identical(other.pageIndex, pageIndex) ||
+                other.pageIndex == pageIndex) &&
+            (identical(other.pageSize, pageSize) ||
+                other.pageSize == pageSize));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, sortType, sortColumn, searchKey,
+      userId, roleOrUserId, roomTag, finishFlag, pageIndex, pageSize);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskFilterImplCopyWith<_$InventoryTaskFilterImpl> get copyWith =>
+      __$$InventoryTaskFilterImplCopyWithImpl<_$InventoryTaskFilterImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskFilterImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskFilter implements InventoryTaskFilter {
+  const factory _InventoryTaskFilter(
+          {@JsonKey(name: 'sortType') final String sortType,
+          @JsonKey(name: 'sortColumn') final String sortColumn,
+          @JsonKey(name: 'searchKey') final String searchKey,
+          @JsonKey(name: 'userId') required final String userId,
+          @JsonKey(name: 'roleoRuserId') required final String roleOrUserId,
+          @JsonKey(name: 'roomTag') final String roomTag,
+          @JsonKey(name: 'finshFlg') final String finishFlag,
+          @JsonKey(name: 'PageIndex') final int pageIndex,
+          @JsonKey(name: 'PageSize') final int pageSize}) =
+      _$InventoryTaskFilterImpl;
+
+  factory _InventoryTaskFilter.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskFilterImpl.fromJson;
+
+  @override
+
+  /// 排序方向
+  @JsonKey(name: 'sortType')
+  String get sortType;
+  @override
+
+  /// 排序字段
+  @JsonKey(name: 'sortColumn')
+  String get sortColumn;
+  @override
+
+  /// 搜索关键字（支持扫码输入任务号/盘库单号）
+  @JsonKey(name: 'searchKey')
+  String get searchKey;
+  @override
+
+  /// 用户ID（字符串，兼容接口入参）
+  @JsonKey(name: 'userId')
+  String get userId;
+  @override
+
+  /// 角色或用户ID（接口字段名为 roleoRuserId）
+  @JsonKey(name: 'roleoRuserId')
+  String get roleOrUserId;
+  @override
+
+  /// 库房标签（1 表示立库）
+  @JsonKey(name: 'roomTag')
+  String get roomTag;
+  @override
+
+  /// 完成标识（0-未完成，1-全部）
+  @JsonKey(name: 'finshFlg')
+  String get finishFlag;
+  @override
+
+  /// 当前页码（接口使用 PageIndex 字段，1 开始）
+  @JsonKey(name: 'PageIndex')
+  int get pageIndex;
+  @override
+
+  /// 每页条目数量
+  @JsonKey(name: 'PageSize')
+  int get pageSize;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskFilterImplCopyWith<_$InventoryTaskFilterImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventoryTaskSummary _$InventoryTaskSummaryFromJson(Map<String, dynamic> json) {
+  return _InventoryTaskSummary.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskSummary {
+  /// 盘库单号
+  @JsonKey(name: 'taskcomment')
+  String get taskComment => throw _privateConstructorUsedError;
+
+  /// 库房号
+  @JsonKey(name: 'storeroomno')
+  String get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 库房名称
+  @JsonKey(name: 'storeroomname')
+  String get storeRoomName => throw _privateConstructorUsedError;
+
+  /// 任务号
+  @JsonKey(name: 'checktaskno')
+  String get checkTaskNo => throw _privateConstructorUsedError;
+
+  /// 任务ID
+  @JsonKey(name: 'checktaskid')
+  int? get checkTaskId => throw _privateConstructorUsedError;
+
+  /// 状态描述
+  @JsonKey(name: 'status')
+  String? get status => throw _privateConstructorUsedError;
+
+  /// 工位/拣选位
+  @JsonKey(name: 'workstation')
+  String? get workStation => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskSummaryCopyWith<InventoryTaskSummary> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskSummaryCopyWith<$Res> {
+  factory $InventoryTaskSummaryCopyWith(InventoryTaskSummary value,
+          $Res Function(InventoryTaskSummary) then) =
+      _$InventoryTaskSummaryCopyWithImpl<$Res, InventoryTaskSummary>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskcomment') String taskComment,
+      @JsonKey(name: 'storeroomno') String storeRoomNo,
+      @JsonKey(name: 'storeroomname') String storeRoomName,
+      @JsonKey(name: 'checktaskno') String checkTaskNo,
+      @JsonKey(name: 'checktaskid') int? checkTaskId,
+      @JsonKey(name: 'status') String? status,
+      @JsonKey(name: 'workstation') String? workStation});
+}
+
+/// @nodoc
+class _$InventoryTaskSummaryCopyWithImpl<$Res,
+        $Val extends InventoryTaskSummary>
+    implements $InventoryTaskSummaryCopyWith<$Res> {
+  _$InventoryTaskSummaryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskComment = null,
+    Object? storeRoomNo = null,
+    Object? storeRoomName = null,
+    Object? checkTaskNo = null,
+    Object? checkTaskId = freezed,
+    Object? status = freezed,
+    Object? workStation = freezed,
+  }) {
+    return _then(_value.copyWith(
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: null == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomName: null == storeRoomName
+          ? _value.storeRoomName
+          : storeRoomName // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskNo: null == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskId: freezed == checkTaskId
+          ? _value.checkTaskId
+          : checkTaskId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      status: freezed == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as String?,
+      workStation: freezed == workStation
+          ? _value.workStation
+          : workStation // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskSummaryImplCopyWith<$Res>
+    implements $InventoryTaskSummaryCopyWith<$Res> {
+  factory _$$InventoryTaskSummaryImplCopyWith(_$InventoryTaskSummaryImpl value,
+          $Res Function(_$InventoryTaskSummaryImpl) then) =
+      __$$InventoryTaskSummaryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskcomment') String taskComment,
+      @JsonKey(name: 'storeroomno') String storeRoomNo,
+      @JsonKey(name: 'storeroomname') String storeRoomName,
+      @JsonKey(name: 'checktaskno') String checkTaskNo,
+      @JsonKey(name: 'checktaskid') int? checkTaskId,
+      @JsonKey(name: 'status') String? status,
+      @JsonKey(name: 'workstation') String? workStation});
+}
+
+/// @nodoc
+class __$$InventoryTaskSummaryImplCopyWithImpl<$Res>
+    extends _$InventoryTaskSummaryCopyWithImpl<$Res, _$InventoryTaskSummaryImpl>
+    implements _$$InventoryTaskSummaryImplCopyWith<$Res> {
+  __$$InventoryTaskSummaryImplCopyWithImpl(_$InventoryTaskSummaryImpl _value,
+      $Res Function(_$InventoryTaskSummaryImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskComment = null,
+    Object? storeRoomNo = null,
+    Object? storeRoomName = null,
+    Object? checkTaskNo = null,
+    Object? checkTaskId = freezed,
+    Object? status = freezed,
+    Object? workStation = freezed,
+  }) {
+    return _then(_$InventoryTaskSummaryImpl(
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: null == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomName: null == storeRoomName
+          ? _value.storeRoomName
+          : storeRoomName // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskNo: null == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskId: freezed == checkTaskId
+          ? _value.checkTaskId
+          : checkTaskId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      status: freezed == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as String?,
+      workStation: freezed == workStation
+          ? _value.workStation
+          : workStation // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskSummaryImpl implements _InventoryTaskSummary {
+  const _$InventoryTaskSummaryImpl(
+      {@JsonKey(name: 'taskcomment') required this.taskComment,
+      @JsonKey(name: 'storeroomno') required this.storeRoomNo,
+      @JsonKey(name: 'storeroomname') required this.storeRoomName,
+      @JsonKey(name: 'checktaskno') required this.checkTaskNo,
+      @JsonKey(name: 'checktaskid') this.checkTaskId,
+      @JsonKey(name: 'status') this.status,
+      @JsonKey(name: 'workstation') this.workStation});
+
+  factory _$InventoryTaskSummaryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskSummaryImplFromJson(json);
+
+  /// 盘库单号
+  @override
+  @JsonKey(name: 'taskcomment')
+  final String taskComment;
+
+  /// 库房号
+  @override
+  @JsonKey(name: 'storeroomno')
+  final String storeRoomNo;
+
+  /// 库房名称
+  @override
+  @JsonKey(name: 'storeroomname')
+  final String storeRoomName;
+
+  /// 任务号
+  @override
+  @JsonKey(name: 'checktaskno')
+  final String checkTaskNo;
+
+  /// 任务ID
+  @override
+  @JsonKey(name: 'checktaskid')
+  final int? checkTaskId;
+
+  /// 状态描述
+  @override
+  @JsonKey(name: 'status')
+  final String? status;
+
+  /// 工位/拣选位
+  @override
+  @JsonKey(name: 'workstation')
+  final String? workStation;
+
+  @override
+  String toString() {
+    return 'InventoryTaskSummary(taskComment: $taskComment, storeRoomNo: $storeRoomNo, storeRoomName: $storeRoomName, checkTaskNo: $checkTaskNo, checkTaskId: $checkTaskId, status: $status, workStation: $workStation)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskSummaryImpl &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeRoomName, storeRoomName) ||
+                other.storeRoomName == storeRoomName) &&
+            (identical(other.checkTaskNo, checkTaskNo) ||
+                other.checkTaskNo == checkTaskNo) &&
+            (identical(other.checkTaskId, checkTaskId) ||
+                other.checkTaskId == checkTaskId) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.workStation, workStation) ||
+                other.workStation == workStation));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, taskComment, storeRoomNo,
+      storeRoomName, checkTaskNo, checkTaskId, status, workStation);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskSummaryImplCopyWith<_$InventoryTaskSummaryImpl>
+      get copyWith =>
+          __$$InventoryTaskSummaryImplCopyWithImpl<_$InventoryTaskSummaryImpl>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskSummaryImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskSummary implements InventoryTaskSummary {
+  const factory _InventoryTaskSummary(
+          {@JsonKey(name: 'taskcomment') required final String taskComment,
+          @JsonKey(name: 'storeroomno') required final String storeRoomNo,
+          @JsonKey(name: 'storeroomname') required final String storeRoomName,
+          @JsonKey(name: 'checktaskno') required final String checkTaskNo,
+          @JsonKey(name: 'checktaskid') final int? checkTaskId,
+          @JsonKey(name: 'status') final String? status,
+          @JsonKey(name: 'workstation') final String? workStation}) =
+      _$InventoryTaskSummaryImpl;
+
+  factory _InventoryTaskSummary.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskSummaryImpl.fromJson;
+
+  @override
+
+  /// 盘库单号
+  @JsonKey(name: 'taskcomment')
+  String get taskComment;
+  @override
+
+  /// 库房号
+  @JsonKey(name: 'storeroomno')
+  String get storeRoomNo;
+  @override
+
+  /// 库房名称
+  @JsonKey(name: 'storeroomname')
+  String get storeRoomName;
+  @override
+
+  /// 任务号
+  @JsonKey(name: 'checktaskno')
+  String get checkTaskNo;
+  @override
+
+  /// 任务ID
+  @JsonKey(name: 'checktaskid')
+  int? get checkTaskId;
+  @override
+
+  /// 状态描述
+  @JsonKey(name: 'status')
+  String? get status;
+  @override
+
+  /// 工位/拣选位
+  @JsonKey(name: 'workstation')
+  String? get workStation;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskSummaryImplCopyWith<_$InventoryTaskSummaryImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+InventoryTaskListData _$InventoryTaskListDataFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryTaskListData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskListData {
+  @JsonKey(name: 'rows')
+  List<InventoryTaskSummary> get rows => throw _privateConstructorUsedError;
+  @JsonKey(name: 'total')
+  int get total => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskListDataCopyWith<InventoryTaskListData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskListDataCopyWith<$Res> {
+  factory $InventoryTaskListDataCopyWith(InventoryTaskListData value,
+          $Res Function(InventoryTaskListData) then) =
+      _$InventoryTaskListDataCopyWithImpl<$Res, InventoryTaskListData>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'rows') List<InventoryTaskSummary> rows,
+      @JsonKey(name: 'total') int total});
+}
+
+/// @nodoc
+class _$InventoryTaskListDataCopyWithImpl<$Res,
+        $Val extends InventoryTaskListData>
+    implements $InventoryTaskListDataCopyWith<$Res> {
+  _$InventoryTaskListDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? rows = null,
+    Object? total = null,
+  }) {
+    return _then(_value.copyWith(
+      rows: null == rows
+          ? _value.rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTaskSummary>,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskListDataImplCopyWith<$Res>
+    implements $InventoryTaskListDataCopyWith<$Res> {
+  factory _$$InventoryTaskListDataImplCopyWith(
+          _$InventoryTaskListDataImpl value,
+          $Res Function(_$InventoryTaskListDataImpl) then) =
+      __$$InventoryTaskListDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'rows') List<InventoryTaskSummary> rows,
+      @JsonKey(name: 'total') int total});
+}
+
+/// @nodoc
+class __$$InventoryTaskListDataImplCopyWithImpl<$Res>
+    extends _$InventoryTaskListDataCopyWithImpl<$Res,
+        _$InventoryTaskListDataImpl>
+    implements _$$InventoryTaskListDataImplCopyWith<$Res> {
+  __$$InventoryTaskListDataImplCopyWithImpl(_$InventoryTaskListDataImpl _value,
+      $Res Function(_$InventoryTaskListDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? rows = null,
+    Object? total = null,
+  }) {
+    return _then(_$InventoryTaskListDataImpl(
+      rows: null == rows
+          ? _value._rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTaskSummary>,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskListDataImpl implements _InventoryTaskListData {
+  const _$InventoryTaskListDataImpl(
+      {@JsonKey(name: 'rows')
+      final List<InventoryTaskSummary> rows = const <InventoryTaskSummary>[],
+      @JsonKey(name: 'total') this.total = 0})
+      : _rows = rows;
+
+  factory _$InventoryTaskListDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskListDataImplFromJson(json);
+
+  final List<InventoryTaskSummary> _rows;
+  @override
+  @JsonKey(name: 'rows')
+  List<InventoryTaskSummary> get rows {
+    if (_rows is EqualUnmodifiableListView) return _rows;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_rows);
+  }
+
+  @override
+  @JsonKey(name: 'total')
+  final int total;
+
+  @override
+  String toString() {
+    return 'InventoryTaskListData(rows: $rows, total: $total)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskListDataImpl &&
+            const DeepCollectionEquality().equals(other._rows, _rows) &&
+            (identical(other.total, total) || other.total == total));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_rows), total);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskListDataImplCopyWith<_$InventoryTaskListDataImpl>
+      get copyWith => __$$InventoryTaskListDataImplCopyWithImpl<
+          _$InventoryTaskListDataImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskListDataImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskListData implements InventoryTaskListData {
+  const factory _InventoryTaskListData(
+      {@JsonKey(name: 'rows') final List<InventoryTaskSummary> rows,
+      @JsonKey(name: 'total') final int total}) = _$InventoryTaskListDataImpl;
+
+  factory _InventoryTaskListData.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskListDataImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'rows')
+  List<InventoryTaskSummary> get rows;
+  @override
+  @JsonKey(name: 'total')
+  int get total;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskListDataImplCopyWith<_$InventoryTaskListDataImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/aswh_inventory/task_list/models/inventory_task.g.dart
+++ b/lib/modules/aswh_inventory/task_list/models/inventory_task.g.dart
@@ -1,0 +1,77 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_task.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryTaskFilterImpl _$$InventoryTaskFilterImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskFilterImpl(
+      sortType: json['sortType'] as String? ?? 'desc',
+      sortColumn: json['sortColumn'] as String? ?? 'createdate',
+      searchKey: json['searchKey'] as String? ?? '',
+      userId: json['userId'] as String,
+      roleOrUserId: json['roleoRuserId'] as String,
+      roomTag: json['roomTag'] as String? ?? '1',
+      finishFlag: json['finshFlg'] as String? ?? '0',
+      pageIndex: (json['PageIndex'] as num?)?.toInt() ?? 1,
+      pageSize: (json['PageSize'] as num?)?.toInt() ?? 100,
+    );
+
+Map<String, dynamic> _$$InventoryTaskFilterImplToJson(
+        _$InventoryTaskFilterImpl instance) =>
+    <String, dynamic>{
+      'sortType': instance.sortType,
+      'sortColumn': instance.sortColumn,
+      'searchKey': instance.searchKey,
+      'userId': instance.userId,
+      'roleoRuserId': instance.roleOrUserId,
+      'roomTag': instance.roomTag,
+      'finshFlg': instance.finishFlag,
+      'PageIndex': instance.pageIndex,
+      'PageSize': instance.pageSize,
+    };
+
+_$InventoryTaskSummaryImpl _$$InventoryTaskSummaryImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskSummaryImpl(
+      taskComment: json['taskcomment'] as String,
+      storeRoomNo: json['storeroomno'] as String,
+      storeRoomName: json['storeroomname'] as String,
+      checkTaskNo: json['checktaskno'] as String,
+      checkTaskId: (json['checktaskid'] as num?)?.toInt(),
+      status: json['status'] as String?,
+      workStation: json['workstation'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryTaskSummaryImplToJson(
+        _$InventoryTaskSummaryImpl instance) =>
+    <String, dynamic>{
+      'taskcomment': instance.taskComment,
+      'storeroomno': instance.storeRoomNo,
+      'storeroomname': instance.storeRoomName,
+      'checktaskno': instance.checkTaskNo,
+      'checktaskid': instance.checkTaskId,
+      'status': instance.status,
+      'workstation': instance.workStation,
+    };
+
+_$InventoryTaskListDataImpl _$$InventoryTaskListDataImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskListDataImpl(
+      rows: (json['rows'] as List<dynamic>?)
+              ?.map((e) =>
+                  InventoryTaskSummary.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <InventoryTaskSummary>[],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$$InventoryTaskListDataImplToJson(
+        _$InventoryTaskListDataImpl instance) =>
+    <String, dynamic>{
+      'rows': instance.rows,
+      'total': instance.total,
+    };

--- a/lib/modules/aswh_inventory/task_receive/aswh_inventory_receive_page.dart
+++ b/lib/modules/aswh_inventory/task_receive/aswh_inventory_receive_page.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/common_widgets/custom_app_bar.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+
+import '../task_list/models/inventory_task.dart';
+import 'bloc/aswh_inventory_receive_bloc.dart';
+import 'bloc/aswh_inventory_receive_event.dart';
+import 'bloc/aswh_inventory_receive_state.dart';
+import 'config/aswh_inventory_receive_grid_config.dart';
+
+const _pageBackground = Color(0xFFF6F6F6);
+
+class AswhInventoryReceivePage extends StatefulWidget {
+  const AswhInventoryReceivePage({super.key});
+
+  @override
+  State<AswhInventoryReceivePage> createState() =>
+      _AswhInventoryReceivePageState();
+}
+
+class _AswhInventoryReceivePageState
+    extends State<AswhInventoryReceivePage> {
+  late final AswhInventoryReceiveBloc _bloc;
+  late final CommonDataGridBloc<InventoryTaskSummary> _gridBloc;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<AswhInventoryReceiveBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+    _bloc.add(const AswhInventoryReceiveStarted());
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AswhInventoryReceiveBloc, AswhInventoryReceiveState>(
+      listener: (context, state) {
+        if (state.status == InventoryReceiveStatus.actionInProgress) {
+          LoadingDialogManager.instance.showLoadingDialog(
+            context,
+            text: '处理中...',
+          );
+        } else if (state.status != InventoryReceiveStatus.loading) {
+          LoadingDialogManager.instance.hideLoadingDialog(context);
+        }
+
+        if (state.status == InventoryReceiveStatus.failure &&
+            state.message != null) {
+          LoadingDialogManager.instance.showErrorDialog(
+            context,
+            state.message!,
+          );
+        }
+
+        if ((state.status == InventoryReceiveStatus.success ||
+                state.status == InventoryReceiveStatus.actionSuccess) &&
+            state.message != null &&
+            state.message!.isNotEmpty) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(content: Text(state.message!)));
+        }
+
+        if (state.status == InventoryReceiveStatus.actionSuccess) {
+          _scannerController.clear();
+          _scannerController.requestFocus();
+        }
+      },
+      child: Scaffold(
+        backgroundColor: _pageBackground,
+        appBar: CustomAppBar(
+          title: '立库盘点接收',
+          onBackPressed: () => Modular.to.pop(),
+        ).appBar,
+        body: Column(
+          children: [
+            _buildScanner(),
+            Expanded(child: _buildDataGrid()),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '请扫描单号',
+      clearOnSubmit: true,
+      autoFocus: true,
+    );
+
+    return ScannerWidget(
+      config: config,
+      controller: _scannerController,
+      onScanResult: (value) =>
+          _bloc.add(AswhInventoryReceiveScanCaptured(value)),
+      onError: (message) {
+        LoadingDialogManager.instance.showErrorDialog(context, message);
+      },
+      suffix: IconButton(
+        icon: SvgPicture.asset('assets/images/icon_filter.svg'),
+        onPressed: () async {
+          final controller = TextEditingController(
+            text: _bloc.state.filter.searchKey,
+          );
+          final searchKey = await showDialog<String>(
+            context: context,
+            builder: (context) {
+              return AlertDialog(
+                title: const Text('输入查询关键字'),
+                content: TextField(
+                  controller: controller,
+                  decoration: const InputDecoration(hintText: '请输入盘库单号/任务号'),
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('取消'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () =>
+                        Navigator.of(context).pop(controller.text.trim()),
+                    child: const Text('查询'),
+                  ),
+                ],
+              );
+            },
+          );
+          if (searchKey != null) {
+            _bloc.add(AswhInventoryReceiveSearchSubmitted(searchKey));
+          }
+        },
+      ),
+    );
+  }
+
+  Widget _buildDataGrid() {
+    return BlocProvider.value(
+      value: _gridBloc,
+      child: BlocConsumer<
+          CommonDataGridBloc<InventoryTaskSummary>,
+          CommonDataGridState<InventoryTaskSummary>>(
+        listener: (context, state) {
+          if (state.status == GridStatus.loading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+
+          if (state.status == GridStatus.error) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.errorMessage ?? '数据加载失败',
+            );
+          }
+        },
+        builder: (context, state) {
+          return CommonDataGrid<InventoryTaskSummary>(
+            columns: AswhInventoryReceiveGridConfig.columns((task) {
+              _confirmReceive(task);
+            }),
+            datas: state.data,
+            currentPage: state.currentPage,
+            totalPages: state.totalPages,
+            onLoadData: (pageIndex) async {
+              _bloc.add(AswhInventoryReceivePageChanged(pageIndex));
+            },
+            selectedRows: const [],
+            allowPager: true,
+            allowSelect: false,
+            headerHeight: 44,
+            rowHeight: 48,
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _confirmReceive(InventoryTaskSummary task) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('接收确认'),
+          content: const Text('是否执行接收操作?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('确认'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed == true) {
+      _bloc.add(AswhInventoryReceiveConfirmed(task));
+    }
+  }
+}

--- a/lib/modules/aswh_inventory/task_receive/bloc/aswh_inventory_receive_bloc.dart
+++ b/lib/modules/aswh_inventory/task_receive/bloc/aswh_inventory_receive_bloc.dart
@@ -1,0 +1,208 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:meta/meta.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+import '../../services/aswh_inventory_task_service.dart';
+import '../../task_list/models/inventory_task.dart';
+import 'aswh_inventory_receive_event.dart';
+import 'aswh_inventory_receive_state.dart';
+
+@immutable
+class AswhInventoryReceiveBloc
+    extends Bloc<AswhInventoryReceiveEvent, AswhInventoryReceiveState> {
+  AswhInventoryReceiveBloc({
+    required AswhInventoryTaskService taskService,
+    required UserManager userManager,
+  })  : _taskService = taskService,
+        _userManager = userManager,
+        super(
+          AswhInventoryReceiveState(
+            filter: InventoryTaskFilter(
+              userId: 'ALL',
+              roleOrUserId: '${userManager.userInfo?.userId ?? ''}',
+            ),
+          ),
+        ) {
+    on<AswhInventoryReceiveStarted>(_onStarted);
+    on<AswhInventoryReceiveSearchSubmitted>(_onSearchSubmitted);
+    on<AswhInventoryReceiveScanCaptured>(_onScanCaptured);
+    on<AswhInventoryReceivePageChanged>(_onPageChanged);
+    on<AswhInventoryReceiveConfirmed>(_onReceiveConfirmed);
+
+    _gridBloc = CommonDataGridBloc<InventoryTaskSummary>(
+      dataLoader: _createDataLoader(),
+    );
+  }
+
+  final AswhInventoryTaskService _taskService;
+  final UserManager _userManager;
+
+  late final CommonDataGridBloc<InventoryTaskSummary> _gridBloc;
+  CommonDataGridBloc<InventoryTaskSummary> get gridBloc => _gridBloc;
+
+  int _latestTotalCount = 0;
+  bool _ignoreNextPageChange = false;
+
+  DataGridLoader<InventoryTaskSummary> _createDataLoader() {
+    return (pageIndex) async {
+      final filter = state.filter.copyWith(pageIndex: pageIndex);
+      final result = await _taskService.fetchInventoryTasks(filter: filter);
+      _latestTotalCount = result.total;
+      final totalPages = result.total == 0
+          ? 1
+          : (result.total / filter.pageSize).ceil().clamp(1, 999999);
+      return DataGridResponseData<InventoryTaskSummary>(
+        totalPages: totalPages,
+        data: result.rows,
+      );
+    };
+  }
+
+  Future<void> _onStarted(
+    AswhInventoryReceiveStarted event,
+    Emitter<AswhInventoryReceiveState> emit,
+  ) async {
+    _ignoreNextPageChange = true;
+    await _loadPage(emit, pageIndex: state.filter.pageIndex);
+  }
+
+  Future<void> _onSearchSubmitted(
+    AswhInventoryReceiveSearchSubmitted event,
+    Emitter<AswhInventoryReceiveState> emit,
+  ) async {
+    final updatedFilter = state.filter.copyWith(
+      searchKey: event.searchKey,
+      pageIndex: 1,
+    );
+    emit(state.copyWith(filter: updatedFilter));
+    await _loadPage(emit, pageIndex: 1);
+  }
+
+  Future<void> _onScanCaptured(
+    AswhInventoryReceiveScanCaptured event,
+    Emitter<AswhInventoryReceiveState> emit,
+  ) async {
+    if (event.scanContent.isEmpty) {
+      return;
+    }
+    final updatedFilter = state.filter.copyWith(
+      searchKey: event.scanContent,
+      pageIndex: 1,
+    );
+    emit(state.copyWith(filter: updatedFilter));
+    await _loadPage(emit, pageIndex: 1);
+  }
+
+  Future<void> _onPageChanged(
+    AswhInventoryReceivePageChanged event,
+    Emitter<AswhInventoryReceiveState> emit,
+  ) async {
+    if (_ignoreNextPageChange) {
+      _ignoreNextPageChange = false;
+      return;
+    }
+    emit(
+      state.copyWith(filter: state.filter.copyWith(pageIndex: event.pageIndex)),
+    );
+    await _loadPage(emit, pageIndex: event.pageIndex);
+  }
+
+  Future<void> _onReceiveConfirmed(
+    AswhInventoryReceiveConfirmed event,
+    Emitter<AswhInventoryReceiveState> emit,
+  ) async {
+    if (state.status == InventoryReceiveStatus.actionInProgress) {
+      return;
+    }
+    final userId = _userManager.userInfo?.userId;
+    if (userId == null || userId.toString().isEmpty) {
+      emit(
+        state.copyWith(
+          status: InventoryReceiveStatus.failure,
+          message: '用户信息缺失，请重新登录',
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: InventoryReceiveStatus.actionInProgress,
+        clearMessage: true,
+      ),
+    );
+    try {
+      await _taskService.cancelInventoryTask(
+        taskComment: event.task.taskComment,
+        userId: userId.toString(),
+        confirm: false,
+      );
+      await _loadPage(
+        emit,
+        pageIndex: state.filter.pageIndex,
+        successMessage: '单据接收成功',
+        successStatus: InventoryReceiveStatus.actionSuccess,
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryReceiveStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> _loadPage(
+    Emitter<AswhInventoryReceiveState> emit, {
+    required int pageIndex,
+    String? successMessage,
+    InventoryReceiveStatus successStatus = InventoryReceiveStatus.success,
+  }) async {
+    emit(
+      state.copyWith(
+        status: InventoryReceiveStatus.loading,
+        clearMessage: true,
+      ),
+    );
+
+    final completer = Completer<DataGridResponseData<InventoryTaskSummary>>();
+    _gridBloc.add(LoadDataEvent(pageIndex, completer: completer));
+
+    try {
+      final response = await completer.future;
+      final emptyMessage =
+          response.data.isEmpty ? '当前任务列表没有待处理任务！' : null;
+      final displayMessage = successMessage ?? emptyMessage;
+      emit(
+        state.copyWith(
+          status: successStatus,
+          tasks: response.data,
+          currentPage: pageIndex,
+          totalPages: response.totalPages,
+          total: _latestTotalCount,
+          filter: state.filter.copyWith(pageIndex: pageIndex),
+          message: displayMessage,
+          clearMessage: displayMessage == null,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryReceiveStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _gridBloc.close();
+    return super.close();
+  }
+}

--- a/lib/modules/aswh_inventory/task_receive/bloc/aswh_inventory_receive_event.dart
+++ b/lib/modules/aswh_inventory/task_receive/bloc/aswh_inventory_receive_event.dart
@@ -1,0 +1,56 @@
+import 'package:equatable/equatable.dart';
+
+import '../../task_list/models/inventory_task.dart';
+
+/// 立库盘点接收页事件定义
+abstract class AswhInventoryReceiveEvent extends Equatable {
+  const AswhInventoryReceiveEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// 页面初始化
+class AswhInventoryReceiveStarted extends AswhInventoryReceiveEvent {
+  const AswhInventoryReceiveStarted();
+}
+
+/// 文本框提交查询
+class AswhInventoryReceiveSearchSubmitted extends AswhInventoryReceiveEvent {
+  const AswhInventoryReceiveSearchSubmitted(this.searchKey);
+
+  final String searchKey;
+
+  @override
+  List<Object?> get props => [searchKey];
+}
+
+/// 扫码回调
+class AswhInventoryReceiveScanCaptured extends AswhInventoryReceiveEvent {
+  const AswhInventoryReceiveScanCaptured(this.scanContent);
+
+  final String scanContent;
+
+  @override
+  List<Object?> get props => [scanContent];
+}
+
+/// 分页切换
+class AswhInventoryReceivePageChanged extends AswhInventoryReceiveEvent {
+  const AswhInventoryReceivePageChanged(this.pageIndex);
+
+  final int pageIndex;
+
+  @override
+  List<Object?> get props => [pageIndex];
+}
+
+/// 执行接收确认
+class AswhInventoryReceiveConfirmed extends AswhInventoryReceiveEvent {
+  const AswhInventoryReceiveConfirmed(this.task);
+
+  final InventoryTaskSummary task;
+
+  @override
+  List<Object?> get props => [task];
+}

--- a/lib/modules/aswh_inventory/task_receive/bloc/aswh_inventory_receive_state.dart
+++ b/lib/modules/aswh_inventory/task_receive/bloc/aswh_inventory_receive_state.dart
@@ -1,0 +1,73 @@
+import 'package:equatable/equatable.dart';
+
+import '../../task_list/models/inventory_task.dart';
+
+/// 页面状态枚举
+enum InventoryReceiveStatus {
+  initial,
+  loading,
+  success,
+  failure,
+  actionInProgress,
+  actionSuccess,
+}
+
+/// 立库盘点接收页状态
+class AswhInventoryReceiveState extends Equatable {
+  const AswhInventoryReceiveState({
+    this.status = InventoryReceiveStatus.initial,
+    required this.filter,
+    this.tasks = const <InventoryTaskSummary>[],
+    this.selectedTask,
+    this.currentPage = 1,
+    this.totalPages = 1,
+    this.total = 0,
+    this.message,
+  });
+
+  final InventoryReceiveStatus status;
+  final InventoryTaskFilter filter;
+  final List<InventoryTaskSummary> tasks;
+  final InventoryTaskSummary? selectedTask;
+  final int currentPage;
+  final int totalPages;
+  final int total;
+  final String? message;
+
+  AswhInventoryReceiveState copyWith({
+    InventoryReceiveStatus? status,
+    InventoryTaskFilter? filter,
+    List<InventoryTaskSummary>? tasks,
+    InventoryTaskSummary? selectedTask,
+    bool clearSelectedTask = false,
+    int? currentPage,
+    int? totalPages,
+    int? total,
+    String? message,
+    bool clearMessage = false,
+  }) {
+    return AswhInventoryReceiveState(
+      status: status ?? this.status,
+      filter: filter ?? this.filter,
+      tasks: tasks ?? this.tasks,
+      selectedTask:
+          clearSelectedTask ? null : (selectedTask ?? this.selectedTask),
+      currentPage: currentPage ?? this.currentPage,
+      totalPages: totalPages ?? this.totalPages,
+      total: total ?? this.total,
+      message: clearMessage ? null : (message ?? this.message),
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        filter,
+        tasks,
+        selectedTask,
+        currentPage,
+        totalPages,
+        total,
+        message,
+      ];
+}

--- a/lib/modules/aswh_inventory/task_receive/config/aswh_inventory_receive_grid_config.dart
+++ b/lib/modules/aswh_inventory/task_receive/config/aswh_inventory_receive_grid_config.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../../../../common_widgets/common_grid/common_data_grid.dart';
+import '../../task_list/models/inventory_task.dart';
+
+typedef InventoryReceiveOperation = void Function(InventoryTaskSummary task);
+
+class AswhInventoryReceiveGridConfig {
+  static List<GridColumnConfig<InventoryTaskSummary>> columns(
+    InventoryReceiveOperation? onReceive,
+  ) {
+    return [
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'actions',
+        headerText: '操作',
+        width: 160,
+        cellBuilder: (task, columnName, cellValue) {
+          return Center(
+            child: SizedBox(
+              height: 32,
+              child: ElevatedButton(
+                onPressed: () => onReceive?.call(task),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF465CFF),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+                child: const Text('接收'),
+              ),
+            ),
+          );
+        },
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'taskComment',
+        headerText: '盘库单号',
+        width: 220,
+        valueGetter: (task) => task.taskComment,
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'storeRoomNo',
+        headerText: '库房号',
+        width: 140,
+        valueGetter: (task) => task.storeRoomNo,
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'storeRoomName',
+        headerText: '库房名称',
+        width: 240,
+        valueGetter: (task) => task.storeRoomName,
+      ),
+      GridColumnConfig<InventoryTaskSummary>(
+        name: 'checkTaskNo',
+        headerText: '任务号',
+        width: 200,
+        valueGetter: (task) => task.checkTaskNo,
+      ),
+    ];
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -596,10 +596,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -937,10 +937,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- add a scanner-enabled ASWH inventory pallet detail page with filtering, refresh, and handoff to resume single-tray dispatch when returning
- introduce pallet detail bloc/service/model wiring and register the route alongside a dedicated checkorder command route
- prompt users before command revokes and update the refactor TODO docs to reflect the completed pallet, collect, and command milestones

## Testing
- not run (flutter tooling unavailable)

------
https://chatgpt.com/codex/tasks/task_e_68f096fbb4d8833089567a2566fe74fc