### PR TITLE
feat: implement inventory task module

### DIFF
--- a/docs/inventory_task_refactor/task_collect_main_todo.md
+++ b/docs/inventory_task_refactor/task_collect_main_todo.md
@@ -1,0 +1,37 @@
+# 平库盘点采集页重构 TODO
+
+## 页面现状回顾
+- 采集页包含扫码输入、任务信息卡片、任务列表与“正在采集”双标签页，以及底部“采集结果 / 提交”操作栏。【F:GlodWind-Wms-App/pages/Inventorytask/task_collect/InventorytaskaskItem.nvue†L3-L210】【F:GlodWind-Wms-App/pages/Inventorytask/task_collect/InventorytaskaskItem.nvue†L360-L368】
+- 页面在 `onLoad` 中解析任务参数并调用 `getInventoryTaskItem` 获取盘点明细，同时注册扫码监听；离开页面或返回时需要校验是否存在未提交的采集记录。【F:GlodWind-Wms-App/pages/Inventorytask/task_collect/InventorytaskaskItem.nvue†L272-L321】
+- 采集数据支持本地缓存（`uni.setStorage`）与任务明细同步；扫描流程需按库位→物料二维码→数量顺序执行，内含大量校验和差异累计逻辑，并最终通过 `commitInventoryInfos` 提交盘点结果。【F:GlodWind-Wms-App/pages/Inventorytask/task_collect/InventorytaskaskItem.nvue†L236-L450】【F:GlodWind-Wms-App/pages/Inventorytask/task_collect/InventorytaskaskItem.nvue†L882-L954】【F:GlodWind-Wms-App/api/system/goodsDown.js†L246-L268】
+
+## Flutter 重构参考
+- UI 与交互可参考平库入库采集页的 Tab 切换、扫码聚焦、表格选择与底部操作栏模式，并复用 `ScannerWidget` 与 `CommonDataGrid`。【F:lib/modules/goods_up/collection_task/goods_up_collection_page.dart†L33-L188】
+- 采集结果弹窗/删除逻辑可对标入库模块的采集结果页，结合 `Navigator` 返回值更新主页面状态。【F:lib/modules/goods_up/collection_task/goods_up_collection_result_page.dart†L30-L188】
+- 数据模型建议使用 Freezed 定义：
+  - `InventoryCollectTaskItem`（盘点任务明细）
+  - `InventoryCollectStock`（采集结果项）
+  - `InventoryBarcodeContent`（二维码解析结果）
+  并参考出库/入库模块的 Freezed 模型定义和 JSON 映射方式。【F:lib/modules/outbound/task_list/models/outbound_task.dart†L7-L195】
+
+## TODO 列表
+- [x] 建立 `lib/modules/inventory_task/collection_task` 目录，拆分为页面、BLoC、状态/事件、模型、服务五个子目录，保持与入库模块一致结构。【F:lib/modules/goods_up/collection_task/goods_up_collection_page.dart†L11-L188】
+- [x] 编写 `InventoryCollectService`：封装 `getInventoryTaskItem`、`commitInventoryInfos`、库位校验及条码解析接口，并提供离线缓存同步（Hive/本地存储）。【F:GlodWind-Wms-App/api/system/goodsDown.js†L246-L268】
+- [x] 定义 Freezed 数据模型及序列化：任务明细、采集记录、提交请求、扫码内容等；确保字段覆盖 UniApp 中的物料编码、批次、序列号、库位等信息。【F:GlodWind-Wms-App/pages/Inventorytask/task_collect/InventorytaskaskItem.nvue†L236-L450】
+- [x] 构建 `InventoryCollectBloc` 状态机：
+  - 维护当前步骤（库位/物料/数量）与占位提示。
+  - 管理双标签数据集（待采集、正在采集）及选中行。
+  - 处理扫码事件、手动输入、数量累加、异常提示、离线缓存刷新。
+  - 支持从结果页返回后同步最新缓存。
+- [x] 实现 `InventoryCollectPage` UI：
+  - 顶部信息区域展示库房、库位、物料、数量等实时反馈。
+  - Tab 切换时刷新对应数据源，表格支持多选与选中回调。
+  - 底部按钮：进入采集结果页、提交采集数据（弹出确认对话框）。
+  - 监听返回事件，存在未提交数据时提示确认。
+- [x] 结果页交互：通过 `Navigator.push` 打开结果页面，支持删除采集记录并返回删除列表，由 BLoC 处理同步更新。
+- [x] 使用 `ScannerWidget` 控制焦点与清空输入，扫描异常时调用 `LoadingDialogManager` 弹出错误提示。【F:lib/modules/goods_up/collection_task/goods_up_collection_page.dart†L97-L188】
+- [x] 集成提交流程：
+  - 组装 `commitInventoryInfos` 请求体（任务备注、物料编码、批次、数量等）。
+  - 成功后清理缓存、重置状态并返回任务列表页。
+  - 失败时展示错误提示并保持当前采集数据。
+- [ ] 编写单元/集成测试：覆盖扫码流程、数量累加、提交成功/失败、离线缓存恢复及结果页回传删除等场景。

--- a/docs/inventory_task_refactor/task_collect_result_todo.md
+++ b/docs/inventory_task_refactor/task_collect_result_todo.md
@@ -1,0 +1,19 @@
+# 平库盘点采集结果页重构 TODO
+
+## 页面现状回顾
+- 结果页通过本地缓存加载采集记录，使用表格支持多选删除，并在底部导航栏提供删除操作按钮。【F:GlodWind-Wms-App/pages/Inventorytask/task_collect/InventorytaskCollectDetail.nvue†L3-L125】
+- 删除逻辑需要同步更新缓存中的采集结果与任务明细、回写 `collectdataqty` 数量，并维护 `checkedIds` 多选状态。【F:GlodWind-Wms-App/pages/Inventorytask/task_collect/InventorytaskCollectDetail.nvue†L127-L200】
+
+## Flutter 重构参考
+- 参考平库入库采集结果页的 `CommonDataGrid` + 底部删除栏模式，支持 PopScope 返回时回传删除数据。【F:lib/modules/goods_up/collection_task/goods_up_collection_result_page.dart†L30-L188】
+- 通过 Freezed 定义采集记录模型，便于与主采集页共享不可变数据与序列化能力。【F:lib/modules/outbound/task_list/models/outbound_task.dart†L7-L195】
+
+## TODO 列表
+- [x] 在 `collection_task` 模块内实现 `InventoryCollectResultPage`，接收初始采集记录与任务明细，使用 `CommonDataGrid` 展示并支持多选。
+- [x] 设计结果页状态（可使用 `StatefulWidget` 或配合 BLoC）以维护选中项、已删除缓存，并在用户确认时返回删除列表给主采集页处理。
+- [x] 删除流程：
+  - 根据选中记录更新 `collectdataqty`，同步主任务明细中的数量减少逻辑。
+  - 更新本地缓存（Hive/本地存储）中的采集结果与任务明细副本。
+  - 删除后刷新表格并清空选中状态。
+- [x] 提供无记录提示与空状态处理，防止在空列表时仍显示删除按钮。
+- [ ] 编写单元测试：验证删除操作更新数量、缓存同步与返回值传递逻辑。

--- a/docs/inventory_task_refactor/task_list_todo.md
+++ b/docs/inventory_task_refactor/task_list_todo.md
@@ -1,0 +1,23 @@
+# 平库盘点任务列表页重构 TODO
+
+## 页面现状回顾
+- UniApp 列表页使用顶部扫码输入、任务表格与分页组件，提供“采集”和“撤销”操作，同时右上角可跳转到接收页。【F:GlodWind-Wms-App/pages/Inventorytask/InventoryTask.nvue†L3-L164】
+- 任务数据通过 `getInventoryTask` 接口获取，并支持基于 `PageIndex`、`PageSize` 的分页查询；撤销操作调用 `commitInventoryTask`。【F:GlodWind-Wms-App/pages/Inventorytask/InventoryTask.nvue†L123-L189】【F:GlodWind-Wms-App/api/system/goodsDown.js†L224-L244】
+
+## Flutter 重构参考
+- 任务列表界面沿用 `CustomAppBar` + `ScannerWidget` + `CommonDataGrid` 组合模式，参考平库出库任务列表实现扫码、筛选与网格展示。【F:lib/modules/outbound/task_list/outbound_task_list_page.dart†L49-L173】
+- 任务数据模型与响应结构采用 Freezed 定义，参考 `OutboundTask` 与列表响应建模方式，方便序列化与不可变数据管理。【F:lib/modules/outbound/task_list/models/outbound_task.dart†L7-L195】
+- 服务层仿照出库模块的 Service+BLoC 组合，统一通过仓储接口管理分页加载与状态同步。【F:lib/modules/outbound/task_list/outbound_task_list_page.dart†L31-L170】
+
+## TODO 列表
+- [x] 建立 `lib/modules/inventory_task/task_list` 目录，配置 `InventoryTaskListPage` 与模块路由，复用 `CustomAppBar` 右上角入口跳转到盘点接收页。
+- [x] 编写 `InventoryTaskService` 列表方法，封装 `getInventoryTask` 与 `commitInventoryTask` 请求参数/响应解析逻辑，复用 Dio 客户端并处理分页入参（使用 Freezed 生成请求/响应模型）。【F:GlodWind-Wms-App/api/system/goodsDown.js†L224-L244】【F:lib/modules/outbound/task_list/models/outbound_task.dart†L7-L195】
+- [x] 定义 Freezed 模型：`InventoryTask`（任务行）、`InventoryTaskQuery`（查询参数）、`InventoryTaskListResponse`（接口响应）。字段映射遵循 UniApp 使用的列（任务号、库房、盘库单号等）。【F:GlodWind-Wms-App/pages/Inventorytask/InventoryTask.nvue†L22-L85】
+- [x] 基于 `CommonDataGridBloc` 建立 `InventoryTaskBloc`，实现分页加载、扫码过滤、任务撤销与刷新逻辑，并同步 `ScannerWidget` 的错误提示/清空行为。【F:lib/modules/outbound/task_list/outbound_task_list_page.dart†L76-L161】
+- [x] UI 层实现：
+  - 顶部扫码输入（带筛选按钮），支持手动触发查询。
+  - 表格列定义覆盖操作列（采集/撤销）、任务号、库房、任务备注。
+  - 表格点击“采集”跳转采集页并携带任务对象，“撤销”弹出确认后调用 BLoC 撤销事件。
+  - 无数据提示和加载状态复用 `LoadingDialogManager`。
+- [x] 与盘点接收页约定导航路由（如 `/inventory/receive`），保留原 UniApp 的右上角“+”行为。确保路由参数包含用户信息以支持任务接收流程。【F:GlodWind-Wms-App/pages/Inventorytask/InventoryTask.nvue†L3-L164】
+- [ ] 编写单元测试：验证 BLoC 触发接口调用、分页状态转换、撤销成功/失败提示流程；使用 Mock 服务覆盖异常分支。

--- a/docs/inventory_task_refactor/task_receive_todo.md
+++ b/docs/inventory_task_refactor/task_receive_todo.md
@@ -1,0 +1,22 @@
+# 平库盘点接收页重构 TODO
+
+## 页面现状回顾
+- UniApp 接收页沿用列表页布局，顶部扫码、表格展示以及分页控制，操作列仅提供“接收”按钮。【F:GlodWind-Wms-App/pages/Inventorytask/task_receive/InventorytaskReceive.nvue†L3-L148】
+- 接口依赖 `getInventoryTask`（userId 默认为 `ALL`）加载待接收任务，并通过 `commitInventoryTask` 完成接收；成功后刷新列表并提示信息。【F:GlodWind-Wms-App/pages/Inventorytask/task_receive/InventorytaskReceive.nvue†L63-L148】【F:GlodWind-Wms-App/api/system/goodsDown.js†L224-L244】
+
+## Flutter 重构参考
+- UI 结构可直接复用出库/入库接收页的 `CustomAppBar`、`ScannerWidget` 与 `CommonDataGrid` 模式，保证扫码输入与分页一致体验。【F:lib/modules/outbound/task_list/outbound_task_list_page.dart†L49-L173】
+- 接收流程可参照现有平库入库模块的接收页状态管理，使用 BLoC 控制加载、成功提示与刷新逻辑。【F:lib/modules/goods_up/collection_task/goods_up_collection_page.dart†L97-L188】
+- 数据模型与服务层复用任务列表定义的 Freezed 结构，避免重复解析。
+
+## TODO 列表
+- [x] 在 `lib/modules/inventory_task/task_receive` 下创建接收页、BLoC、事件与状态类，复用任务列表的服务实例并共享 Freezed 模型。
+- [x] 扩展 `InventoryTaskService`，提供 `fetchReceivableTasks`（userId 可覆盖为 `ALL`）与 `receiveTask`（`commitInventoryTask`，`isCanel=false`）方法，封装错误提示。
+- [x] 构建 `InventoryTaskReceiveBloc`：处理初始化加载、扫码过滤、接收提交及成功/失败反馈，触发表格刷新和 Loading 弹窗。
+- [x] UI 实现：
+  - 顶部扫码输入（可直接录入单号触发查询）。
+  - 表格列展示盘库单号、库房号、任务号等基础字段，并在操作列提供“接收”按钮。
+  - 点击接收后显示确认对话框，调用 BLoC 事件并在成功后刷新当前页。
+  - 无待接收数据时展示空状态提示。
+- [x] 集成路由：支持从任务列表页导航至 `/inventory/receive`，返回后可自动刷新列表任务。
+- [ ] 编写测试：验证接收事件触发接口、成功后刷新与错误提示；同时覆盖扫码搜索行为。

--- a/lib/app_module.dart
+++ b/lib/app_module.dart
@@ -10,6 +10,7 @@ import 'modules/outbound/outbound_module.dart';
 import 'modules/goods_up/goods_up_module.dart';
 import 'modules/arrival_sign/arrival_sign_module.dart';
 import 'modules/aswh_inventory/aswh_inventory_module.dart';
+import 'modules/inventory_task/inventory_task_module.dart';
 
 /// 应用主模块
 class AppModule extends Module {
@@ -52,5 +53,8 @@ class AppModule extends Module {
 
     // 立库盘点模块
     r.module('/aswh-inventory', module: AswhInventoryModule());
+
+    // 平库盘点模块
+    r.module('/inventory', module: InventoryTaskModule());
   }
 }

--- a/lib/modules/inventory_task/collection_task/bloc/inventory_collect_bloc.dart
+++ b/lib/modules/inventory_task/collection_task/bloc/inventory_collect_bloc.dart
@@ -1,0 +1,363 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:meta/meta.dart';
+
+import '../../services/inventory_task_service.dart';
+import '../../task_list/models/inventory_task.dart';
+import '../models/inventory_collect_models.dart';
+import '../repositories/inventory_collect_cache_repository.dart';
+import 'inventory_collect_enums.dart';
+import 'inventory_collect_event.dart';
+import 'inventory_collect_state.dart';
+
+@immutable
+class InventoryCollectBloc
+    extends Bloc<InventoryCollectEvent, InventoryCollectState> {
+  InventoryCollectBloc({
+    required InventoryTaskService service,
+    required InventoryCollectCacheRepository cacheRepository,
+  })  : _service = service,
+        _cacheRepository = cacheRepository,
+        super(const InventoryCollectState()) {
+    on<_Started>(_onStarted);
+    on<_StoreSiteScanned>(_onStoreSiteScanned);
+    on<_MaterialScanned>(_onMaterialScanned);
+    on<_QuantitySubmitted>(_onQuantitySubmitted);
+    on<_TabChanged>(_onTabChanged);
+    on<_RecordsRemoved>(_onRecordsRemoved);
+    on<_SubmitRequested>(_onSubmitRequested);
+    on<_RefreshRequested>(_onRefreshRequested);
+  }
+
+  final InventoryTaskService _service;
+  final InventoryCollectCacheRepository _cacheRepository;
+
+  InventoryTask? get _task => state.task;
+
+  Future<void> _onStarted(
+    _Started event,
+    Emitter<InventoryCollectState> emit,
+  ) async {
+    emit(state.copyWith(status: InventoryCollectStatus.loading, message: null));
+
+    final task = event.task;
+    final taskKey = task.checkTaskNo.isNotEmpty
+        ? task.checkTaskNo
+        : task.taskComment;
+    await _cacheRepository.init(taskKey ?? 'inventory');
+
+    try {
+      final items = await _service.fetchInventoryTaskItems(
+        query: InventoryTaskItemQuery(
+          taskId: (task.checkTaskId ?? task.checkTaskNo).toString(),
+        ),
+      );
+      final cachedRecords = await _cacheRepository.loadRecords();
+      final adjustedItems = _applyRecordsToItems(items, cachedRecords);
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.success,
+          task: task,
+          taskItems: adjustedItems,
+          collectingRecords: cachedRecords,
+          hasUnsubmittedData: cachedRecords.isNotEmpty,
+          currentStoreSite: '',
+          step: InventoryCollectStep.scanLocation,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: error.toString(),
+          task: task,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onStoreSiteScanned(
+    _StoreSiteScanned event,
+    Emitter<InventoryCollectState> emit,
+  ) async {
+    final task = _task;
+    if (task == null) return;
+
+    emit(state.copyWith(status: InventoryCollectStatus.cacheUpdating));
+    final isValid = await _service.validateStoreSite(
+      storeRoomNo: task.storeRoomNo,
+      storeSiteNo: event.storeSite,
+    );
+    if (!isValid) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: '库位 ${event.storeSite} 校验失败',
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: InventoryCollectStatus.success,
+        currentStoreSite: event.storeSite,
+        step: InventoryCollectStep.scanMaterial,
+        message: '库位 ${event.storeSite} 校验成功',
+      ),
+    );
+  }
+
+  Future<void> _onMaterialScanned(
+    _MaterialScanned event,
+    Emitter<InventoryCollectState> emit,
+  ) async {
+    if (state.currentStoreSite.isEmpty) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: '请先扫描库位',
+        ),
+      );
+      return;
+    }
+
+    try {
+      emit(state.copyWith(status: InventoryCollectStatus.loading));
+      final barcode = await _service.fetchBarcodeContent(event.barcode);
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.success,
+          barcodeContent: barcode,
+          step: InventoryCollectStep.inputQuantity,
+          message: '物料 ${barcode.materialCode ?? ''} 解析成功',
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onQuantitySubmitted(
+    _QuantitySubmitted event,
+    Emitter<InventoryCollectState> emit,
+  ) async {
+    final task = _task;
+    final barcode = state.barcodeContent;
+    if (task == null || barcode == null || state.currentStoreSite.isEmpty) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: '请先扫描库位和物料',
+        ),
+      );
+      return;
+    }
+
+    if (state.taskItems.isEmpty) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: '任务明细为空，无法采集',
+        ),
+      );
+      return;
+    }
+
+    final matchedItem = state.taskItems.firstWhere(
+      (item) =>
+          item.storeSiteNo == state.currentStoreSite &&
+          item.materialCode == (barcode.materialCode ?? barcode.materialName ?? ''),
+      orElse: () => state.taskItems.firstWhere(
+        (item) => item.storeSiteNo == state.currentStoreSite,
+        orElse: () => state.taskItems.first,
+      ),
+    );
+
+    final newRecord = InventoryCollectRecord(
+      itemId: matchedItem.itemId,
+      materialCode: matchedItem.materialCode,
+      materialName: matchedItem.materialName ?? barcode.materialName,
+      storeSiteNo: matchedItem.storeSiteNo,
+      storeRoomNo: matchedItem.storeRoomNo,
+      systemQuantity: matchedItem.systemQuantity,
+      actualQuantity: event.quantity,
+      difference: event.quantity - matchedItem.systemQuantity,
+      batchNo: barcode.batchNo,
+      serialNo: barcode.serialNo,
+      unit: matchedItem.unit,
+      taskComment: task.taskComment,
+    );
+
+    final updatedRecords = List<InventoryCollectRecord>.from(
+      state.collectingRecords,
+    )..add(newRecord);
+    final updatedItems = _applyRecordsToItems(state.taskItems, updatedRecords);
+
+    await _cacheRepository.saveRecords(updatedRecords);
+
+    emit(
+      state.copyWith(
+        status: InventoryCollectStatus.success,
+        collectingRecords: updatedRecords,
+        taskItems: updatedItems,
+        step: InventoryCollectStep.scanLocation,
+        barcodeContent: null,
+        currentStoreSite: '',
+        hasUnsubmittedData: true,
+        message: '已采集数量 ${event.quantity}',
+      ),
+    );
+  }
+
+  Future<void> _onTabChanged(
+    _TabChanged event,
+    Emitter<InventoryCollectState> emit,
+  ) async {
+    final tab = event.index == 0
+        ? InventoryCollectTab.pending
+        : InventoryCollectTab.collecting;
+    emit(state.copyWith(activeTab: tab));
+  }
+
+  Future<void> _onRecordsRemoved(
+    _RecordsRemoved event,
+    Emitter<InventoryCollectState> emit,
+  ) async {
+    final removed = event.removed;
+    if (removed.isEmpty) return;
+
+    final remaining = List<InventoryCollectRecord>.from(state.collectingRecords)
+      ..removeWhere(
+        (record) => removed.any(
+          (item) =>
+              item.itemId == record.itemId &&
+              item.storeSiteNo == record.storeSiteNo &&
+              item.materialCode == record.materialCode,
+        ),
+      );
+
+    final updatedItems = _applyRecordsToItems(state.taskItems, remaining);
+    await _cacheRepository.saveRecords(remaining);
+
+    emit(
+      state.copyWith(
+        status: InventoryCollectStatus.success,
+        collectingRecords: remaining,
+        taskItems: updatedItems,
+        hasUnsubmittedData: remaining.isNotEmpty,
+        message: '已删除 ${removed.length} 条采集记录',
+      ),
+    );
+  }
+
+  Future<void> _onSubmitRequested(
+    _SubmitRequested event,
+    Emitter<InventoryCollectState> emit,
+  ) async {
+    final task = _task;
+    if (task == null) return;
+    if (state.collectingRecords.isEmpty) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: '暂无需要提交的记录',
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: InventoryCollectStatus.submitting));
+    final request = InventoryCommitRequest(
+      records: state.collectingRecords,
+      taskComment: task.taskComment,
+    );
+
+    try {
+      await _service.submitInventoryInfos(request);
+      await _cacheRepository.saveRecords(const []);
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.success,
+          collectingRecords: const [],
+          hasUnsubmittedData: false,
+          message: '提交成功',
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> _onRefreshRequested(
+    _RefreshRequested event,
+    Emitter<InventoryCollectState> emit,
+  ) async {
+    final task = _task;
+    if (task == null) return;
+    emit(state.copyWith(status: InventoryCollectStatus.loading));
+    try {
+      final items = await _service.fetchInventoryTaskItems(
+        query: InventoryTaskItemQuery(
+          taskId: (task.checkTaskId ?? task.checkTaskNo).toString(),
+        ),
+      );
+      final updatedItems = _applyRecordsToItems(items, state.collectingRecords);
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.success,
+          taskItems: updatedItems,
+          message: '已刷新任务明细',
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryCollectStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  List<InventoryTaskItem> _applyRecordsToItems(
+    List<InventoryTaskItem> items,
+    List<InventoryCollectRecord> records,
+  ) {
+    final grouped = <String, double>{};
+    for (final record in records) {
+      final key = '${record.itemId}_${record.storeSiteNo}';
+      grouped.update(key, (value) => value + record.actualQuantity,
+          ifAbsent: () => record.actualQuantity);
+    }
+
+    return items
+        .map(
+          (item) => item.copyWith(
+            collectedQuantity: grouped['${item.itemId}_${item.storeSiteNo}'] ??
+                0,
+            actualQuantity: grouped['${item.itemId}_${item.storeSiteNo}'] ?? 0,
+            difference: (grouped['${item.itemId}_${item.storeSiteNo}'] ?? 0) -
+                item.systemQuantity,
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<void> close() async {
+    await _cacheRepository.dispose();
+    return super.close();
+  }
+}

--- a/lib/modules/inventory_task/collection_task/bloc/inventory_collect_enums.dart
+++ b/lib/modules/inventory_task/collection_task/bloc/inventory_collect_enums.dart
@@ -1,0 +1,10 @@
+enum InventoryCollectStep { scanLocation, scanMaterial, inputQuantity }
+
+enum InventoryCollectStatus {
+  initial,
+  loading,
+  success,
+  failure,
+  submitting,
+  cacheUpdating,
+}

--- a/lib/modules/inventory_task/collection_task/bloc/inventory_collect_event.dart
+++ b/lib/modules/inventory_task/collection_task/bloc/inventory_collect_event.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../task_list/models/inventory_task.dart';
+import '../models/inventory_collect_models.dart';
+
+part 'inventory_collect_event.freezed.dart';
+
+@freezed
+class InventoryCollectEvent with _$InventoryCollectEvent {
+  const factory InventoryCollectEvent.started(InventoryTask task) = _Started;
+  const factory InventoryCollectEvent.storeSiteScanned(String storeSite) =
+      _StoreSiteScanned;
+  const factory InventoryCollectEvent.materialScanned(String barcode) =
+      _MaterialScanned;
+  const factory InventoryCollectEvent.quantitySubmitted(double quantity) =
+      _QuantitySubmitted;
+  const factory InventoryCollectEvent.tabChanged(int index) = _TabChanged;
+  const factory InventoryCollectEvent.recordsRemoved(
+    List<InventoryCollectRecord> removed,
+  ) = _RecordsRemoved;
+  const factory InventoryCollectEvent.submitRequested() = _SubmitRequested;
+  const factory InventoryCollectEvent.refreshRequested() = _RefreshRequested;
+}

--- a/lib/modules/inventory_task/collection_task/bloc/inventory_collect_event.freezed.dart
+++ b/lib/modules/inventory_task/collection_task/bloc/inventory_collect_event.freezed.dart
@@ -1,0 +1,1437 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_collect_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$InventoryCollectEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryCollectEventCopyWith<$Res> {
+  factory $InventoryCollectEventCopyWith(InventoryCollectEvent value,
+          $Res Function(InventoryCollectEvent) then) =
+      _$InventoryCollectEventCopyWithImpl<$Res, InventoryCollectEvent>;
+}
+
+/// @nodoc
+class _$InventoryCollectEventCopyWithImpl<$Res,
+        $Val extends InventoryCollectEvent>
+    implements $InventoryCollectEventCopyWith<$Res> {
+  _$InventoryCollectEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$StartedImplCopyWith<$Res> {
+  factory _$$StartedImplCopyWith(
+          _$StartedImpl value, $Res Function(_$StartedImpl) then) =
+      __$$StartedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({InventoryTask task});
+
+  $InventoryTaskCopyWith<$Res> get task;
+}
+
+/// @nodoc
+class __$$StartedImplCopyWithImpl<$Res>
+    extends _$InventoryCollectEventCopyWithImpl<$Res, _$StartedImpl>
+    implements _$$StartedImplCopyWith<$Res> {
+  __$$StartedImplCopyWithImpl(
+      _$StartedImpl _value, $Res Function(_$StartedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? task = null,
+  }) {
+    return _then(_$StartedImpl(
+      null == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as InventoryTask,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryTaskCopyWith<$Res> get task {
+    return $InventoryTaskCopyWith<$Res>(_value.task, (value) {
+      return _then(_value.copyWith(task: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$StartedImpl implements _Started {
+  const _$StartedImpl(this.task);
+
+  @override
+  final InventoryTask task;
+
+  @override
+  String toString() {
+    return 'InventoryCollectEvent.started(task: $task)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StartedImpl &&
+            (identical(other.task, task) || other.task == task));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, task);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StartedImplCopyWith<_$StartedImpl> get copyWith =>
+      __$$StartedImplCopyWithImpl<_$StartedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) {
+    return started(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) {
+    return started?.call(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started(task);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return started(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return started?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Started implements InventoryCollectEvent {
+  const factory _Started(final InventoryTask task) = _$StartedImpl;
+
+  InventoryTask get task;
+  @JsonKey(ignore: true)
+  _$$StartedImplCopyWith<_$StartedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$StoreSiteScannedImplCopyWith<$Res> {
+  factory _$$StoreSiteScannedImplCopyWith(_$StoreSiteScannedImpl value,
+          $Res Function(_$StoreSiteScannedImpl) then) =
+      __$$StoreSiteScannedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String storeSite});
+}
+
+/// @nodoc
+class __$$StoreSiteScannedImplCopyWithImpl<$Res>
+    extends _$InventoryCollectEventCopyWithImpl<$Res, _$StoreSiteScannedImpl>
+    implements _$$StoreSiteScannedImplCopyWith<$Res> {
+  __$$StoreSiteScannedImplCopyWithImpl(_$StoreSiteScannedImpl _value,
+      $Res Function(_$StoreSiteScannedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? storeSite = null,
+  }) {
+    return _then(_$StoreSiteScannedImpl(
+      null == storeSite
+          ? _value.storeSite
+          : storeSite // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$StoreSiteScannedImpl implements _StoreSiteScanned {
+  const _$StoreSiteScannedImpl(this.storeSite);
+
+  @override
+  final String storeSite;
+
+  @override
+  String toString() {
+    return 'InventoryCollectEvent.storeSiteScanned(storeSite: $storeSite)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StoreSiteScannedImpl &&
+            (identical(other.storeSite, storeSite) ||
+                other.storeSite == storeSite));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, storeSite);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StoreSiteScannedImplCopyWith<_$StoreSiteScannedImpl> get copyWith =>
+      __$$StoreSiteScannedImplCopyWithImpl<_$StoreSiteScannedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) {
+    return storeSiteScanned(storeSite);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) {
+    return storeSiteScanned?.call(storeSite);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (storeSiteScanned != null) {
+      return storeSiteScanned(storeSite);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return storeSiteScanned(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return storeSiteScanned?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (storeSiteScanned != null) {
+      return storeSiteScanned(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _StoreSiteScanned implements InventoryCollectEvent {
+  const factory _StoreSiteScanned(final String storeSite) =
+      _$StoreSiteScannedImpl;
+
+  String get storeSite;
+  @JsonKey(ignore: true)
+  _$$StoreSiteScannedImplCopyWith<_$StoreSiteScannedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$MaterialScannedImplCopyWith<$Res> {
+  factory _$$MaterialScannedImplCopyWith(_$MaterialScannedImpl value,
+          $Res Function(_$MaterialScannedImpl) then) =
+      __$$MaterialScannedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String barcode});
+}
+
+/// @nodoc
+class __$$MaterialScannedImplCopyWithImpl<$Res>
+    extends _$InventoryCollectEventCopyWithImpl<$Res, _$MaterialScannedImpl>
+    implements _$$MaterialScannedImplCopyWith<$Res> {
+  __$$MaterialScannedImplCopyWithImpl(
+      _$MaterialScannedImpl _value, $Res Function(_$MaterialScannedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? barcode = null,
+  }) {
+    return _then(_$MaterialScannedImpl(
+      null == barcode
+          ? _value.barcode
+          : barcode // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$MaterialScannedImpl implements _MaterialScanned {
+  const _$MaterialScannedImpl(this.barcode);
+
+  @override
+  final String barcode;
+
+  @override
+  String toString() {
+    return 'InventoryCollectEvent.materialScanned(barcode: $barcode)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MaterialScannedImpl &&
+            (identical(other.barcode, barcode) || other.barcode == barcode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, barcode);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MaterialScannedImplCopyWith<_$MaterialScannedImpl> get copyWith =>
+      __$$MaterialScannedImplCopyWithImpl<_$MaterialScannedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) {
+    return materialScanned(barcode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) {
+    return materialScanned?.call(barcode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (materialScanned != null) {
+      return materialScanned(barcode);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return materialScanned(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return materialScanned?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (materialScanned != null) {
+      return materialScanned(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _MaterialScanned implements InventoryCollectEvent {
+  const factory _MaterialScanned(final String barcode) = _$MaterialScannedImpl;
+
+  String get barcode;
+  @JsonKey(ignore: true)
+  _$$MaterialScannedImplCopyWith<_$MaterialScannedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$QuantitySubmittedImplCopyWith<$Res> {
+  factory _$$QuantitySubmittedImplCopyWith(_$QuantitySubmittedImpl value,
+          $Res Function(_$QuantitySubmittedImpl) then) =
+      __$$QuantitySubmittedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({double quantity});
+}
+
+/// @nodoc
+class __$$QuantitySubmittedImplCopyWithImpl<$Res>
+    extends _$InventoryCollectEventCopyWithImpl<$Res, _$QuantitySubmittedImpl>
+    implements _$$QuantitySubmittedImplCopyWith<$Res> {
+  __$$QuantitySubmittedImplCopyWithImpl(_$QuantitySubmittedImpl _value,
+      $Res Function(_$QuantitySubmittedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? quantity = null,
+  }) {
+    return _then(_$QuantitySubmittedImpl(
+      null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$QuantitySubmittedImpl implements _QuantitySubmitted {
+  const _$QuantitySubmittedImpl(this.quantity);
+
+  @override
+  final double quantity;
+
+  @override
+  String toString() {
+    return 'InventoryCollectEvent.quantitySubmitted(quantity: $quantity)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$QuantitySubmittedImpl &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, quantity);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$QuantitySubmittedImplCopyWith<_$QuantitySubmittedImpl> get copyWith =>
+      __$$QuantitySubmittedImplCopyWithImpl<_$QuantitySubmittedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) {
+    return quantitySubmitted(quantity);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) {
+    return quantitySubmitted?.call(quantity);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (quantitySubmitted != null) {
+      return quantitySubmitted(quantity);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return quantitySubmitted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return quantitySubmitted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (quantitySubmitted != null) {
+      return quantitySubmitted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _QuantitySubmitted implements InventoryCollectEvent {
+  const factory _QuantitySubmitted(final double quantity) =
+      _$QuantitySubmittedImpl;
+
+  double get quantity;
+  @JsonKey(ignore: true)
+  _$$QuantitySubmittedImplCopyWith<_$QuantitySubmittedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$TabChangedImplCopyWith<$Res> {
+  factory _$$TabChangedImplCopyWith(
+          _$TabChangedImpl value, $Res Function(_$TabChangedImpl) then) =
+      __$$TabChangedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int index});
+}
+
+/// @nodoc
+class __$$TabChangedImplCopyWithImpl<$Res>
+    extends _$InventoryCollectEventCopyWithImpl<$Res, _$TabChangedImpl>
+    implements _$$TabChangedImplCopyWith<$Res> {
+  __$$TabChangedImplCopyWithImpl(
+      _$TabChangedImpl _value, $Res Function(_$TabChangedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? index = null,
+  }) {
+    return _then(_$TabChangedImpl(
+      null == index
+          ? _value.index
+          : index // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$TabChangedImpl implements _TabChanged {
+  const _$TabChangedImpl(this.index);
+
+  @override
+  final int index;
+
+  @override
+  String toString() {
+    return 'InventoryCollectEvent.tabChanged(index: $index)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TabChangedImpl &&
+            (identical(other.index, index) || other.index == index));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, index);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TabChangedImplCopyWith<_$TabChangedImpl> get copyWith =>
+      __$$TabChangedImplCopyWithImpl<_$TabChangedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) {
+    return tabChanged(index);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) {
+    return tabChanged?.call(index);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (tabChanged != null) {
+      return tabChanged(index);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return tabChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return tabChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (tabChanged != null) {
+      return tabChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _TabChanged implements InventoryCollectEvent {
+  const factory _TabChanged(final int index) = _$TabChangedImpl;
+
+  int get index;
+  @JsonKey(ignore: true)
+  _$$TabChangedImplCopyWith<_$TabChangedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$RecordsRemovedImplCopyWith<$Res> {
+  factory _$$RecordsRemovedImplCopyWith(_$RecordsRemovedImpl value,
+          $Res Function(_$RecordsRemovedImpl) then) =
+      __$$RecordsRemovedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({List<InventoryCollectRecord> removed});
+}
+
+/// @nodoc
+class __$$RecordsRemovedImplCopyWithImpl<$Res>
+    extends _$InventoryCollectEventCopyWithImpl<$Res, _$RecordsRemovedImpl>
+    implements _$$RecordsRemovedImplCopyWith<$Res> {
+  __$$RecordsRemovedImplCopyWithImpl(
+      _$RecordsRemovedImpl _value, $Res Function(_$RecordsRemovedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? removed = null,
+  }) {
+    return _then(_$RecordsRemovedImpl(
+      null == removed
+          ? _value._removed
+          : removed // ignore: cast_nullable_to_non_nullable
+              as List<InventoryCollectRecord>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$RecordsRemovedImpl implements _RecordsRemoved {
+  const _$RecordsRemovedImpl(final List<InventoryCollectRecord> removed)
+      : _removed = removed;
+
+  final List<InventoryCollectRecord> _removed;
+  @override
+  List<InventoryCollectRecord> get removed {
+    if (_removed is EqualUnmodifiableListView) return _removed;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_removed);
+  }
+
+  @override
+  String toString() {
+    return 'InventoryCollectEvent.recordsRemoved(removed: $removed)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$RecordsRemovedImpl &&
+            const DeepCollectionEquality().equals(other._removed, _removed));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_removed));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$RecordsRemovedImplCopyWith<_$RecordsRemovedImpl> get copyWith =>
+      __$$RecordsRemovedImplCopyWithImpl<_$RecordsRemovedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) {
+    return recordsRemoved(removed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) {
+    return recordsRemoved?.call(removed);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (recordsRemoved != null) {
+      return recordsRemoved(removed);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return recordsRemoved(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return recordsRemoved?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (recordsRemoved != null) {
+      return recordsRemoved(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _RecordsRemoved implements InventoryCollectEvent {
+  const factory _RecordsRemoved(final List<InventoryCollectRecord> removed) =
+      _$RecordsRemovedImpl;
+
+  List<InventoryCollectRecord> get removed;
+  @JsonKey(ignore: true)
+  _$$RecordsRemovedImplCopyWith<_$RecordsRemovedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SubmitRequestedImplCopyWith<$Res> {
+  factory _$$SubmitRequestedImplCopyWith(_$SubmitRequestedImpl value,
+          $Res Function(_$SubmitRequestedImpl) then) =
+      __$$SubmitRequestedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$SubmitRequestedImplCopyWithImpl<$Res>
+    extends _$InventoryCollectEventCopyWithImpl<$Res, _$SubmitRequestedImpl>
+    implements _$$SubmitRequestedImplCopyWith<$Res> {
+  __$$SubmitRequestedImplCopyWithImpl(
+      _$SubmitRequestedImpl _value, $Res Function(_$SubmitRequestedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$SubmitRequestedImpl implements _SubmitRequested {
+  const _$SubmitRequestedImpl();
+
+  @override
+  String toString() {
+    return 'InventoryCollectEvent.submitRequested()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$SubmitRequestedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) {
+    return submitRequested();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) {
+    return submitRequested?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (submitRequested != null) {
+      return submitRequested();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return submitRequested(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return submitRequested?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (submitRequested != null) {
+      return submitRequested(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _SubmitRequested implements InventoryCollectEvent {
+  const factory _SubmitRequested() = _$SubmitRequestedImpl;
+}
+
+/// @nodoc
+abstract class _$$RefreshRequestedImplCopyWith<$Res> {
+  factory _$$RefreshRequestedImplCopyWith(_$RefreshRequestedImpl value,
+          $Res Function(_$RefreshRequestedImpl) then) =
+      __$$RefreshRequestedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RefreshRequestedImplCopyWithImpl<$Res>
+    extends _$InventoryCollectEventCopyWithImpl<$Res, _$RefreshRequestedImpl>
+    implements _$$RefreshRequestedImplCopyWith<$Res> {
+  __$$RefreshRequestedImplCopyWithImpl(_$RefreshRequestedImpl _value,
+      $Res Function(_$RefreshRequestedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$RefreshRequestedImpl implements _RefreshRequested {
+  const _$RefreshRequestedImpl();
+
+  @override
+  String toString() {
+    return 'InventoryCollectEvent.refreshRequested()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$RefreshRequestedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(InventoryTask task) started,
+    required TResult Function(String storeSite) storeSiteScanned,
+    required TResult Function(String barcode) materialScanned,
+    required TResult Function(double quantity) quantitySubmitted,
+    required TResult Function(int index) tabChanged,
+    required TResult Function(List<InventoryCollectRecord> removed)
+        recordsRemoved,
+    required TResult Function() submitRequested,
+    required TResult Function() refreshRequested,
+  }) {
+    return refreshRequested();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(InventoryTask task)? started,
+    TResult? Function(String storeSite)? storeSiteScanned,
+    TResult? Function(String barcode)? materialScanned,
+    TResult? Function(double quantity)? quantitySubmitted,
+    TResult? Function(int index)? tabChanged,
+    TResult? Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult? Function()? submitRequested,
+    TResult? Function()? refreshRequested,
+  }) {
+    return refreshRequested?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(InventoryTask task)? started,
+    TResult Function(String storeSite)? storeSiteScanned,
+    TResult Function(String barcode)? materialScanned,
+    TResult Function(double quantity)? quantitySubmitted,
+    TResult Function(int index)? tabChanged,
+    TResult Function(List<InventoryCollectRecord> removed)? recordsRemoved,
+    TResult Function()? submitRequested,
+    TResult Function()? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (refreshRequested != null) {
+      return refreshRequested();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_StoreSiteScanned value) storeSiteScanned,
+    required TResult Function(_MaterialScanned value) materialScanned,
+    required TResult Function(_QuantitySubmitted value) quantitySubmitted,
+    required TResult Function(_TabChanged value) tabChanged,
+    required TResult Function(_RecordsRemoved value) recordsRemoved,
+    required TResult Function(_SubmitRequested value) submitRequested,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+  }) {
+    return refreshRequested(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult? Function(_MaterialScanned value)? materialScanned,
+    TResult? Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult? Function(_TabChanged value)? tabChanged,
+    TResult? Function(_RecordsRemoved value)? recordsRemoved,
+    TResult? Function(_SubmitRequested value)? submitRequested,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+  }) {
+    return refreshRequested?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_StoreSiteScanned value)? storeSiteScanned,
+    TResult Function(_MaterialScanned value)? materialScanned,
+    TResult Function(_QuantitySubmitted value)? quantitySubmitted,
+    TResult Function(_TabChanged value)? tabChanged,
+    TResult Function(_RecordsRemoved value)? recordsRemoved,
+    TResult Function(_SubmitRequested value)? submitRequested,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    required TResult orElse(),
+  }) {
+    if (refreshRequested != null) {
+      return refreshRequested(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _RefreshRequested implements InventoryCollectEvent {
+  const factory _RefreshRequested() = _$RefreshRequestedImpl;
+}

--- a/lib/modules/inventory_task/collection_task/bloc/inventory_collect_state.dart
+++ b/lib/modules/inventory_task/collection_task/bloc/inventory_collect_state.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../task_list/models/inventory_task.dart';
+import '../models/inventory_collect_models.dart';
+import 'inventory_collect_enums.dart';
+
+part 'inventory_collect_state.freezed.dart';
+
+enum InventoryCollectTab { pending, collecting }
+
+@freezed
+class InventoryCollectState with _$InventoryCollectState {
+  const factory InventoryCollectState({
+    @Default(InventoryCollectStatus.initial) InventoryCollectStatus status,
+    InventoryTask? task,
+    @Default('') String currentStoreSite,
+    InventoryBarcodeContent? barcodeContent,
+    @Default(InventoryCollectStep.scanLocation) InventoryCollectStep step,
+    @Default(InventoryCollectTab.pending) InventoryCollectTab activeTab,
+    @Default(<InventoryTaskItem>[]) List<InventoryTaskItem> taskItems,
+    @Default(<InventoryCollectRecord>[])
+    List<InventoryCollectRecord> collectingRecords,
+    String? message,
+    @Default(false) bool hasUnsubmittedData,
+  }) = _InventoryCollectState;
+}

--- a/lib/modules/inventory_task/collection_task/bloc/inventory_collect_state.freezed.dart
+++ b/lib/modules/inventory_task/collection_task/bloc/inventory_collect_state.freezed.dart
@@ -1,0 +1,395 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_collect_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$InventoryCollectState {
+  InventoryCollectStatus get status => throw _privateConstructorUsedError;
+  InventoryTask? get task => throw _privateConstructorUsedError;
+  String get currentStoreSite => throw _privateConstructorUsedError;
+  InventoryBarcodeContent? get barcodeContent =>
+      throw _privateConstructorUsedError;
+  InventoryCollectStep get step => throw _privateConstructorUsedError;
+  InventoryCollectTab get activeTab => throw _privateConstructorUsedError;
+  List<InventoryTaskItem> get taskItems => throw _privateConstructorUsedError;
+  List<InventoryCollectRecord> get collectingRecords =>
+      throw _privateConstructorUsedError;
+  String? get message => throw _privateConstructorUsedError;
+  bool get hasUnsubmittedData => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $InventoryCollectStateCopyWith<InventoryCollectState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryCollectStateCopyWith<$Res> {
+  factory $InventoryCollectStateCopyWith(InventoryCollectState value,
+          $Res Function(InventoryCollectState) then) =
+      _$InventoryCollectStateCopyWithImpl<$Res, InventoryCollectState>;
+  @useResult
+  $Res call(
+      {InventoryCollectStatus status,
+      InventoryTask? task,
+      String currentStoreSite,
+      InventoryBarcodeContent? barcodeContent,
+      InventoryCollectStep step,
+      InventoryCollectTab activeTab,
+      List<InventoryTaskItem> taskItems,
+      List<InventoryCollectRecord> collectingRecords,
+      String? message,
+      bool hasUnsubmittedData});
+
+  $InventoryTaskCopyWith<$Res>? get task;
+  $InventoryBarcodeContentCopyWith<$Res>? get barcodeContent;
+}
+
+/// @nodoc
+class _$InventoryCollectStateCopyWithImpl<$Res,
+        $Val extends InventoryCollectState>
+    implements $InventoryCollectStateCopyWith<$Res> {
+  _$InventoryCollectStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? task = freezed,
+    Object? currentStoreSite = null,
+    Object? barcodeContent = freezed,
+    Object? step = null,
+    Object? activeTab = null,
+    Object? taskItems = null,
+    Object? collectingRecords = null,
+    Object? message = freezed,
+    Object? hasUnsubmittedData = null,
+  }) {
+    return _then(_value.copyWith(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as InventoryCollectStatus,
+      task: freezed == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as InventoryTask?,
+      currentStoreSite: null == currentStoreSite
+          ? _value.currentStoreSite
+          : currentStoreSite // ignore: cast_nullable_to_non_nullable
+              as String,
+      barcodeContent: freezed == barcodeContent
+          ? _value.barcodeContent
+          : barcodeContent // ignore: cast_nullable_to_non_nullable
+              as InventoryBarcodeContent?,
+      step: null == step
+          ? _value.step
+          : step // ignore: cast_nullable_to_non_nullable
+              as InventoryCollectStep,
+      activeTab: null == activeTab
+          ? _value.activeTab
+          : activeTab // ignore: cast_nullable_to_non_nullable
+              as InventoryCollectTab,
+      taskItems: null == taskItems
+          ? _value.taskItems
+          : taskItems // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTaskItem>,
+      collectingRecords: null == collectingRecords
+          ? _value.collectingRecords
+          : collectingRecords // ignore: cast_nullable_to_non_nullable
+              as List<InventoryCollectRecord>,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hasUnsubmittedData: null == hasUnsubmittedData
+          ? _value.hasUnsubmittedData
+          : hasUnsubmittedData // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryTaskCopyWith<$Res>? get task {
+    if (_value.task == null) {
+      return null;
+    }
+
+    return $InventoryTaskCopyWith<$Res>(_value.task!, (value) {
+      return _then(_value.copyWith(task: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryBarcodeContentCopyWith<$Res>? get barcodeContent {
+    if (_value.barcodeContent == null) {
+      return null;
+    }
+
+    return $InventoryBarcodeContentCopyWith<$Res>(_value.barcodeContent!,
+        (value) {
+      return _then(_value.copyWith(barcodeContent: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryCollectStateImplCopyWith<$Res>
+    implements $InventoryCollectStateCopyWith<$Res> {
+  factory _$$InventoryCollectStateImplCopyWith(
+          _$InventoryCollectStateImpl value,
+          $Res Function(_$InventoryCollectStateImpl) then) =
+      __$$InventoryCollectStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {InventoryCollectStatus status,
+      InventoryTask? task,
+      String currentStoreSite,
+      InventoryBarcodeContent? barcodeContent,
+      InventoryCollectStep step,
+      InventoryCollectTab activeTab,
+      List<InventoryTaskItem> taskItems,
+      List<InventoryCollectRecord> collectingRecords,
+      String? message,
+      bool hasUnsubmittedData});
+
+  @override
+  $InventoryTaskCopyWith<$Res>? get task;
+  @override
+  $InventoryBarcodeContentCopyWith<$Res>? get barcodeContent;
+}
+
+/// @nodoc
+class __$$InventoryCollectStateImplCopyWithImpl<$Res>
+    extends _$InventoryCollectStateCopyWithImpl<$Res,
+        _$InventoryCollectStateImpl>
+    implements _$$InventoryCollectStateImplCopyWith<$Res> {
+  __$$InventoryCollectStateImplCopyWithImpl(_$InventoryCollectStateImpl _value,
+      $Res Function(_$InventoryCollectStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? task = freezed,
+    Object? currentStoreSite = null,
+    Object? barcodeContent = freezed,
+    Object? step = null,
+    Object? activeTab = null,
+    Object? taskItems = null,
+    Object? collectingRecords = null,
+    Object? message = freezed,
+    Object? hasUnsubmittedData = null,
+  }) {
+    return _then(_$InventoryCollectStateImpl(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as InventoryCollectStatus,
+      task: freezed == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as InventoryTask?,
+      currentStoreSite: null == currentStoreSite
+          ? _value.currentStoreSite
+          : currentStoreSite // ignore: cast_nullable_to_non_nullable
+              as String,
+      barcodeContent: freezed == barcodeContent
+          ? _value.barcodeContent
+          : barcodeContent // ignore: cast_nullable_to_non_nullable
+              as InventoryBarcodeContent?,
+      step: null == step
+          ? _value.step
+          : step // ignore: cast_nullable_to_non_nullable
+              as InventoryCollectStep,
+      activeTab: null == activeTab
+          ? _value.activeTab
+          : activeTab // ignore: cast_nullable_to_non_nullable
+              as InventoryCollectTab,
+      taskItems: null == taskItems
+          ? _value._taskItems
+          : taskItems // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTaskItem>,
+      collectingRecords: null == collectingRecords
+          ? _value._collectingRecords
+          : collectingRecords // ignore: cast_nullable_to_non_nullable
+              as List<InventoryCollectRecord>,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+      hasUnsubmittedData: null == hasUnsubmittedData
+          ? _value.hasUnsubmittedData
+          : hasUnsubmittedData // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$InventoryCollectStateImpl implements _InventoryCollectState {
+  const _$InventoryCollectStateImpl(
+      {this.status = InventoryCollectStatus.initial,
+      this.task,
+      this.currentStoreSite = '',
+      this.barcodeContent,
+      this.step = InventoryCollectStep.scanLocation,
+      this.activeTab = InventoryCollectTab.pending,
+      final List<InventoryTaskItem> taskItems = const <InventoryTaskItem>[],
+      final List<InventoryCollectRecord> collectingRecords =
+          const <InventoryCollectRecord>[],
+      this.message,
+      this.hasUnsubmittedData = false})
+      : _taskItems = taskItems,
+        _collectingRecords = collectingRecords;
+
+  @override
+  @JsonKey()
+  final InventoryCollectStatus status;
+  @override
+  final InventoryTask? task;
+  @override
+  @JsonKey()
+  final String currentStoreSite;
+  @override
+  final InventoryBarcodeContent? barcodeContent;
+  @override
+  @JsonKey()
+  final InventoryCollectStep step;
+  @override
+  @JsonKey()
+  final InventoryCollectTab activeTab;
+  final List<InventoryTaskItem> _taskItems;
+  @override
+  @JsonKey()
+  List<InventoryTaskItem> get taskItems {
+    if (_taskItems is EqualUnmodifiableListView) return _taskItems;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_taskItems);
+  }
+
+  final List<InventoryCollectRecord> _collectingRecords;
+  @override
+  @JsonKey()
+  List<InventoryCollectRecord> get collectingRecords {
+    if (_collectingRecords is EqualUnmodifiableListView)
+      return _collectingRecords;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_collectingRecords);
+  }
+
+  @override
+  final String? message;
+  @override
+  @JsonKey()
+  final bool hasUnsubmittedData;
+
+  @override
+  String toString() {
+    return 'InventoryCollectState(status: $status, task: $task, currentStoreSite: $currentStoreSite, barcodeContent: $barcodeContent, step: $step, activeTab: $activeTab, taskItems: $taskItems, collectingRecords: $collectingRecords, message: $message, hasUnsubmittedData: $hasUnsubmittedData)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryCollectStateImpl &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.task, task) || other.task == task) &&
+            (identical(other.currentStoreSite, currentStoreSite) ||
+                other.currentStoreSite == currentStoreSite) &&
+            (identical(other.barcodeContent, barcodeContent) ||
+                other.barcodeContent == barcodeContent) &&
+            (identical(other.step, step) || other.step == step) &&
+            (identical(other.activeTab, activeTab) ||
+                other.activeTab == activeTab) &&
+            const DeepCollectionEquality()
+                .equals(other._taskItems, _taskItems) &&
+            const DeepCollectionEquality()
+                .equals(other._collectingRecords, _collectingRecords) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.hasUnsubmittedData, hasUnsubmittedData) ||
+                other.hasUnsubmittedData == hasUnsubmittedData));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      status,
+      task,
+      currentStoreSite,
+      barcodeContent,
+      step,
+      activeTab,
+      const DeepCollectionEquality().hash(_taskItems),
+      const DeepCollectionEquality().hash(_collectingRecords),
+      message,
+      hasUnsubmittedData);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryCollectStateImplCopyWith<_$InventoryCollectStateImpl>
+      get copyWith => __$$InventoryCollectStateImplCopyWithImpl<
+          _$InventoryCollectStateImpl>(this, _$identity);
+}
+
+abstract class _InventoryCollectState implements InventoryCollectState {
+  const factory _InventoryCollectState(
+      {final InventoryCollectStatus status,
+      final InventoryTask? task,
+      final String currentStoreSite,
+      final InventoryBarcodeContent? barcodeContent,
+      final InventoryCollectStep step,
+      final InventoryCollectTab activeTab,
+      final List<InventoryTaskItem> taskItems,
+      final List<InventoryCollectRecord> collectingRecords,
+      final String? message,
+      final bool hasUnsubmittedData}) = _$InventoryCollectStateImpl;
+
+  @override
+  InventoryCollectStatus get status;
+  @override
+  InventoryTask? get task;
+  @override
+  String get currentStoreSite;
+  @override
+  InventoryBarcodeContent? get barcodeContent;
+  @override
+  InventoryCollectStep get step;
+  @override
+  InventoryCollectTab get activeTab;
+  @override
+  List<InventoryTaskItem> get taskItems;
+  @override
+  List<InventoryCollectRecord> get collectingRecords;
+  @override
+  String? get message;
+  @override
+  bool get hasUnsubmittedData;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryCollectStateImplCopyWith<_$InventoryCollectStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_task/collection_task/inventory_collect_page.dart
+++ b/lib/modules/inventory_task/collection_task/inventory_collect_page.dart
@@ -1,0 +1,349 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../../common_widgets/loading_dialog_manager.dart';
+import '../../../common_widgets/scanner_widget/scanner_config.dart';
+import '../../../common_widgets/scanner_widget/scanner_widget.dart';
+import '../task_list/models/inventory_task.dart';
+import 'bloc/inventory_collect_bloc.dart';
+import 'bloc/inventory_collect_enums.dart';
+import 'bloc/inventory_collect_event.dart';
+import 'bloc/inventory_collect_state.dart';
+import 'inventory_collect_result_page.dart';
+import 'models/inventory_collect_models.dart';
+
+class InventoryCollectPage extends StatefulWidget {
+  const InventoryCollectPage({super.key, required this.task});
+
+  final InventoryTask task;
+
+  @override
+  State<InventoryCollectPage> createState() => _InventoryCollectPageState();
+}
+
+class _InventoryCollectPageState extends State<InventoryCollectPage>
+    with SingleTickerProviderStateMixin {
+  late final InventoryCollectBloc _bloc;
+  late final TabController _tabController;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<InventoryCollectBloc>(context);
+    _tabController = TabController(length: 2, vsync: this);
+    _tabController.addListener(() {
+      if (_tabController.indexIsChanging) return;
+      _bloc.add(InventoryCollectEvent.tabChanged(_tabController.index));
+    });
+    _bloc.add(InventoryCollectEvent.started(widget.task));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<InventoryCollectBloc, InventoryCollectState>(
+        listener: (context, state) {
+          if (state.status == InventoryCollectStatus.loading ||
+              state.status == InventoryCollectStatus.submitting) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+          }
+          if (state.status == InventoryCollectStatus.failure &&
+              state.message != null) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.message!,
+            );
+          }
+          if (state.status == InventoryCollectStatus.success &&
+              state.message != null) {
+            LoadingDialogManager.instance.showSuccessDialog(
+              context,
+              state.message!,
+            );
+          }
+        },
+        builder: (context, state) {
+          return WillPopScope(
+            onWillPop: () async {
+              if (state.hasUnsubmittedData) {
+                final result = await showDialog<bool>(
+                      context: context,
+                      builder: (context) {
+                        return AlertDialog(
+                          title: const Text('提示'),
+                          content: const Text('存在未提交的数据，确认返回吗？'),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.of(context).pop(false),
+                              child: const Text('取消'),
+                            ),
+                            ElevatedButton(
+                              onPressed: () => Navigator.of(context).pop(true),
+                              child: const Text('确认'),
+                            ),
+                          ],
+                        );
+                      },
+                    ) ??
+                    false;
+                return result;
+              }
+              return true;
+            },
+            child: Scaffold(
+              appBar: AppBar(
+                title: const Text('平库盘点采集'),
+                leading: IconButton(
+                  icon: const Icon(Icons.arrow_back),
+                  onPressed: () {
+                    if (state.hasUnsubmittedData) {
+                      showDialog<void>(
+                        context: context,
+                        builder: (context) {
+                          return AlertDialog(
+                            title: const Text('提示'),
+                            content: const Text('存在未提交的数据，确认返回吗？'),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.of(context).pop(),
+                                child: const Text('取消'),
+                              ),
+                              ElevatedButton(
+                                onPressed: () {
+                                  Navigator.of(context).pop();
+                                  Navigator.of(context).pop();
+                                },
+                                child: const Text('确认'),
+                              ),
+                            ],
+                          );
+                        },
+                      );
+                    } else {
+                      Navigator.of(context).pop();
+                    }
+                  },
+                ),
+              ),
+              body: Column(
+                children: [
+                  _buildScanner(state),
+                  _buildInfoSection(state),
+                  _buildTabs(state),
+                  Expanded(child: _buildTabContent(state)),
+                  _buildBottomBar(state),
+                ],
+              ),
+            ),
+          );
+        },
+        );
+    }
+
+  Widget _buildScanner(InventoryCollectState state) {
+    String placeholder;
+    if (state.step == InventoryCollectStep.scanLocation) {
+      placeholder = '请扫描库位编码';
+    } else if (state.step == InventoryCollectStep.scanMaterial) {
+      placeholder = '请扫描物料条码';
+    } else {
+      placeholder = '请输入采集数量';
+    }
+    final keyboardType =
+        state.step == InventoryCollectStep.inputQuantity ? TextInputType.number : TextInputType.text;
+
+    final config = ScannerConfig().copyWith(
+      placeholder: placeholder,
+      clearOnSubmit: true,
+      keyboardType: keyboardType,
+      padding: const EdgeInsets.all(12),
+    );
+
+    return ScannerWidget(
+      config: config,
+      controller: _scannerController,
+      onScanResult: (value) => _handleInput(value, state),
+      onError: (message) {
+        LoadingDialogManager.instance.showErrorDialog(context, message);
+      },
+      suffix: IconButton(
+        icon: const Icon(Icons.refresh),
+        onPressed: () => _bloc.add(const InventoryCollectEvent.refreshRequested()),
+      ),
+    );
+  }
+
+  void _handleInput(String value, InventoryCollectState state) {
+    if (value.isEmpty) return;
+    switch (state.step) {
+      case InventoryCollectStep.scanLocation:
+        _bloc.add(InventoryCollectEvent.storeSiteScanned(value));
+        break;
+      case InventoryCollectStep.scanMaterial:
+        _bloc.add(InventoryCollectEvent.materialScanned(value));
+        break;
+      case InventoryCollectStep.inputQuantity:
+        final quantity = double.tryParse(value);
+        if (quantity == null) {
+          LoadingDialogManager.instance.showErrorDialog(context, '请输入有效的数量');
+        } else {
+          _bloc.add(InventoryCollectEvent.quantitySubmitted(quantity));
+        }
+        break;
+    }
+    _scannerController.clear();
+  }
+
+  Widget _buildInfoSection(InventoryCollectState state) {
+    final task = state.task;
+    return Container(
+      width: double.infinity,
+      color: Colors.white,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('库房：${task?.storeRoomName ?? ''}', style: const TextStyle(fontSize: 16)),
+          const SizedBox(height: 4),
+          Text('库位：${state.currentStoreSite.isEmpty ? '-' : state.currentStoreSite}',
+              style: const TextStyle(fontSize: 16)),
+          const SizedBox(height: 4),
+          Text('物料：${state.barcodeContent?.materialCode ?? '-'}',
+              style: const TextStyle(fontSize: 16)),
+          const SizedBox(height: 4),
+          Text('采集数量：${state.barcodeContent == null ? '-' : ''}',
+              style: const TextStyle(fontSize: 16)),
+          if (state.barcodeContent?.batchNo != null)
+            Text('批次：${state.barcodeContent?.batchNo}', style: const TextStyle(fontSize: 14)),
+          if (state.barcodeContent?.serialNo != null)
+            Text('序列号：${state.barcodeContent?.serialNo}',
+                style: const TextStyle(fontSize: 14)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabs(InventoryCollectState state) {
+    return Container(
+      color: Colors.white,
+      child: TabBar(
+        controller: _tabController,
+        labelColor: Colors.blue,
+        unselectedLabelColor: Colors.black54,
+        tabs: const [
+          Tab(text: '任务列表'),
+          Tab(text: '正在采集'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabContent(InventoryCollectState state) {
+    final pending = state.taskItems;
+    final collecting = state.collectingRecords;
+    return TabBarView(
+      controller: _tabController,
+      children: [
+        _buildTaskList(pending),
+        _buildCollectingList(collecting),
+      ],
+    );
+  }
+
+  Widget _buildTaskList(List<InventoryTaskItem> items) {
+    if (items.isEmpty) {
+      return const Center(child: Text('暂无任务明细'));
+    }
+    return ListView.separated(
+      itemCount: items.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return ListTile(
+          title: Text('${item.materialCode}  ${item.materialName ?? ''}'),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('库位：${item.storeSiteNo}'),
+              Text('系统数量：${item.systemQuantity}'),
+              Text('已采集：${item.collectedQuantity.toStringAsFixed(2)}'),
+              Text('差异：${item.difference.toStringAsFixed(2)}'),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildCollectingList(List<InventoryCollectRecord> records) {
+    if (records.isEmpty) {
+      return const Center(child: Text('暂无采集记录'));
+    }
+    return ListView.separated(
+      itemCount: records.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final record = records[index];
+        return ListTile(
+          leading: const Icon(Icons.assignment),
+          title: Text('${record.materialCode}  ${record.materialName ?? ''}'),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('库位：${record.storeSiteNo}'),
+              Text('采集数量：${record.actualQuantity}'),
+              Text('差异：${record.difference.toStringAsFixed(2)}'),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildBottomBar(InventoryCollectState state) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      color: Colors.white,
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: () async {
+                final removed = await Navigator.of(context).push<List<InventoryCollectRecord>>(
+                  MaterialPageRoute(
+                    builder: (_) => InventoryCollectResultPage(
+                      initialRecords: state.collectingRecords,
+                    ),
+                  ),
+                );
+                if (removed != null && removed.isNotEmpty) {
+                  _bloc.add(InventoryCollectEvent.recordsRemoved(removed));
+                }
+              },
+              child: const Text('采集结果'),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: ElevatedButton(
+              onPressed: state.collectingRecords.isEmpty
+                  ? null
+                  : () => _bloc.add(const InventoryCollectEvent.submitRequested()),
+              child: const Text('提交'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    _tabController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/modules/inventory_task/collection_task/inventory_collect_result_page.dart
+++ b/lib/modules/inventory_task/collection_task/inventory_collect_result_page.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+import 'models/inventory_collect_models.dart';
+
+class InventoryCollectResultPage extends StatefulWidget {
+  const InventoryCollectResultPage({super.key, required this.initialRecords});
+
+  final List<InventoryCollectRecord> initialRecords;
+
+  @override
+  State<InventoryCollectResultPage> createState() =>
+      _InventoryCollectResultPageState();
+}
+
+class _InventoryCollectResultPageState extends State<InventoryCollectResultPage> {
+  late List<InventoryCollectRecord> _records;
+  final Set<int> _selected = <int>{};
+
+  @override
+  void initState() {
+    super.initState();
+    _records = List<InventoryCollectRecord>.from(widget.initialRecords);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasRecords = _records.isNotEmpty;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('采集结果'),
+      ),
+      body: hasRecords
+          ? ListView.separated(
+              itemCount: _records.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (context, index) {
+                final record = _records[index];
+                final checked = _selected.contains(index);
+                return CheckboxListTile(
+                  value: checked,
+                  onChanged: (value) {
+                    setState(() {
+                      if (value == true) {
+                        _selected.add(index);
+                      } else {
+                        _selected.remove(index);
+                      }
+                    });
+                  },
+                  title: Text('${record.materialCode}  ${record.materialName ?? ''}'),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('库位：${record.storeSiteNo}'),
+                      Text('采集数量：${record.actualQuantity}'),
+                      Text('差异：${record.difference.toStringAsFixed(2)}'),
+                    ],
+                  ),
+                );
+              },
+            )
+          : const Center(child: Text('暂无采集记录')),
+      bottomNavigationBar: hasRecords
+          ? Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              color: Colors.white,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('返回'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: _selected.isEmpty ? null : _onDeleteSelected,
+                      child: const Text('删除选中'),
+                    ),
+                  ),
+                ],
+              ),
+            )
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('返回'),
+                ),
+              ),
+            ),
+    );
+  }
+
+  void _onDeleteSelected() {
+    final removed = _selected.map((index) => _records[index]).toList();
+    Navigator.of(context).pop(removed);
+  }
+}

--- a/lib/modules/inventory_task/collection_task/models/inventory_collect_models.dart
+++ b/lib/modules/inventory_task/collection_task/models/inventory_collect_models.dart
@@ -1,0 +1,93 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_collect_models.freezed.dart';
+part 'inventory_collect_models.g.dart';
+
+/// 盘点任务明细查询参数
+@freezed
+class InventoryTaskItemQuery with _$InventoryTaskItemQuery {
+  const factory InventoryTaskItemQuery({
+    @JsonKey(name: 'taskId') required String taskId,
+    @JsonKey(name: 'roomTag') @Default('0') String roomTag,
+  }) = _InventoryTaskItemQuery;
+
+  factory InventoryTaskItemQuery.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskItemQueryFromJson(json);
+}
+
+/// 盘点任务明细项
+@freezed
+class InventoryTaskItem with _$InventoryTaskItem {
+  const factory InventoryTaskItem({
+    @JsonKey(name: 'itemid') required String itemId,
+    @JsonKey(name: 'checktaskno') String? checkTaskNo,
+    @JsonKey(name: 'matcode') required String materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'storesiteno') required String storeSiteNo,
+    @JsonKey(name: 'storeroomno') String? storeRoomNo,
+    @JsonKey(name: 'storeroomname') String? storeRoomName,
+    @JsonKey(name: 'systemquantity') @Default(0) double systemQuantity,
+    @JsonKey(name: 'actualquantity') @Default(0) double actualQuantity,
+    @JsonKey(name: 'difference') @Default(0) double difference,
+    @JsonKey(name: 'collectdataqty') @Default(0) double collectedQuantity,
+    @JsonKey(name: 'checkmethod_nm') String? checkMethodName,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNo,
+    @JsonKey(name: 'unit') String? unit,
+  }) = _InventoryTaskItem;
+
+  factory InventoryTaskItem.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskItemFromJson(json);
+}
+
+/// 扫码解析结果
+@freezed
+class InventoryBarcodeContent with _$InventoryBarcodeContent {
+  const factory InventoryBarcodeContent({
+    @JsonKey(name: 'matcode') String? materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNo,
+    @JsonKey(name: 'qty') @Default(0) double quantity,
+    @JsonKey(name: 'unit') String? unit,
+  }) = _InventoryBarcodeContent;
+
+  factory InventoryBarcodeContent.fromJson(Map<String, dynamic> json) =>
+      _$InventoryBarcodeContentFromJson(json);
+}
+
+/// 盘点采集记录
+@freezed
+class InventoryCollectRecord with _$InventoryCollectRecord {
+  const factory InventoryCollectRecord({
+    @JsonKey(name: 'itemid') required String itemId,
+    @JsonKey(name: 'matcode') required String materialCode,
+    @JsonKey(name: 'matname') String? materialName,
+    @JsonKey(name: 'storesiteno') required String storeSiteNo,
+    @JsonKey(name: 'storeroomno') String? storeRoomNo,
+    @JsonKey(name: 'systemquantity') @Default(0) double systemQuantity,
+    @JsonKey(name: 'actualquantity') @Default(0) double actualQuantity,
+    @JsonKey(name: 'difference') @Default(0) double difference,
+    @JsonKey(name: 'batchno') String? batchNo,
+    @JsonKey(name: 'sn') String? serialNo,
+    @JsonKey(name: 'unit') String? unit,
+    @JsonKey(name: 'taskComment') String? taskComment,
+  }) = _InventoryCollectRecord;
+
+  factory InventoryCollectRecord.fromJson(Map<String, dynamic> json) =>
+      _$InventoryCollectRecordFromJson(json);
+}
+
+/// 盘点采集提交请求
+@freezed
+class InventoryCommitRequest with _$InventoryCommitRequest {
+  const factory InventoryCommitRequest({
+    @JsonKey(name: 'inventoryInfos')
+    @Default(<InventoryCollectRecord>[])
+    List<InventoryCollectRecord> records,
+    @JsonKey(name: 'taskComment') required String taskComment,
+  }) = _InventoryCommitRequest;
+
+  factory InventoryCommitRequest.fromJson(Map<String, dynamic> json) =>
+      _$InventoryCommitRequestFromJson(json);
+}

--- a/lib/modules/inventory_task/collection_task/models/inventory_collect_models.freezed.dart
+++ b/lib/modules/inventory_task/collection_task/models/inventory_collect_models.freezed.dart
@@ -1,0 +1,1563 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_collect_models.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+InventoryTaskItemQuery _$InventoryTaskItemQueryFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryTaskItemQuery.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskItemQuery {
+  @JsonKey(name: 'taskId')
+  String get taskId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'roomTag')
+  String get roomTag => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskItemQueryCopyWith<InventoryTaskItemQuery> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskItemQueryCopyWith<$Res> {
+  factory $InventoryTaskItemQueryCopyWith(InventoryTaskItemQuery value,
+          $Res Function(InventoryTaskItemQuery) then) =
+      _$InventoryTaskItemQueryCopyWithImpl<$Res, InventoryTaskItemQuery>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskId') String taskId,
+      @JsonKey(name: 'roomTag') String roomTag});
+}
+
+/// @nodoc
+class _$InventoryTaskItemQueryCopyWithImpl<$Res,
+        $Val extends InventoryTaskItemQuery>
+    implements $InventoryTaskItemQueryCopyWith<$Res> {
+  _$InventoryTaskItemQueryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskId = null,
+    Object? roomTag = null,
+  }) {
+    return _then(_value.copyWith(
+      taskId: null == taskId
+          ? _value.taskId
+          : taskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roomTag: null == roomTag
+          ? _value.roomTag
+          : roomTag // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskItemQueryImplCopyWith<$Res>
+    implements $InventoryTaskItemQueryCopyWith<$Res> {
+  factory _$$InventoryTaskItemQueryImplCopyWith(
+          _$InventoryTaskItemQueryImpl value,
+          $Res Function(_$InventoryTaskItemQueryImpl) then) =
+      __$$InventoryTaskItemQueryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskId') String taskId,
+      @JsonKey(name: 'roomTag') String roomTag});
+}
+
+/// @nodoc
+class __$$InventoryTaskItemQueryImplCopyWithImpl<$Res>
+    extends _$InventoryTaskItemQueryCopyWithImpl<$Res,
+        _$InventoryTaskItemQueryImpl>
+    implements _$$InventoryTaskItemQueryImplCopyWith<$Res> {
+  __$$InventoryTaskItemQueryImplCopyWithImpl(
+      _$InventoryTaskItemQueryImpl _value,
+      $Res Function(_$InventoryTaskItemQueryImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskId = null,
+    Object? roomTag = null,
+  }) {
+    return _then(_$InventoryTaskItemQueryImpl(
+      taskId: null == taskId
+          ? _value.taskId
+          : taskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roomTag: null == roomTag
+          ? _value.roomTag
+          : roomTag // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskItemQueryImpl implements _InventoryTaskItemQuery {
+  const _$InventoryTaskItemQueryImpl(
+      {@JsonKey(name: 'taskId') required this.taskId,
+      @JsonKey(name: 'roomTag') this.roomTag = '0'});
+
+  factory _$InventoryTaskItemQueryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskItemQueryImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'taskId')
+  final String taskId;
+  @override
+  @JsonKey(name: 'roomTag')
+  final String roomTag;
+
+  @override
+  String toString() {
+    return 'InventoryTaskItemQuery(taskId: $taskId, roomTag: $roomTag)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskItemQueryImpl &&
+            (identical(other.taskId, taskId) || other.taskId == taskId) &&
+            (identical(other.roomTag, roomTag) || other.roomTag == roomTag));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, taskId, roomTag);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskItemQueryImplCopyWith<_$InventoryTaskItemQueryImpl>
+      get copyWith => __$$InventoryTaskItemQueryImplCopyWithImpl<
+          _$InventoryTaskItemQueryImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskItemQueryImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskItemQuery implements InventoryTaskItemQuery {
+  const factory _InventoryTaskItemQuery(
+          {@JsonKey(name: 'taskId') required final String taskId,
+          @JsonKey(name: 'roomTag') final String roomTag}) =
+      _$InventoryTaskItemQueryImpl;
+
+  factory _InventoryTaskItemQuery.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskItemQueryImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'taskId')
+  String get taskId;
+  @override
+  @JsonKey(name: 'roomTag')
+  String get roomTag;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskItemQueryImplCopyWith<_$InventoryTaskItemQueryImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+InventoryTaskItem _$InventoryTaskItemFromJson(Map<String, dynamic> json) {
+  return _InventoryTaskItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskItem {
+  @JsonKey(name: 'itemid')
+  String get itemId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'checktaskno')
+  String? get checkTaskNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matcode')
+  String get materialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matname')
+  String? get materialName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storesiteno')
+  String get storeSiteNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoomNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storeroomname')
+  String? get storeRoomName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'systemquantity')
+  double get systemQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'actualquantity')
+  double get actualQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'difference')
+  double get difference => throw _privateConstructorUsedError;
+  @JsonKey(name: 'collectdataqty')
+  double get collectedQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'checkmethod_nm')
+  String? get checkMethodName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'batchno')
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sn')
+  String? get serialNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'unit')
+  String? get unit => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskItemCopyWith<InventoryTaskItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskItemCopyWith<$Res> {
+  factory $InventoryTaskItemCopyWith(
+          InventoryTaskItem value, $Res Function(InventoryTaskItem) then) =
+      _$InventoryTaskItemCopyWithImpl<$Res, InventoryTaskItem>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'itemid') String itemId,
+      @JsonKey(name: 'checktaskno') String? checkTaskNo,
+      @JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'storesiteno') String storeSiteNo,
+      @JsonKey(name: 'storeroomno') String? storeRoomNo,
+      @JsonKey(name: 'storeroomname') String? storeRoomName,
+      @JsonKey(name: 'systemquantity') double systemQuantity,
+      @JsonKey(name: 'actualquantity') double actualQuantity,
+      @JsonKey(name: 'difference') double difference,
+      @JsonKey(name: 'collectdataqty') double collectedQuantity,
+      @JsonKey(name: 'checkmethod_nm') String? checkMethodName,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'unit') String? unit});
+}
+
+/// @nodoc
+class _$InventoryTaskItemCopyWithImpl<$Res, $Val extends InventoryTaskItem>
+    implements $InventoryTaskItemCopyWith<$Res> {
+  _$InventoryTaskItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? itemId = null,
+    Object? checkTaskNo = freezed,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? storeSiteNo = null,
+    Object? storeRoomNo = freezed,
+    Object? storeRoomName = freezed,
+    Object? systemQuantity = null,
+    Object? actualQuantity = null,
+    Object? difference = null,
+    Object? collectedQuantity = null,
+    Object? checkMethodName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? unit = freezed,
+  }) {
+    return _then(_value.copyWith(
+      itemId: null == itemId
+          ? _value.itemId
+          : itemId // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskNo: freezed == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomName: freezed == storeRoomName
+          ? _value.storeRoomName
+          : storeRoomName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      systemQuantity: null == systemQuantity
+          ? _value.systemQuantity
+          : systemQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      actualQuantity: null == actualQuantity
+          ? _value.actualQuantity
+          : actualQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      difference: null == difference
+          ? _value.difference
+          : difference // ignore: cast_nullable_to_non_nullable
+              as double,
+      collectedQuantity: null == collectedQuantity
+          ? _value.collectedQuantity
+          : collectedQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      checkMethodName: freezed == checkMethodName
+          ? _value.checkMethodName
+          : checkMethodName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      unit: freezed == unit
+          ? _value.unit
+          : unit // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskItemImplCopyWith<$Res>
+    implements $InventoryTaskItemCopyWith<$Res> {
+  factory _$$InventoryTaskItemImplCopyWith(_$InventoryTaskItemImpl value,
+          $Res Function(_$InventoryTaskItemImpl) then) =
+      __$$InventoryTaskItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'itemid') String itemId,
+      @JsonKey(name: 'checktaskno') String? checkTaskNo,
+      @JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'storesiteno') String storeSiteNo,
+      @JsonKey(name: 'storeroomno') String? storeRoomNo,
+      @JsonKey(name: 'storeroomname') String? storeRoomName,
+      @JsonKey(name: 'systemquantity') double systemQuantity,
+      @JsonKey(name: 'actualquantity') double actualQuantity,
+      @JsonKey(name: 'difference') double difference,
+      @JsonKey(name: 'collectdataqty') double collectedQuantity,
+      @JsonKey(name: 'checkmethod_nm') String? checkMethodName,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'unit') String? unit});
+}
+
+/// @nodoc
+class __$$InventoryTaskItemImplCopyWithImpl<$Res>
+    extends _$InventoryTaskItemCopyWithImpl<$Res, _$InventoryTaskItemImpl>
+    implements _$$InventoryTaskItemImplCopyWith<$Res> {
+  __$$InventoryTaskItemImplCopyWithImpl(_$InventoryTaskItemImpl _value,
+      $Res Function(_$InventoryTaskItemImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? itemId = null,
+    Object? checkTaskNo = freezed,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? storeSiteNo = null,
+    Object? storeRoomNo = freezed,
+    Object? storeRoomName = freezed,
+    Object? systemQuantity = null,
+    Object? actualQuantity = null,
+    Object? difference = null,
+    Object? collectedQuantity = null,
+    Object? checkMethodName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? unit = freezed,
+  }) {
+    return _then(_$InventoryTaskItemImpl(
+      itemId: null == itemId
+          ? _value.itemId
+          : itemId // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskNo: freezed == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomName: freezed == storeRoomName
+          ? _value.storeRoomName
+          : storeRoomName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      systemQuantity: null == systemQuantity
+          ? _value.systemQuantity
+          : systemQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      actualQuantity: null == actualQuantity
+          ? _value.actualQuantity
+          : actualQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      difference: null == difference
+          ? _value.difference
+          : difference // ignore: cast_nullable_to_non_nullable
+              as double,
+      collectedQuantity: null == collectedQuantity
+          ? _value.collectedQuantity
+          : collectedQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      checkMethodName: freezed == checkMethodName
+          ? _value.checkMethodName
+          : checkMethodName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      unit: freezed == unit
+          ? _value.unit
+          : unit // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskItemImpl implements _InventoryTaskItem {
+  const _$InventoryTaskItemImpl(
+      {@JsonKey(name: 'itemid') required this.itemId,
+      @JsonKey(name: 'checktaskno') this.checkTaskNo,
+      @JsonKey(name: 'matcode') required this.materialCode,
+      @JsonKey(name: 'matname') this.materialName,
+      @JsonKey(name: 'storesiteno') required this.storeSiteNo,
+      @JsonKey(name: 'storeroomno') this.storeRoomNo,
+      @JsonKey(name: 'storeroomname') this.storeRoomName,
+      @JsonKey(name: 'systemquantity') this.systemQuantity = 0,
+      @JsonKey(name: 'actualquantity') this.actualQuantity = 0,
+      @JsonKey(name: 'difference') this.difference = 0,
+      @JsonKey(name: 'collectdataqty') this.collectedQuantity = 0,
+      @JsonKey(name: 'checkmethod_nm') this.checkMethodName,
+      @JsonKey(name: 'batchno') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNo,
+      @JsonKey(name: 'unit') this.unit});
+
+  factory _$InventoryTaskItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskItemImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'itemid')
+  final String itemId;
+  @override
+  @JsonKey(name: 'checktaskno')
+  final String? checkTaskNo;
+  @override
+  @JsonKey(name: 'matcode')
+  final String materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  final String? materialName;
+  @override
+  @JsonKey(name: 'storesiteno')
+  final String storeSiteNo;
+  @override
+  @JsonKey(name: 'storeroomno')
+  final String? storeRoomNo;
+  @override
+  @JsonKey(name: 'storeroomname')
+  final String? storeRoomName;
+  @override
+  @JsonKey(name: 'systemquantity')
+  final double systemQuantity;
+  @override
+  @JsonKey(name: 'actualquantity')
+  final double actualQuantity;
+  @override
+  @JsonKey(name: 'difference')
+  final double difference;
+  @override
+  @JsonKey(name: 'collectdataqty')
+  final double collectedQuantity;
+  @override
+  @JsonKey(name: 'checkmethod_nm')
+  final String? checkMethodName;
+  @override
+  @JsonKey(name: 'batchno')
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNo;
+  @override
+  @JsonKey(name: 'unit')
+  final String? unit;
+
+  @override
+  String toString() {
+    return 'InventoryTaskItem(itemId: $itemId, checkTaskNo: $checkTaskNo, materialCode: $materialCode, materialName: $materialName, storeSiteNo: $storeSiteNo, storeRoomNo: $storeRoomNo, storeRoomName: $storeRoomName, systemQuantity: $systemQuantity, actualQuantity: $actualQuantity, difference: $difference, collectedQuantity: $collectedQuantity, checkMethodName: $checkMethodName, batchNo: $batchNo, serialNo: $serialNo, unit: $unit)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskItemImpl &&
+            (identical(other.itemId, itemId) || other.itemId == itemId) &&
+            (identical(other.checkTaskNo, checkTaskNo) ||
+                other.checkTaskNo == checkTaskNo) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeRoomName, storeRoomName) ||
+                other.storeRoomName == storeRoomName) &&
+            (identical(other.systemQuantity, systemQuantity) ||
+                other.systemQuantity == systemQuantity) &&
+            (identical(other.actualQuantity, actualQuantity) ||
+                other.actualQuantity == actualQuantity) &&
+            (identical(other.difference, difference) ||
+                other.difference == difference) &&
+            (identical(other.collectedQuantity, collectedQuantity) ||
+                other.collectedQuantity == collectedQuantity) &&
+            (identical(other.checkMethodName, checkMethodName) ||
+                other.checkMethodName == checkMethodName) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo) &&
+            (identical(other.unit, unit) || other.unit == unit));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      itemId,
+      checkTaskNo,
+      materialCode,
+      materialName,
+      storeSiteNo,
+      storeRoomNo,
+      storeRoomName,
+      systemQuantity,
+      actualQuantity,
+      difference,
+      collectedQuantity,
+      checkMethodName,
+      batchNo,
+      serialNo,
+      unit);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskItemImplCopyWith<_$InventoryTaskItemImpl> get copyWith =>
+      __$$InventoryTaskItemImplCopyWithImpl<_$InventoryTaskItemImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskItemImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskItem implements InventoryTaskItem {
+  const factory _InventoryTaskItem(
+      {@JsonKey(name: 'itemid') required final String itemId,
+      @JsonKey(name: 'checktaskno') final String? checkTaskNo,
+      @JsonKey(name: 'matcode') required final String materialCode,
+      @JsonKey(name: 'matname') final String? materialName,
+      @JsonKey(name: 'storesiteno') required final String storeSiteNo,
+      @JsonKey(name: 'storeroomno') final String? storeRoomNo,
+      @JsonKey(name: 'storeroomname') final String? storeRoomName,
+      @JsonKey(name: 'systemquantity') final double systemQuantity,
+      @JsonKey(name: 'actualquantity') final double actualQuantity,
+      @JsonKey(name: 'difference') final double difference,
+      @JsonKey(name: 'collectdataqty') final double collectedQuantity,
+      @JsonKey(name: 'checkmethod_nm') final String? checkMethodName,
+      @JsonKey(name: 'batchno') final String? batchNo,
+      @JsonKey(name: 'sn') final String? serialNo,
+      @JsonKey(name: 'unit') final String? unit}) = _$InventoryTaskItemImpl;
+
+  factory _InventoryTaskItem.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskItemImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'itemid')
+  String get itemId;
+  @override
+  @JsonKey(name: 'checktaskno')
+  String? get checkTaskNo;
+  @override
+  @JsonKey(name: 'matcode')
+  String get materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  String? get materialName;
+  @override
+  @JsonKey(name: 'storesiteno')
+  String get storeSiteNo;
+  @override
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoomNo;
+  @override
+  @JsonKey(name: 'storeroomname')
+  String? get storeRoomName;
+  @override
+  @JsonKey(name: 'systemquantity')
+  double get systemQuantity;
+  @override
+  @JsonKey(name: 'actualquantity')
+  double get actualQuantity;
+  @override
+  @JsonKey(name: 'difference')
+  double get difference;
+  @override
+  @JsonKey(name: 'collectdataqty')
+  double get collectedQuantity;
+  @override
+  @JsonKey(name: 'checkmethod_nm')
+  String? get checkMethodName;
+  @override
+  @JsonKey(name: 'batchno')
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  String? get serialNo;
+  @override
+  @JsonKey(name: 'unit')
+  String? get unit;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskItemImplCopyWith<_$InventoryTaskItemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventoryBarcodeContent _$InventoryBarcodeContentFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryBarcodeContent.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryBarcodeContent {
+  @JsonKey(name: 'matcode')
+  String? get materialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matname')
+  String? get materialName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'batchno')
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sn')
+  String? get serialNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'qty')
+  double get quantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'unit')
+  String? get unit => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryBarcodeContentCopyWith<InventoryBarcodeContent> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryBarcodeContentCopyWith<$Res> {
+  factory $InventoryBarcodeContentCopyWith(InventoryBarcodeContent value,
+          $Res Function(InventoryBarcodeContent) then) =
+      _$InventoryBarcodeContentCopyWithImpl<$Res, InventoryBarcodeContent>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'matcode') String? materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'qty') double quantity,
+      @JsonKey(name: 'unit') String? unit});
+}
+
+/// @nodoc
+class _$InventoryBarcodeContentCopyWithImpl<$Res,
+        $Val extends InventoryBarcodeContent>
+    implements $InventoryBarcodeContentCopyWith<$Res> {
+  _$InventoryBarcodeContentCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? quantity = null,
+    Object? unit = freezed,
+  }) {
+    return _then(_value.copyWith(
+      materialCode: freezed == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      quantity: null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      unit: freezed == unit
+          ? _value.unit
+          : unit // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryBarcodeContentImplCopyWith<$Res>
+    implements $InventoryBarcodeContentCopyWith<$Res> {
+  factory _$$InventoryBarcodeContentImplCopyWith(
+          _$InventoryBarcodeContentImpl value,
+          $Res Function(_$InventoryBarcodeContentImpl) then) =
+      __$$InventoryBarcodeContentImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'matcode') String? materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'qty') double quantity,
+      @JsonKey(name: 'unit') String? unit});
+}
+
+/// @nodoc
+class __$$InventoryBarcodeContentImplCopyWithImpl<$Res>
+    extends _$InventoryBarcodeContentCopyWithImpl<$Res,
+        _$InventoryBarcodeContentImpl>
+    implements _$$InventoryBarcodeContentImplCopyWith<$Res> {
+  __$$InventoryBarcodeContentImplCopyWithImpl(
+      _$InventoryBarcodeContentImpl _value,
+      $Res Function(_$InventoryBarcodeContentImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = freezed,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? quantity = null,
+    Object? unit = freezed,
+  }) {
+    return _then(_$InventoryBarcodeContentImpl(
+      materialCode: freezed == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      quantity: null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      unit: freezed == unit
+          ? _value.unit
+          : unit // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryBarcodeContentImpl implements _InventoryBarcodeContent {
+  const _$InventoryBarcodeContentImpl(
+      {@JsonKey(name: 'matcode') this.materialCode,
+      @JsonKey(name: 'matname') this.materialName,
+      @JsonKey(name: 'batchno') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNo,
+      @JsonKey(name: 'qty') this.quantity = 0,
+      @JsonKey(name: 'unit') this.unit});
+
+  factory _$InventoryBarcodeContentImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryBarcodeContentImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'matcode')
+  final String? materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  final String? materialName;
+  @override
+  @JsonKey(name: 'batchno')
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNo;
+  @override
+  @JsonKey(name: 'qty')
+  final double quantity;
+  @override
+  @JsonKey(name: 'unit')
+  final String? unit;
+
+  @override
+  String toString() {
+    return 'InventoryBarcodeContent(materialCode: $materialCode, materialName: $materialName, batchNo: $batchNo, serialNo: $serialNo, quantity: $quantity, unit: $unit)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryBarcodeContentImpl &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo) &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity) &&
+            (identical(other.unit, unit) || other.unit == unit));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, materialCode, materialName,
+      batchNo, serialNo, quantity, unit);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryBarcodeContentImplCopyWith<_$InventoryBarcodeContentImpl>
+      get copyWith => __$$InventoryBarcodeContentImplCopyWithImpl<
+          _$InventoryBarcodeContentImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryBarcodeContentImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryBarcodeContent implements InventoryBarcodeContent {
+  const factory _InventoryBarcodeContent(
+          {@JsonKey(name: 'matcode') final String? materialCode,
+          @JsonKey(name: 'matname') final String? materialName,
+          @JsonKey(name: 'batchno') final String? batchNo,
+          @JsonKey(name: 'sn') final String? serialNo,
+          @JsonKey(name: 'qty') final double quantity,
+          @JsonKey(name: 'unit') final String? unit}) =
+      _$InventoryBarcodeContentImpl;
+
+  factory _InventoryBarcodeContent.fromJson(Map<String, dynamic> json) =
+      _$InventoryBarcodeContentImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'matcode')
+  String? get materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  String? get materialName;
+  @override
+  @JsonKey(name: 'batchno')
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  String? get serialNo;
+  @override
+  @JsonKey(name: 'qty')
+  double get quantity;
+  @override
+  @JsonKey(name: 'unit')
+  String? get unit;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryBarcodeContentImplCopyWith<_$InventoryBarcodeContentImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+InventoryCollectRecord _$InventoryCollectRecordFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryCollectRecord.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryCollectRecord {
+  @JsonKey(name: 'itemid')
+  String get itemId => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matcode')
+  String get materialCode => throw _privateConstructorUsedError;
+  @JsonKey(name: 'matname')
+  String? get materialName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storesiteno')
+  String get storeSiteNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoomNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'systemquantity')
+  double get systemQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'actualquantity')
+  double get actualQuantity => throw _privateConstructorUsedError;
+  @JsonKey(name: 'difference')
+  double get difference => throw _privateConstructorUsedError;
+  @JsonKey(name: 'batchno')
+  String? get batchNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'sn')
+  String? get serialNo => throw _privateConstructorUsedError;
+  @JsonKey(name: 'unit')
+  String? get unit => throw _privateConstructorUsedError;
+  @JsonKey(name: 'taskComment')
+  String? get taskComment => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryCollectRecordCopyWith<InventoryCollectRecord> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryCollectRecordCopyWith<$Res> {
+  factory $InventoryCollectRecordCopyWith(InventoryCollectRecord value,
+          $Res Function(InventoryCollectRecord) then) =
+      _$InventoryCollectRecordCopyWithImpl<$Res, InventoryCollectRecord>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'itemid') String itemId,
+      @JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'storesiteno') String storeSiteNo,
+      @JsonKey(name: 'storeroomno') String? storeRoomNo,
+      @JsonKey(name: 'systemquantity') double systemQuantity,
+      @JsonKey(name: 'actualquantity') double actualQuantity,
+      @JsonKey(name: 'difference') double difference,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'unit') String? unit,
+      @JsonKey(name: 'taskComment') String? taskComment});
+}
+
+/// @nodoc
+class _$InventoryCollectRecordCopyWithImpl<$Res,
+        $Val extends InventoryCollectRecord>
+    implements $InventoryCollectRecordCopyWith<$Res> {
+  _$InventoryCollectRecordCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? itemId = null,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? storeSiteNo = null,
+    Object? storeRoomNo = freezed,
+    Object? systemQuantity = null,
+    Object? actualQuantity = null,
+    Object? difference = null,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? unit = freezed,
+    Object? taskComment = freezed,
+  }) {
+    return _then(_value.copyWith(
+      itemId: null == itemId
+          ? _value.itemId
+          : itemId // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      systemQuantity: null == systemQuantity
+          ? _value.systemQuantity
+          : systemQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      actualQuantity: null == actualQuantity
+          ? _value.actualQuantity
+          : actualQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      difference: null == difference
+          ? _value.difference
+          : difference // ignore: cast_nullable_to_non_nullable
+              as double,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      unit: freezed == unit
+          ? _value.unit
+          : unit // ignore: cast_nullable_to_non_nullable
+              as String?,
+      taskComment: freezed == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryCollectRecordImplCopyWith<$Res>
+    implements $InventoryCollectRecordCopyWith<$Res> {
+  factory _$$InventoryCollectRecordImplCopyWith(
+          _$InventoryCollectRecordImpl value,
+          $Res Function(_$InventoryCollectRecordImpl) then) =
+      __$$InventoryCollectRecordImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'itemid') String itemId,
+      @JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'storesiteno') String storeSiteNo,
+      @JsonKey(name: 'storeroomno') String? storeRoomNo,
+      @JsonKey(name: 'systemquantity') double systemQuantity,
+      @JsonKey(name: 'actualquantity') double actualQuantity,
+      @JsonKey(name: 'difference') double difference,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'unit') String? unit,
+      @JsonKey(name: 'taskComment') String? taskComment});
+}
+
+/// @nodoc
+class __$$InventoryCollectRecordImplCopyWithImpl<$Res>
+    extends _$InventoryCollectRecordCopyWithImpl<$Res,
+        _$InventoryCollectRecordImpl>
+    implements _$$InventoryCollectRecordImplCopyWith<$Res> {
+  __$$InventoryCollectRecordImplCopyWithImpl(
+      _$InventoryCollectRecordImpl _value,
+      $Res Function(_$InventoryCollectRecordImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? itemId = null,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? storeSiteNo = null,
+    Object? storeRoomNo = freezed,
+    Object? systemQuantity = null,
+    Object? actualQuantity = null,
+    Object? difference = null,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? unit = freezed,
+    Object? taskComment = freezed,
+  }) {
+    return _then(_$InventoryCollectRecordImpl(
+      itemId: null == itemId
+          ? _value.itemId
+          : itemId // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      systemQuantity: null == systemQuantity
+          ? _value.systemQuantity
+          : systemQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      actualQuantity: null == actualQuantity
+          ? _value.actualQuantity
+          : actualQuantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      difference: null == difference
+          ? _value.difference
+          : difference // ignore: cast_nullable_to_non_nullable
+              as double,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      unit: freezed == unit
+          ? _value.unit
+          : unit // ignore: cast_nullable_to_non_nullable
+              as String?,
+      taskComment: freezed == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryCollectRecordImpl implements _InventoryCollectRecord {
+  const _$InventoryCollectRecordImpl(
+      {@JsonKey(name: 'itemid') required this.itemId,
+      @JsonKey(name: 'matcode') required this.materialCode,
+      @JsonKey(name: 'matname') this.materialName,
+      @JsonKey(name: 'storesiteno') required this.storeSiteNo,
+      @JsonKey(name: 'storeroomno') this.storeRoomNo,
+      @JsonKey(name: 'systemquantity') this.systemQuantity = 0,
+      @JsonKey(name: 'actualquantity') this.actualQuantity = 0,
+      @JsonKey(name: 'difference') this.difference = 0,
+      @JsonKey(name: 'batchno') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNo,
+      @JsonKey(name: 'unit') this.unit,
+      @JsonKey(name: 'taskComment') this.taskComment});
+
+  factory _$InventoryCollectRecordImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryCollectRecordImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'itemid')
+  final String itemId;
+  @override
+  @JsonKey(name: 'matcode')
+  final String materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  final String? materialName;
+  @override
+  @JsonKey(name: 'storesiteno')
+  final String storeSiteNo;
+  @override
+  @JsonKey(name: 'storeroomno')
+  final String? storeRoomNo;
+  @override
+  @JsonKey(name: 'systemquantity')
+  final double systemQuantity;
+  @override
+  @JsonKey(name: 'actualquantity')
+  final double actualQuantity;
+  @override
+  @JsonKey(name: 'difference')
+  final double difference;
+  @override
+  @JsonKey(name: 'batchno')
+  final String? batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  final String? serialNo;
+  @override
+  @JsonKey(name: 'unit')
+  final String? unit;
+  @override
+  @JsonKey(name: 'taskComment')
+  final String? taskComment;
+
+  @override
+  String toString() {
+    return 'InventoryCollectRecord(itemId: $itemId, materialCode: $materialCode, materialName: $materialName, storeSiteNo: $storeSiteNo, storeRoomNo: $storeRoomNo, systemQuantity: $systemQuantity, actualQuantity: $actualQuantity, difference: $difference, batchNo: $batchNo, serialNo: $serialNo, unit: $unit, taskComment: $taskComment)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryCollectRecordImpl &&
+            (identical(other.itemId, itemId) || other.itemId == itemId) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.systemQuantity, systemQuantity) ||
+                other.systemQuantity == systemQuantity) &&
+            (identical(other.actualQuantity, actualQuantity) ||
+                other.actualQuantity == actualQuantity) &&
+            (identical(other.difference, difference) ||
+                other.difference == difference) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo) &&
+            (identical(other.unit, unit) || other.unit == unit) &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      itemId,
+      materialCode,
+      materialName,
+      storeSiteNo,
+      storeRoomNo,
+      systemQuantity,
+      actualQuantity,
+      difference,
+      batchNo,
+      serialNo,
+      unit,
+      taskComment);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryCollectRecordImplCopyWith<_$InventoryCollectRecordImpl>
+      get copyWith => __$$InventoryCollectRecordImplCopyWithImpl<
+          _$InventoryCollectRecordImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryCollectRecordImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryCollectRecord implements InventoryCollectRecord {
+  const factory _InventoryCollectRecord(
+          {@JsonKey(name: 'itemid') required final String itemId,
+          @JsonKey(name: 'matcode') required final String materialCode,
+          @JsonKey(name: 'matname') final String? materialName,
+          @JsonKey(name: 'storesiteno') required final String storeSiteNo,
+          @JsonKey(name: 'storeroomno') final String? storeRoomNo,
+          @JsonKey(name: 'systemquantity') final double systemQuantity,
+          @JsonKey(name: 'actualquantity') final double actualQuantity,
+          @JsonKey(name: 'difference') final double difference,
+          @JsonKey(name: 'batchno') final String? batchNo,
+          @JsonKey(name: 'sn') final String? serialNo,
+          @JsonKey(name: 'unit') final String? unit,
+          @JsonKey(name: 'taskComment') final String? taskComment}) =
+      _$InventoryCollectRecordImpl;
+
+  factory _InventoryCollectRecord.fromJson(Map<String, dynamic> json) =
+      _$InventoryCollectRecordImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'itemid')
+  String get itemId;
+  @override
+  @JsonKey(name: 'matcode')
+  String get materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  String? get materialName;
+  @override
+  @JsonKey(name: 'storesiteno')
+  String get storeSiteNo;
+  @override
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoomNo;
+  @override
+  @JsonKey(name: 'systemquantity')
+  double get systemQuantity;
+  @override
+  @JsonKey(name: 'actualquantity')
+  double get actualQuantity;
+  @override
+  @JsonKey(name: 'difference')
+  double get difference;
+  @override
+  @JsonKey(name: 'batchno')
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'sn')
+  String? get serialNo;
+  @override
+  @JsonKey(name: 'unit')
+  String? get unit;
+  @override
+  @JsonKey(name: 'taskComment')
+  String? get taskComment;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryCollectRecordImplCopyWith<_$InventoryCollectRecordImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+InventoryCommitRequest _$InventoryCommitRequestFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryCommitRequest.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryCommitRequest {
+  @JsonKey(name: 'inventoryInfos')
+  List<InventoryCollectRecord> get records =>
+      throw _privateConstructorUsedError;
+  @JsonKey(name: 'taskComment')
+  String get taskComment => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryCommitRequestCopyWith<InventoryCommitRequest> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryCommitRequestCopyWith<$Res> {
+  factory $InventoryCommitRequestCopyWith(InventoryCommitRequest value,
+          $Res Function(InventoryCommitRequest) then) =
+      _$InventoryCommitRequestCopyWithImpl<$Res, InventoryCommitRequest>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'inventoryInfos') List<InventoryCollectRecord> records,
+      @JsonKey(name: 'taskComment') String taskComment});
+}
+
+/// @nodoc
+class _$InventoryCommitRequestCopyWithImpl<$Res,
+        $Val extends InventoryCommitRequest>
+    implements $InventoryCommitRequestCopyWith<$Res> {
+  _$InventoryCommitRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? records = null,
+    Object? taskComment = null,
+  }) {
+    return _then(_value.copyWith(
+      records: null == records
+          ? _value.records
+          : records // ignore: cast_nullable_to_non_nullable
+              as List<InventoryCollectRecord>,
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryCommitRequestImplCopyWith<$Res>
+    implements $InventoryCommitRequestCopyWith<$Res> {
+  factory _$$InventoryCommitRequestImplCopyWith(
+          _$InventoryCommitRequestImpl value,
+          $Res Function(_$InventoryCommitRequestImpl) then) =
+      __$$InventoryCommitRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'inventoryInfos') List<InventoryCollectRecord> records,
+      @JsonKey(name: 'taskComment') String taskComment});
+}
+
+/// @nodoc
+class __$$InventoryCommitRequestImplCopyWithImpl<$Res>
+    extends _$InventoryCommitRequestCopyWithImpl<$Res,
+        _$InventoryCommitRequestImpl>
+    implements _$$InventoryCommitRequestImplCopyWith<$Res> {
+  __$$InventoryCommitRequestImplCopyWithImpl(
+      _$InventoryCommitRequestImpl _value,
+      $Res Function(_$InventoryCommitRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? records = null,
+    Object? taskComment = null,
+  }) {
+    return _then(_$InventoryCommitRequestImpl(
+      records: null == records
+          ? _value._records
+          : records // ignore: cast_nullable_to_non_nullable
+              as List<InventoryCollectRecord>,
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryCommitRequestImpl implements _InventoryCommitRequest {
+  const _$InventoryCommitRequestImpl(
+      {@JsonKey(name: 'inventoryInfos')
+      final List<InventoryCollectRecord> records =
+          const <InventoryCollectRecord>[],
+      @JsonKey(name: 'taskComment') required this.taskComment})
+      : _records = records;
+
+  factory _$InventoryCommitRequestImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryCommitRequestImplFromJson(json);
+
+  final List<InventoryCollectRecord> _records;
+  @override
+  @JsonKey(name: 'inventoryInfos')
+  List<InventoryCollectRecord> get records {
+    if (_records is EqualUnmodifiableListView) return _records;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_records);
+  }
+
+  @override
+  @JsonKey(name: 'taskComment')
+  final String taskComment;
+
+  @override
+  String toString() {
+    return 'InventoryCommitRequest(records: $records, taskComment: $taskComment)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryCommitRequestImpl &&
+            const DeepCollectionEquality().equals(other._records, _records) &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_records), taskComment);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryCommitRequestImplCopyWith<_$InventoryCommitRequestImpl>
+      get copyWith => __$$InventoryCommitRequestImplCopyWithImpl<
+          _$InventoryCommitRequestImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryCommitRequestImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryCommitRequest implements InventoryCommitRequest {
+  const factory _InventoryCommitRequest(
+          {@JsonKey(name: 'inventoryInfos')
+          final List<InventoryCollectRecord> records,
+          @JsonKey(name: 'taskComment') required final String taskComment}) =
+      _$InventoryCommitRequestImpl;
+
+  factory _InventoryCommitRequest.fromJson(Map<String, dynamic> json) =
+      _$InventoryCommitRequestImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'inventoryInfos')
+  List<InventoryCollectRecord> get records;
+  @override
+  @JsonKey(name: 'taskComment')
+  String get taskComment;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryCommitRequestImplCopyWith<_$InventoryCommitRequestImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_task/collection_task/models/inventory_collect_models.g.dart
+++ b/lib/modules/inventory_task/collection_task/models/inventory_collect_models.g.dart
@@ -1,0 +1,135 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_collect_models.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryTaskItemQueryImpl _$$InventoryTaskItemQueryImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskItemQueryImpl(
+      taskId: json['taskId'] as String,
+      roomTag: json['roomTag'] as String? ?? '0',
+    );
+
+Map<String, dynamic> _$$InventoryTaskItemQueryImplToJson(
+        _$InventoryTaskItemQueryImpl instance) =>
+    <String, dynamic>{
+      'taskId': instance.taskId,
+      'roomTag': instance.roomTag,
+    };
+
+_$InventoryTaskItemImpl _$$InventoryTaskItemImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskItemImpl(
+      itemId: json['itemid'] as String,
+      checkTaskNo: json['checktaskno'] as String?,
+      materialCode: json['matcode'] as String,
+      materialName: json['matname'] as String?,
+      storeSiteNo: json['storesiteno'] as String,
+      storeRoomNo: json['storeroomno'] as String?,
+      storeRoomName: json['storeroomname'] as String?,
+      systemQuantity: (json['systemquantity'] as num?)?.toDouble() ?? 0,
+      actualQuantity: (json['actualquantity'] as num?)?.toDouble() ?? 0,
+      difference: (json['difference'] as num?)?.toDouble() ?? 0,
+      collectedQuantity: (json['collectdataqty'] as num?)?.toDouble() ?? 0,
+      checkMethodName: json['checkmethod_nm'] as String?,
+      batchNo: json['batchno'] as String?,
+      serialNo: json['sn'] as String?,
+      unit: json['unit'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryTaskItemImplToJson(
+        _$InventoryTaskItemImpl instance) =>
+    <String, dynamic>{
+      'itemid': instance.itemId,
+      'checktaskno': instance.checkTaskNo,
+      'matcode': instance.materialCode,
+      'matname': instance.materialName,
+      'storesiteno': instance.storeSiteNo,
+      'storeroomno': instance.storeRoomNo,
+      'storeroomname': instance.storeRoomName,
+      'systemquantity': instance.systemQuantity,
+      'actualquantity': instance.actualQuantity,
+      'difference': instance.difference,
+      'collectdataqty': instance.collectedQuantity,
+      'checkmethod_nm': instance.checkMethodName,
+      'batchno': instance.batchNo,
+      'sn': instance.serialNo,
+      'unit': instance.unit,
+    };
+
+_$InventoryBarcodeContentImpl _$$InventoryBarcodeContentImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryBarcodeContentImpl(
+      materialCode: json['matcode'] as String?,
+      materialName: json['matname'] as String?,
+      batchNo: json['batchno'] as String?,
+      serialNo: json['sn'] as String?,
+      quantity: (json['qty'] as num?)?.toDouble() ?? 0,
+      unit: json['unit'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryBarcodeContentImplToJson(
+        _$InventoryBarcodeContentImpl instance) =>
+    <String, dynamic>{
+      'matcode': instance.materialCode,
+      'matname': instance.materialName,
+      'batchno': instance.batchNo,
+      'sn': instance.serialNo,
+      'qty': instance.quantity,
+      'unit': instance.unit,
+    };
+
+_$InventoryCollectRecordImpl _$$InventoryCollectRecordImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryCollectRecordImpl(
+      itemId: json['itemid'] as String,
+      materialCode: json['matcode'] as String,
+      materialName: json['matname'] as String?,
+      storeSiteNo: json['storesiteno'] as String,
+      storeRoomNo: json['storeroomno'] as String?,
+      systemQuantity: (json['systemquantity'] as num?)?.toDouble() ?? 0,
+      actualQuantity: (json['actualquantity'] as num?)?.toDouble() ?? 0,
+      difference: (json['difference'] as num?)?.toDouble() ?? 0,
+      batchNo: json['batchno'] as String?,
+      serialNo: json['sn'] as String?,
+      unit: json['unit'] as String?,
+      taskComment: json['taskComment'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryCollectRecordImplToJson(
+        _$InventoryCollectRecordImpl instance) =>
+    <String, dynamic>{
+      'itemid': instance.itemId,
+      'matcode': instance.materialCode,
+      'matname': instance.materialName,
+      'storesiteno': instance.storeSiteNo,
+      'storeroomno': instance.storeRoomNo,
+      'systemquantity': instance.systemQuantity,
+      'actualquantity': instance.actualQuantity,
+      'difference': instance.difference,
+      'batchno': instance.batchNo,
+      'sn': instance.serialNo,
+      'unit': instance.unit,
+      'taskComment': instance.taskComment,
+    };
+
+_$InventoryCommitRequestImpl _$$InventoryCommitRequestImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryCommitRequestImpl(
+      records: (json['inventoryInfos'] as List<dynamic>?)
+              ?.map((e) =>
+                  InventoryCollectRecord.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <InventoryCollectRecord>[],
+      taskComment: json['taskComment'] as String,
+    );
+
+Map<String, dynamic> _$$InventoryCommitRequestImplToJson(
+        _$InventoryCommitRequestImpl instance) =>
+    <String, dynamic>{
+      'inventoryInfos': instance.records,
+      'taskComment': instance.taskComment,
+    };

--- a/lib/modules/inventory_task/collection_task/repositories/inventory_collect_cache_repository.dart
+++ b/lib/modules/inventory_task/collection_task/repositories/inventory_collect_cache_repository.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+import 'package:hive/hive.dart';
+
+import '../models/inventory_collect_models.dart';
+
+/// 管理盘点采集本地缓存
+class InventoryCollectCacheRepository {
+  InventoryCollectCacheRepository(this._hive);
+
+  final HiveInterface _hive;
+
+  Box<String>? _cacheBox;
+
+  Future<void> init(String taskKey) async {
+    final boxName = 'inventory_collect_\$taskKey';
+    _cacheBox = await _hive.openBox<String>(boxName);
+  }
+
+  Future<void> dispose() async {
+    await _cacheBox?.close();
+    _cacheBox = null;
+  }
+
+  Future<List<InventoryCollectRecord>> loadRecords() async {
+    final data = _cacheBox?.values.toList() ?? const [];
+    if (data.isEmpty) {
+      return const [];
+    }
+    return data
+        .map((jsonStr) => InventoryCollectRecord.fromJson(
+              json.decode(jsonStr) as Map<String, dynamic>,
+            ))
+        .toList();
+  }
+
+  Future<void> saveRecords(List<InventoryCollectRecord> records) async {
+    final box = _cacheBox;
+    if (box == null) {
+      throw StateError('InventoryCollectCacheRepository 尚未初始化');
+    }
+    await box.clear();
+    if (records.isEmpty) {
+      return;
+    }
+    final entries = records
+        .map((record) => json.encode(record.toJson()))
+        .toList(growable: false);
+    await box.addAll(entries);
+  }
+
+  Future<void> removeRecord(InventoryCollectRecord record) async {
+    final box = _cacheBox;
+    if (box == null) {
+      throw StateError('InventoryCollectCacheRepository 尚未初始化');
+    }
+    dynamic matchedKey;
+    for (final key in box.keys) {
+      final value = box.get(key) as String?;
+      if (value == null) {
+        continue;
+      }
+      final jsonMap = json.decode(value) as Map<String, dynamic>;
+      final sameItem = jsonMap['itemid']?.toString() == record.itemId &&
+          jsonMap['storesiteno']?.toString() == record.storeSiteNo &&
+          jsonMap['matcode']?.toString() == record.materialCode;
+      if (sameItem) {
+        matchedKey = key;
+        break;
+      }
+    }
+    if (matchedKey != null) {
+      await box.delete(matchedKey);
+    }
+  }
+}

--- a/lib/modules/inventory_task/inventory_task_module.dart
+++ b/lib/modules/inventory_task/inventory_task_module.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:hive/hive.dart';
+
+import '../../app_module.dart';
+import '../../services/dio_client.dart';
+import '../../services/user_manager.dart';
+import 'collection_task/bloc/inventory_collect_bloc.dart';
+import 'collection_task/inventory_collect_page.dart';
+import 'collection_task/repositories/inventory_collect_cache_repository.dart';
+import 'services/inventory_task_service.dart';
+import 'task_list/bloc/inventory_task_bloc.dart';
+import 'task_list/inventory_task_list_page.dart';
+import 'task_receive/bloc/inventory_receive_bloc.dart';
+import 'task_receive/inventory_task_receive_page.dart';
+import 'task_list/models/inventory_task.dart';
+
+class InventoryTaskModule extends Module {
+  @override
+  List<Module> get imports => [AppModule()];
+
+  @override
+  void binds(Injector i) {
+    i.addSingleton<InventoryTaskService>(
+      () => InventoryTaskService(i.get<DioClient>().dio),
+    );
+
+    i.add<InventoryTaskBloc>(
+      () => InventoryTaskBloc(
+        taskService: i.get<InventoryTaskService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+
+    i.add<InventoryReceiveBloc>(
+      () => InventoryReceiveBloc(
+        taskService: i.get<InventoryTaskService>(),
+        userManager: i.get<UserManager>(),
+      ),
+    );
+
+    i.add<InventoryCollectBloc>(
+      () => InventoryCollectBloc(
+        service: i.get<InventoryTaskService>(),
+        cacheRepository: InventoryCollectCacheRepository(Hive),
+      ),
+    );
+  }
+
+  @override
+  void routes(RouteManager r) {
+    r.child(
+      '/',
+      child: (_) => BlocProvider(
+        create: (_) => Modular.get<InventoryTaskBloc>(),
+        child: const InventoryTaskListPage(),
+      ),
+    );
+
+    r.child(
+      '/list',
+      child: (_) => BlocProvider(
+        create: (_) => Modular.get<InventoryTaskBloc>(),
+        child: const InventoryTaskListPage(),
+      ),
+    );
+
+    r.child(
+      '/collect/:checkTaskNo',
+      child: (_) {
+        final data = Modular.args.data as Map? ?? {};
+        final task = data['task'] as InventoryTask?;
+        if (task == null) {
+          return const _TodoPlaceholder(title: '缺少任务信息，无法进入盘点采集');
+        }
+        return BlocProvider(
+          create: (_) => Modular.get<InventoryCollectBloc>(),
+          child: InventoryCollectPage(task: task),
+        );
+      },
+    );
+
+    r.child(
+      '/receive',
+      child: (_) => BlocProvider(
+        create: (_) => Modular.get<InventoryReceiveBloc>(),
+        child: const InventoryTaskReceivePage(),
+      ),
+    );
+  }
+}
+
+class _TodoPlaceholder extends StatelessWidget {
+  const _TodoPlaceholder({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: Center(
+        child: Text(
+          '$title\n请检查路由参数是否完整。',
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/inventory_task/services/inventory_task_service.dart
+++ b/lib/modules/inventory_task/services/inventory_task_service.dart
@@ -1,0 +1,173 @@
+import 'package:dio/dio.dart';
+
+import '../../services/api_response_handler.dart';
+import '../collection_task/models/inventory_collect_models.dart';
+import '../task_list/models/inventory_task.dart';
+
+/// 平库盘点模块服务
+class InventoryTaskService {
+  InventoryTaskService(this._dio);
+
+  final Dio _dio;
+
+  /// 查询盘点任务列表
+  Future<InventoryTaskListResponse> fetchInventoryTasks({
+    required InventoryTaskQuery query,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getInventoryTask',
+      queryParameters: query.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => InventoryTaskListResponse.fromJson(
+        Map<String, dynamic>.from(data as Map),
+      ),
+    );
+  }
+
+  /// 查询待接收盘点任务列表
+  Future<InventoryTaskListResponse> fetchReceivableTasks({
+    required InventoryTaskQuery query,
+  }) async {
+    return fetchInventoryTasks(query: query);
+  }
+
+  /// 撤销盘点任务
+  Future<void> cancelTask({
+    required String taskComment,
+    required String userId,
+  }) async {
+    await _commitInventoryTask(
+      taskComment: taskComment,
+      userId: userId,
+      isCancel: true,
+    );
+  }
+
+  /// 接收盘点任务
+  Future<void> receiveTask({
+    required String taskComment,
+    required String userId,
+  }) async {
+    await _commitInventoryTask(
+      taskComment: taskComment,
+      userId: userId,
+      isCancel: false,
+    );
+  }
+
+  Future<void> _commitInventoryTask({
+    required String taskComment,
+    required String userId,
+    required bool isCancel,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/commitInventoryTask',
+      queryParameters: {
+        'taskcomment': taskComment,
+        'userId': userId,
+        'isCanel': isCancel.toString(),
+      },
+    );
+
+    ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => data,
+    );
+  }
+
+  /// 查询盘点任务明细
+  Future<List<InventoryTaskItem>> fetchInventoryTaskItems({
+    required InventoryTaskItemQuery query,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getInventoryTaskItem',
+      queryParameters: query.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          return data
+              .map(
+                (e) => InventoryTaskItem.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList();
+        }
+        if (data is Map<String, dynamic>) {
+          final items = data['items'] as List? ?? const [];
+          return items
+              .map(
+                (e) => InventoryTaskItem.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList();
+        }
+        throw Exception('盘点任务明细返回格式异常');
+      },
+    );
+  }
+
+  /// 解析二维码信息
+  Future<InventoryBarcodeContent> fetchBarcodeContent(String qrContent) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/materialInfo',
+      queryParameters: {'QRstring': qrContent},
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => InventoryBarcodeContent.fromJson(
+        Map<String, dynamic>.from(data as Map),
+      ),
+    );
+  }
+
+  /// 提交盘点采集结果
+  Future<void> submitInventoryInfos(InventoryCommitRequest request) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/commitInventoryInfos',
+      data: request.toJson(),
+      options: Options(
+        headers: const {
+          'content-type': 'application/json;charset=UTF-8',
+        },
+      ),
+    );
+
+    ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => data,
+    );
+  }
+
+  /// 校验库位
+  Future<bool> validateStoreSite({
+    required String storeRoomNo,
+    required String storeSiteNo,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getStoreSite',
+      queryParameters: {
+        'storeRoomNo': storeRoomNo,
+        'storeSiteNo': storeSiteNo,
+      },
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List && data.isNotEmpty) {
+          return true;
+        }
+        return false;
+      },
+    );
+  }
+}

--- a/lib/modules/inventory_task/task_list/bloc/inventory_task_bloc.dart
+++ b/lib/modules/inventory_task/task_list/bloc/inventory_task_bloc.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:meta/meta.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_state.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+import '../../services/inventory_task_service.dart';
+import '../models/inventory_task.dart';
+import 'inventory_task_event.dart';
+import 'inventory_task_state.dart';
+
+@immutable
+class InventoryTaskBloc extends Bloc<InventoryTaskEvent, InventoryTaskState> {
+  InventoryTaskBloc({
+    required InventoryTaskService taskService,
+    required UserManager userManager,
+  })  : _taskService = taskService,
+        _userManager = userManager,
+        super(
+          InventoryTaskState(
+            filter: InventoryTaskQuery(
+              userId: '${userManager.userInfo?.userId ?? ''}',
+              roleOrUserId: '${userManager.userInfo?.userId ?? ''}',
+            ),
+          ),
+        ) {
+    on<_Started>(_onStarted);
+    on<_Scanned>(_onScanned);
+    on<_SearchSubmitted>(_onSearchSubmitted);
+    on<_PageChanged>(_onPageChanged);
+    on<_RefreshRequested>(_onRefreshRequested);
+    on<_CancelTaskRequested>(_onCancelTaskRequested);
+
+    _gridBloc = CommonDataGridBloc<InventoryTask>(
+      dataLoader: _createDataLoader(),
+    );
+  }
+
+  final InventoryTaskService _taskService;
+  final UserManager _userManager;
+
+  late final CommonDataGridBloc<InventoryTask> _gridBloc;
+  CommonDataGridBloc<InventoryTask> get gridBloc => _gridBloc;
+
+  int _latestTotalCount = 0;
+  bool _ignoreNextPageChange = false;
+
+  DataGridLoader<InventoryTask> _createDataLoader() {
+    return (pageIndex) async {
+      final filter = state.filter.copyWith(pageIndex: pageIndex);
+      final response = await _taskService.fetchInventoryTasks(query: filter);
+      _latestTotalCount = response.total;
+      final totalPages = response.total == 0
+          ? 1
+          : (response.total / filter.pageSize).ceil().clamp(1, 999999);
+      return DataGridResponseData<InventoryTask>(
+        totalPages: totalPages,
+        data: response.rows,
+      );
+    };
+  }
+
+  Future<void> _onStarted(
+    _Started event,
+    Emitter<InventoryTaskState> emit,
+  ) async {
+    _ignoreNextPageChange = true;
+    await _loadPage(emit, pageIndex: state.filter.pageIndex);
+  }
+
+  Future<void> _onScanned(
+    _Scanned event,
+    Emitter<InventoryTaskState> emit,
+  ) async {
+    if (event.content.isEmpty) {
+      return;
+    }
+    final updatedFilter = state.filter.copyWith(
+      searchKey: event.content,
+      pageIndex: 1,
+    );
+    emit(state.copyWith(filter: updatedFilter));
+    await _loadPage(emit, pageIndex: 1);
+  }
+
+  Future<void> _onSearchSubmitted(
+    _SearchSubmitted event,
+    Emitter<InventoryTaskState> emit,
+  ) async {
+    final updatedFilter = state.filter.copyWith(
+      searchKey: event.keyword,
+      pageIndex: 1,
+    );
+    emit(state.copyWith(filter: updatedFilter));
+    await _loadPage(emit, pageIndex: 1);
+  }
+
+  Future<void> _onPageChanged(
+    _PageChanged event,
+    Emitter<InventoryTaskState> emit,
+  ) async {
+    if (_ignoreNextPageChange) {
+      _ignoreNextPageChange = false;
+      return;
+    }
+    emit(
+      state.copyWith(
+        filter: state.filter.copyWith(pageIndex: event.pageIndex),
+      ),
+    );
+    await _loadPage(emit, pageIndex: event.pageIndex);
+  }
+
+  Future<void> _onRefreshRequested(
+    _RefreshRequested event,
+    Emitter<InventoryTaskState> emit,
+  ) async {
+    await _loadPage(emit, pageIndex: state.filter.pageIndex);
+  }
+
+  Future<void> _onCancelTaskRequested(
+    _CancelTaskRequested event,
+    Emitter<InventoryTaskState> emit,
+  ) async {
+    final userId = _userManager.userInfo?.userId;
+    if (userId == null) {
+      emit(
+        state.copyWith(
+          status: InventoryTaskListStatus.failure,
+          message: '用户信息缺失，请重新登录',
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: InventoryTaskListStatus.actionInProgress));
+    try {
+      await _taskService.cancelTask(
+        taskComment: event.task.taskComment,
+        userId: userId.toString(),
+      );
+      await _loadPage(
+        emit,
+        pageIndex: state.filter.pageIndex,
+        successMessage: '单据撤销成功',
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryTaskListStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> _loadPage(
+    Emitter<InventoryTaskState> emit, {
+    required int pageIndex,
+    String? successMessage,
+  }) async {
+    emit(state.copyWith(status: InventoryTaskListStatus.loading, message: null));
+
+    final completer = Completer<DataGridResponseData<InventoryTask>>();
+    _gridBloc.add(LoadDataEvent(pageIndex, completer: completer));
+
+    try {
+      final response = await completer.future;
+      emit(
+        state.copyWith(
+          status: InventoryTaskListStatus.success,
+          tasks: response.data,
+          currentPage: pageIndex,
+          totalPages: response.totalPages,
+          total: _latestTotalCount,
+          filter: state.filter.copyWith(pageIndex: pageIndex),
+          message: successMessage,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryTaskListStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _gridBloc.close();
+    return super.close();
+  }
+}

--- a/lib/modules/inventory_task/task_list/bloc/inventory_task_event.dart
+++ b/lib/modules/inventory_task/task_list/bloc/inventory_task_event.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../models/inventory_task.dart';
+
+part 'inventory_task_event.freezed.dart';
+
+@freezed
+class InventoryTaskEvent with _$InventoryTaskEvent {
+  const factory InventoryTaskEvent.started() = _Started;
+  const factory InventoryTaskEvent.scanned(String content) = _Scanned;
+  const factory InventoryTaskEvent.searchSubmitted(String keyword) =
+      _SearchSubmitted;
+  const factory InventoryTaskEvent.pageChanged(int pageIndex) = _PageChanged;
+  const factory InventoryTaskEvent.refreshRequested() = _RefreshRequested;
+  const factory InventoryTaskEvent.cancelTaskRequested(InventoryTask task) =
+      _CancelTaskRequested;
+  const factory InventoryTaskEvent.navigateToReceive() = _NavigateToReceive;
+}

--- a/lib/modules/inventory_task/task_list/bloc/inventory_task_event.freezed.dart
+++ b/lib/modules/inventory_task/task_list/bloc/inventory_task_event.freezed.dart
@@ -1,0 +1,1167 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_task_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$InventoryTaskEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+    required TResult Function(InventoryTask task) cancelTaskRequested,
+    required TResult Function() navigateToReceive,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+    TResult? Function(InventoryTask task)? cancelTaskRequested,
+    TResult? Function()? navigateToReceive,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    TResult Function(InventoryTask task)? cancelTaskRequested,
+    TResult Function()? navigateToReceive,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+    required TResult Function(_CancelTaskRequested value) cancelTaskRequested,
+    required TResult Function(_NavigateToReceive value) navigateToReceive,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+    TResult? Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult? Function(_NavigateToReceive value)? navigateToReceive,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    TResult Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult Function(_NavigateToReceive value)? navigateToReceive,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskEventCopyWith<$Res> {
+  factory $InventoryTaskEventCopyWith(
+          InventoryTaskEvent value, $Res Function(InventoryTaskEvent) then) =
+      _$InventoryTaskEventCopyWithImpl<$Res, InventoryTaskEvent>;
+}
+
+/// @nodoc
+class _$InventoryTaskEventCopyWithImpl<$Res, $Val extends InventoryTaskEvent>
+    implements $InventoryTaskEventCopyWith<$Res> {
+  _$InventoryTaskEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$StartedImplCopyWith<$Res> {
+  factory _$$StartedImplCopyWith(
+          _$StartedImpl value, $Res Function(_$StartedImpl) then) =
+      __$$StartedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$StartedImplCopyWithImpl<$Res>
+    extends _$InventoryTaskEventCopyWithImpl<$Res, _$StartedImpl>
+    implements _$$StartedImplCopyWith<$Res> {
+  __$$StartedImplCopyWithImpl(
+      _$StartedImpl _value, $Res Function(_$StartedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$StartedImpl implements _Started {
+  const _$StartedImpl();
+
+  @override
+  String toString() {
+    return 'InventoryTaskEvent.started()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$StartedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+    required TResult Function(InventoryTask task) cancelTaskRequested,
+    required TResult Function() navigateToReceive,
+  }) {
+    return started();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+    TResult? Function(InventoryTask task)? cancelTaskRequested,
+    TResult? Function()? navigateToReceive,
+  }) {
+    return started?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    TResult Function(InventoryTask task)? cancelTaskRequested,
+    TResult Function()? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+    required TResult Function(_CancelTaskRequested value) cancelTaskRequested,
+    required TResult Function(_NavigateToReceive value) navigateToReceive,
+  }) {
+    return started(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+    TResult? Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult? Function(_NavigateToReceive value)? navigateToReceive,
+  }) {
+    return started?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    TResult Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult Function(_NavigateToReceive value)? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Started implements InventoryTaskEvent {
+  const factory _Started() = _$StartedImpl;
+}
+
+/// @nodoc
+abstract class _$$ScannedImplCopyWith<$Res> {
+  factory _$$ScannedImplCopyWith(
+          _$ScannedImpl value, $Res Function(_$ScannedImpl) then) =
+      __$$ScannedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String content});
+}
+
+/// @nodoc
+class __$$ScannedImplCopyWithImpl<$Res>
+    extends _$InventoryTaskEventCopyWithImpl<$Res, _$ScannedImpl>
+    implements _$$ScannedImplCopyWith<$Res> {
+  __$$ScannedImplCopyWithImpl(
+      _$ScannedImpl _value, $Res Function(_$ScannedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? content = null,
+  }) {
+    return _then(_$ScannedImpl(
+      null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ScannedImpl implements _Scanned {
+  const _$ScannedImpl(this.content);
+
+  @override
+  final String content;
+
+  @override
+  String toString() {
+    return 'InventoryTaskEvent.scanned(content: $content)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ScannedImpl &&
+            (identical(other.content, content) || other.content == content));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, content);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ScannedImplCopyWith<_$ScannedImpl> get copyWith =>
+      __$$ScannedImplCopyWithImpl<_$ScannedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+    required TResult Function(InventoryTask task) cancelTaskRequested,
+    required TResult Function() navigateToReceive,
+  }) {
+    return scanned(content);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+    TResult? Function(InventoryTask task)? cancelTaskRequested,
+    TResult? Function()? navigateToReceive,
+  }) {
+    return scanned?.call(content);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    TResult Function(InventoryTask task)? cancelTaskRequested,
+    TResult Function()? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (scanned != null) {
+      return scanned(content);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+    required TResult Function(_CancelTaskRequested value) cancelTaskRequested,
+    required TResult Function(_NavigateToReceive value) navigateToReceive,
+  }) {
+    return scanned(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+    TResult? Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult? Function(_NavigateToReceive value)? navigateToReceive,
+  }) {
+    return scanned?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    TResult Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult Function(_NavigateToReceive value)? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (scanned != null) {
+      return scanned(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Scanned implements InventoryTaskEvent {
+  const factory _Scanned(final String content) = _$ScannedImpl;
+
+  String get content;
+  @JsonKey(ignore: true)
+  _$$ScannedImplCopyWith<_$ScannedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SearchSubmittedImplCopyWith<$Res> {
+  factory _$$SearchSubmittedImplCopyWith(_$SearchSubmittedImpl value,
+          $Res Function(_$SearchSubmittedImpl) then) =
+      __$$SearchSubmittedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String keyword});
+}
+
+/// @nodoc
+class __$$SearchSubmittedImplCopyWithImpl<$Res>
+    extends _$InventoryTaskEventCopyWithImpl<$Res, _$SearchSubmittedImpl>
+    implements _$$SearchSubmittedImplCopyWith<$Res> {
+  __$$SearchSubmittedImplCopyWithImpl(
+      _$SearchSubmittedImpl _value, $Res Function(_$SearchSubmittedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? keyword = null,
+  }) {
+    return _then(_$SearchSubmittedImpl(
+      null == keyword
+          ? _value.keyword
+          : keyword // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SearchSubmittedImpl implements _SearchSubmitted {
+  const _$SearchSubmittedImpl(this.keyword);
+
+  @override
+  final String keyword;
+
+  @override
+  String toString() {
+    return 'InventoryTaskEvent.searchSubmitted(keyword: $keyword)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SearchSubmittedImpl &&
+            (identical(other.keyword, keyword) || other.keyword == keyword));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, keyword);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SearchSubmittedImplCopyWith<_$SearchSubmittedImpl> get copyWith =>
+      __$$SearchSubmittedImplCopyWithImpl<_$SearchSubmittedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+    required TResult Function(InventoryTask task) cancelTaskRequested,
+    required TResult Function() navigateToReceive,
+  }) {
+    return searchSubmitted(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+    TResult? Function(InventoryTask task)? cancelTaskRequested,
+    TResult? Function()? navigateToReceive,
+  }) {
+    return searchSubmitted?.call(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    TResult Function(InventoryTask task)? cancelTaskRequested,
+    TResult Function()? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (searchSubmitted != null) {
+      return searchSubmitted(keyword);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+    required TResult Function(_CancelTaskRequested value) cancelTaskRequested,
+    required TResult Function(_NavigateToReceive value) navigateToReceive,
+  }) {
+    return searchSubmitted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+    TResult? Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult? Function(_NavigateToReceive value)? navigateToReceive,
+  }) {
+    return searchSubmitted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    TResult Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult Function(_NavigateToReceive value)? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (searchSubmitted != null) {
+      return searchSubmitted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _SearchSubmitted implements InventoryTaskEvent {
+  const factory _SearchSubmitted(final String keyword) = _$SearchSubmittedImpl;
+
+  String get keyword;
+  @JsonKey(ignore: true)
+  _$$SearchSubmittedImplCopyWith<_$SearchSubmittedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PageChangedImplCopyWith<$Res> {
+  factory _$$PageChangedImplCopyWith(
+          _$PageChangedImpl value, $Res Function(_$PageChangedImpl) then) =
+      __$$PageChangedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int pageIndex});
+}
+
+/// @nodoc
+class __$$PageChangedImplCopyWithImpl<$Res>
+    extends _$InventoryTaskEventCopyWithImpl<$Res, _$PageChangedImpl>
+    implements _$$PageChangedImplCopyWith<$Res> {
+  __$$PageChangedImplCopyWithImpl(
+      _$PageChangedImpl _value, $Res Function(_$PageChangedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pageIndex = null,
+  }) {
+    return _then(_$PageChangedImpl(
+      null == pageIndex
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PageChangedImpl implements _PageChanged {
+  const _$PageChangedImpl(this.pageIndex);
+
+  @override
+  final int pageIndex;
+
+  @override
+  String toString() {
+    return 'InventoryTaskEvent.pageChanged(pageIndex: $pageIndex)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageChangedImpl &&
+            (identical(other.pageIndex, pageIndex) ||
+                other.pageIndex == pageIndex));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, pageIndex);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      __$$PageChangedImplCopyWithImpl<_$PageChangedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+    required TResult Function(InventoryTask task) cancelTaskRequested,
+    required TResult Function() navigateToReceive,
+  }) {
+    return pageChanged(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+    TResult? Function(InventoryTask task)? cancelTaskRequested,
+    TResult? Function()? navigateToReceive,
+  }) {
+    return pageChanged?.call(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    TResult Function(InventoryTask task)? cancelTaskRequested,
+    TResult Function()? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(pageIndex);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+    required TResult Function(_CancelTaskRequested value) cancelTaskRequested,
+    required TResult Function(_NavigateToReceive value) navigateToReceive,
+  }) {
+    return pageChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+    TResult? Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult? Function(_NavigateToReceive value)? navigateToReceive,
+  }) {
+    return pageChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    TResult Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult Function(_NavigateToReceive value)? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _PageChanged implements InventoryTaskEvent {
+  const factory _PageChanged(final int pageIndex) = _$PageChangedImpl;
+
+  int get pageIndex;
+  @JsonKey(ignore: true)
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$RefreshRequestedImplCopyWith<$Res> {
+  factory _$$RefreshRequestedImplCopyWith(_$RefreshRequestedImpl value,
+          $Res Function(_$RefreshRequestedImpl) then) =
+      __$$RefreshRequestedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$RefreshRequestedImplCopyWithImpl<$Res>
+    extends _$InventoryTaskEventCopyWithImpl<$Res, _$RefreshRequestedImpl>
+    implements _$$RefreshRequestedImplCopyWith<$Res> {
+  __$$RefreshRequestedImplCopyWithImpl(_$RefreshRequestedImpl _value,
+      $Res Function(_$RefreshRequestedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$RefreshRequestedImpl implements _RefreshRequested {
+  const _$RefreshRequestedImpl();
+
+  @override
+  String toString() {
+    return 'InventoryTaskEvent.refreshRequested()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$RefreshRequestedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+    required TResult Function(InventoryTask task) cancelTaskRequested,
+    required TResult Function() navigateToReceive,
+  }) {
+    return refreshRequested();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+    TResult? Function(InventoryTask task)? cancelTaskRequested,
+    TResult? Function()? navigateToReceive,
+  }) {
+    return refreshRequested?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    TResult Function(InventoryTask task)? cancelTaskRequested,
+    TResult Function()? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (refreshRequested != null) {
+      return refreshRequested();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+    required TResult Function(_CancelTaskRequested value) cancelTaskRequested,
+    required TResult Function(_NavigateToReceive value) navigateToReceive,
+  }) {
+    return refreshRequested(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+    TResult? Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult? Function(_NavigateToReceive value)? navigateToReceive,
+  }) {
+    return refreshRequested?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    TResult Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult Function(_NavigateToReceive value)? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (refreshRequested != null) {
+      return refreshRequested(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _RefreshRequested implements InventoryTaskEvent {
+  const factory _RefreshRequested() = _$RefreshRequestedImpl;
+}
+
+/// @nodoc
+abstract class _$$CancelTaskRequestedImplCopyWith<$Res> {
+  factory _$$CancelTaskRequestedImplCopyWith(_$CancelTaskRequestedImpl value,
+          $Res Function(_$CancelTaskRequestedImpl) then) =
+      __$$CancelTaskRequestedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({InventoryTask task});
+
+  $InventoryTaskCopyWith<$Res> get task;
+}
+
+/// @nodoc
+class __$$CancelTaskRequestedImplCopyWithImpl<$Res>
+    extends _$InventoryTaskEventCopyWithImpl<$Res, _$CancelTaskRequestedImpl>
+    implements _$$CancelTaskRequestedImplCopyWith<$Res> {
+  __$$CancelTaskRequestedImplCopyWithImpl(_$CancelTaskRequestedImpl _value,
+      $Res Function(_$CancelTaskRequestedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? task = null,
+  }) {
+    return _then(_$CancelTaskRequestedImpl(
+      null == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as InventoryTask,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryTaskCopyWith<$Res> get task {
+    return $InventoryTaskCopyWith<$Res>(_value.task, (value) {
+      return _then(_value.copyWith(task: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$CancelTaskRequestedImpl implements _CancelTaskRequested {
+  const _$CancelTaskRequestedImpl(this.task);
+
+  @override
+  final InventoryTask task;
+
+  @override
+  String toString() {
+    return 'InventoryTaskEvent.cancelTaskRequested(task: $task)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CancelTaskRequestedImpl &&
+            (identical(other.task, task) || other.task == task));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, task);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CancelTaskRequestedImplCopyWith<_$CancelTaskRequestedImpl> get copyWith =>
+      __$$CancelTaskRequestedImplCopyWithImpl<_$CancelTaskRequestedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+    required TResult Function(InventoryTask task) cancelTaskRequested,
+    required TResult Function() navigateToReceive,
+  }) {
+    return cancelTaskRequested(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+    TResult? Function(InventoryTask task)? cancelTaskRequested,
+    TResult? Function()? navigateToReceive,
+  }) {
+    return cancelTaskRequested?.call(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    TResult Function(InventoryTask task)? cancelTaskRequested,
+    TResult Function()? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (cancelTaskRequested != null) {
+      return cancelTaskRequested(task);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+    required TResult Function(_CancelTaskRequested value) cancelTaskRequested,
+    required TResult Function(_NavigateToReceive value) navigateToReceive,
+  }) {
+    return cancelTaskRequested(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+    TResult? Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult? Function(_NavigateToReceive value)? navigateToReceive,
+  }) {
+    return cancelTaskRequested?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    TResult Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult Function(_NavigateToReceive value)? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (cancelTaskRequested != null) {
+      return cancelTaskRequested(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _CancelTaskRequested implements InventoryTaskEvent {
+  const factory _CancelTaskRequested(final InventoryTask task) =
+      _$CancelTaskRequestedImpl;
+
+  InventoryTask get task;
+  @JsonKey(ignore: true)
+  _$$CancelTaskRequestedImplCopyWith<_$CancelTaskRequestedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$NavigateToReceiveImplCopyWith<$Res> {
+  factory _$$NavigateToReceiveImplCopyWith(_$NavigateToReceiveImpl value,
+          $Res Function(_$NavigateToReceiveImpl) then) =
+      __$$NavigateToReceiveImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$NavigateToReceiveImplCopyWithImpl<$Res>
+    extends _$InventoryTaskEventCopyWithImpl<$Res, _$NavigateToReceiveImpl>
+    implements _$$NavigateToReceiveImplCopyWith<$Res> {
+  __$$NavigateToReceiveImplCopyWithImpl(_$NavigateToReceiveImpl _value,
+      $Res Function(_$NavigateToReceiveImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$NavigateToReceiveImpl implements _NavigateToReceive {
+  const _$NavigateToReceiveImpl();
+
+  @override
+  String toString() {
+    return 'InventoryTaskEvent.navigateToReceive()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$NavigateToReceiveImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() refreshRequested,
+    required TResult Function(InventoryTask task) cancelTaskRequested,
+    required TResult Function() navigateToReceive,
+  }) {
+    return navigateToReceive();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? refreshRequested,
+    TResult? Function(InventoryTask task)? cancelTaskRequested,
+    TResult? Function()? navigateToReceive,
+  }) {
+    return navigateToReceive?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? refreshRequested,
+    TResult Function(InventoryTask task)? cancelTaskRequested,
+    TResult Function()? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (navigateToReceive != null) {
+      return navigateToReceive();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_RefreshRequested value) refreshRequested,
+    required TResult Function(_CancelTaskRequested value) cancelTaskRequested,
+    required TResult Function(_NavigateToReceive value) navigateToReceive,
+  }) {
+    return navigateToReceive(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_RefreshRequested value)? refreshRequested,
+    TResult? Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult? Function(_NavigateToReceive value)? navigateToReceive,
+  }) {
+    return navigateToReceive?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_RefreshRequested value)? refreshRequested,
+    TResult Function(_CancelTaskRequested value)? cancelTaskRequested,
+    TResult Function(_NavigateToReceive value)? navigateToReceive,
+    required TResult orElse(),
+  }) {
+    if (navigateToReceive != null) {
+      return navigateToReceive(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _NavigateToReceive implements InventoryTaskEvent {
+  const factory _NavigateToReceive() = _$NavigateToReceiveImpl;
+}

--- a/lib/modules/inventory_task/task_list/bloc/inventory_task_state.dart
+++ b/lib/modules/inventory_task/task_list/bloc/inventory_task_state.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../models/inventory_task.dart';
+
+part 'inventory_task_state.freezed.dart';
+
+enum InventoryTaskListStatus { initial, loading, success, failure, actionInProgress }
+
+@freezed
+class InventoryTaskState with _$InventoryTaskState {
+  const factory InventoryTaskState({
+    @Default(InventoryTaskListStatus.initial) InventoryTaskListStatus status,
+    @Default(InventoryTaskQuery(userId: '', roleOrUserId: ''))
+    InventoryTaskQuery filter,
+    @Default(<InventoryTask>[]) List<InventoryTask> tasks,
+    @Default(1) int currentPage,
+    @Default(1) int totalPages,
+    @Default(0) int total,
+    String? message,
+  }) = _InventoryTaskState;
+}

--- a/lib/modules/inventory_task/task_list/bloc/inventory_task_state.freezed.dart
+++ b/lib/modules/inventory_task/task_list/bloc/inventory_task_state.freezed.dart
@@ -1,0 +1,293 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_task_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$InventoryTaskState {
+  InventoryTaskListStatus get status => throw _privateConstructorUsedError;
+  InventoryTaskQuery get filter => throw _privateConstructorUsedError;
+  List<InventoryTask> get tasks => throw _privateConstructorUsedError;
+  int get currentPage => throw _privateConstructorUsedError;
+  int get totalPages => throw _privateConstructorUsedError;
+  int get total => throw _privateConstructorUsedError;
+  String? get message => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $InventoryTaskStateCopyWith<InventoryTaskState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskStateCopyWith<$Res> {
+  factory $InventoryTaskStateCopyWith(
+          InventoryTaskState value, $Res Function(InventoryTaskState) then) =
+      _$InventoryTaskStateCopyWithImpl<$Res, InventoryTaskState>;
+  @useResult
+  $Res call(
+      {InventoryTaskListStatus status,
+      InventoryTaskQuery filter,
+      List<InventoryTask> tasks,
+      int currentPage,
+      int totalPages,
+      int total,
+      String? message});
+
+  $InventoryTaskQueryCopyWith<$Res> get filter;
+}
+
+/// @nodoc
+class _$InventoryTaskStateCopyWithImpl<$Res, $Val extends InventoryTaskState>
+    implements $InventoryTaskStateCopyWith<$Res> {
+  _$InventoryTaskStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? filter = null,
+    Object? tasks = null,
+    Object? currentPage = null,
+    Object? totalPages = null,
+    Object? total = null,
+    Object? message = freezed,
+  }) {
+    return _then(_value.copyWith(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskListStatus,
+      filter: null == filter
+          ? _value.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskQuery,
+      tasks: null == tasks
+          ? _value.tasks
+          : tasks // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTask>,
+      currentPage: null == currentPage
+          ? _value.currentPage
+          : currentPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryTaskQueryCopyWith<$Res> get filter {
+    return $InventoryTaskQueryCopyWith<$Res>(_value.filter, (value) {
+      return _then(_value.copyWith(filter: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskStateImplCopyWith<$Res>
+    implements $InventoryTaskStateCopyWith<$Res> {
+  factory _$$InventoryTaskStateImplCopyWith(_$InventoryTaskStateImpl value,
+          $Res Function(_$InventoryTaskStateImpl) then) =
+      __$$InventoryTaskStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {InventoryTaskListStatus status,
+      InventoryTaskQuery filter,
+      List<InventoryTask> tasks,
+      int currentPage,
+      int totalPages,
+      int total,
+      String? message});
+
+  @override
+  $InventoryTaskQueryCopyWith<$Res> get filter;
+}
+
+/// @nodoc
+class __$$InventoryTaskStateImplCopyWithImpl<$Res>
+    extends _$InventoryTaskStateCopyWithImpl<$Res, _$InventoryTaskStateImpl>
+    implements _$$InventoryTaskStateImplCopyWith<$Res> {
+  __$$InventoryTaskStateImplCopyWithImpl(_$InventoryTaskStateImpl _value,
+      $Res Function(_$InventoryTaskStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? filter = null,
+    Object? tasks = null,
+    Object? currentPage = null,
+    Object? totalPages = null,
+    Object? total = null,
+    Object? message = freezed,
+  }) {
+    return _then(_$InventoryTaskStateImpl(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskListStatus,
+      filter: null == filter
+          ? _value.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskQuery,
+      tasks: null == tasks
+          ? _value._tasks
+          : tasks // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTask>,
+      currentPage: null == currentPage
+          ? _value.currentPage
+          : currentPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$InventoryTaskStateImpl implements _InventoryTaskState {
+  const _$InventoryTaskStateImpl(
+      {this.status = InventoryTaskListStatus.initial,
+      this.filter = const InventoryTaskQuery(userId: '', roleOrUserId: ''),
+      final List<InventoryTask> tasks = const <InventoryTask>[],
+      this.currentPage = 1,
+      this.totalPages = 1,
+      this.total = 0,
+      this.message})
+      : _tasks = tasks;
+
+  @override
+  @JsonKey()
+  final InventoryTaskListStatus status;
+  @override
+  @JsonKey()
+  final InventoryTaskQuery filter;
+  final List<InventoryTask> _tasks;
+  @override
+  @JsonKey()
+  List<InventoryTask> get tasks {
+    if (_tasks is EqualUnmodifiableListView) return _tasks;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_tasks);
+  }
+
+  @override
+  @JsonKey()
+  final int currentPage;
+  @override
+  @JsonKey()
+  final int totalPages;
+  @override
+  @JsonKey()
+  final int total;
+  @override
+  final String? message;
+
+  @override
+  String toString() {
+    return 'InventoryTaskState(status: $status, filter: $filter, tasks: $tasks, currentPage: $currentPage, totalPages: $totalPages, total: $total, message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskStateImpl &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.filter, filter) || other.filter == filter) &&
+            const DeepCollectionEquality().equals(other._tasks, _tasks) &&
+            (identical(other.currentPage, currentPage) ||
+                other.currentPage == currentPage) &&
+            (identical(other.totalPages, totalPages) ||
+                other.totalPages == totalPages) &&
+            (identical(other.total, total) || other.total == total) &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      status,
+      filter,
+      const DeepCollectionEquality().hash(_tasks),
+      currentPage,
+      totalPages,
+      total,
+      message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskStateImplCopyWith<_$InventoryTaskStateImpl> get copyWith =>
+      __$$InventoryTaskStateImplCopyWithImpl<_$InventoryTaskStateImpl>(
+          this, _$identity);
+}
+
+abstract class _InventoryTaskState implements InventoryTaskState {
+  const factory _InventoryTaskState(
+      {final InventoryTaskListStatus status,
+      final InventoryTaskQuery filter,
+      final List<InventoryTask> tasks,
+      final int currentPage,
+      final int totalPages,
+      final int total,
+      final String? message}) = _$InventoryTaskStateImpl;
+
+  @override
+  InventoryTaskListStatus get status;
+  @override
+  InventoryTaskQuery get filter;
+  @override
+  List<InventoryTask> get tasks;
+  @override
+  int get currentPage;
+  @override
+  int get totalPages;
+  @override
+  int get total;
+  @override
+  String? get message;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskStateImplCopyWith<_$InventoryTaskStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_task/task_list/config/inventory_task_grid_config.dart
+++ b/lib/modules/inventory_task/task_list/config/inventory_task_grid_config.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+import '../../../../common_widgets/common_grid/common_data_grid.dart';
+import '../models/inventory_task.dart';
+
+typedef InventoryTaskOperation = void Function(InventoryTask task, int type);
+
+class InventoryTaskGridConfig {
+  static List<GridColumnConfig<InventoryTask>> columns(
+    InventoryTaskOperation? operation, {
+    bool showCancel = true,
+  }) {
+    return [
+      GridColumnConfig<InventoryTask>(
+        name: 'actions',
+        headerText: '操作',
+        width: 160,
+        valueGetter: (task) => '',
+        cellBuilder: (task, columnName, cellValue) {
+          final buttons = <Widget>[
+            SizedBox(
+              height: 30,
+              child: ElevatedButton(
+                onPressed: () => operation?.call(task, 0),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF465CFF),
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                ),
+                child: Text(showCancel ? '采集' : '接收'),
+              ),
+            ),
+          ];
+          if (showCancel) {
+            buttons.addAll([
+              const SizedBox(width: 8),
+              SizedBox(
+                height: 30,
+                child: OutlinedButton(
+                  onPressed: () => operation?.call(task, 1),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: const Color(0xFF465CFF),
+                    side: const BorderSide(color: Color(0xFF465CFF)),
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                  ),
+                  child: const Text('撤销'),
+                ),
+              ),
+            ]);
+          }
+
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: buttons,
+          );
+        },
+      ),
+      GridColumnConfig<InventoryTask>(
+        name: 'taskcomment',
+        headerText: '盘库单号',
+        width: 180,
+        valueGetter: (task) => task.taskComment,
+      ),
+      GridColumnConfig<InventoryTask>(
+        name: 'storeroomno',
+        headerText: '库房号',
+        width: 120,
+        valueGetter: (task) => task.storeRoomNo,
+      ),
+      GridColumnConfig<InventoryTask>(
+        name: 'storeroomname',
+        headerText: '库房名称',
+        width: 200,
+        valueGetter: (task) => task.storeRoomName,
+      ),
+      GridColumnConfig<InventoryTask>(
+        name: 'checktaskno',
+        headerText: '任务号',
+        width: 200,
+        valueGetter: (task) => task.checkTaskNo,
+      ),
+      GridColumnConfig<InventoryTask>(
+        name: 'status',
+        headerText: '状态',
+        width: 120,
+        valueGetter: (task) => task.status ?? '',
+      ),
+    ];
+  }
+}

--- a/lib/modules/inventory_task/task_list/inventory_task_list_page.dart
+++ b/lib/modules/inventory_task/task_list/inventory_task_list_page.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../../../common_widgets/common_grid/common_data_grid.dart';
+import '../../../common_widgets/common_grid/grid_bloc.dart';
+import '../../../common_widgets/common_grid/grid_event.dart';
+import '../../../common_widgets/common_grid/grid_state.dart';
+import '../../../common_widgets/custom_app_bar.dart';
+import '../../../common_widgets/loading_dialog_manager.dart';
+import '../../../common_widgets/scanner_widget/scanner_config.dart';
+import '../../../common_widgets/scanner_widget/scanner_widget.dart';
+import '../../../services/user_manager.dart';
+import 'bloc/inventory_task_bloc.dart';
+import 'bloc/inventory_task_event.dart';
+import 'bloc/inventory_task_state.dart';
+import 'config/inventory_task_grid_config.dart';
+import 'models/inventory_task.dart';
+
+class InventoryTaskListPage extends StatefulWidget {
+  const InventoryTaskListPage({super.key});
+
+  @override
+  State<InventoryTaskListPage> createState() => _InventoryTaskListPageState();
+}
+
+class _InventoryTaskListPageState extends State<InventoryTaskListPage> {
+  late final InventoryTaskBloc _bloc;
+  late final CommonDataGridBloc<InventoryTask> _gridBloc;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<InventoryTaskBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+    _bloc.add(const InventoryTaskEvent.started());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: CustomAppBar(
+        title: '平库盘点任务',
+        onBackPressed: () => Navigator.of(context).pop(),
+        actions: [
+          IconButton(
+            onPressed: () {
+              Modular.to.pushNamed('/inventory/receive').then((_) {
+                _bloc.add(const InventoryTaskEvent.refreshRequested());
+              });
+            },
+            icon: const Icon(Icons.add, color: Colors.white, size: 28),
+          ),
+        ],
+      ).appBar,
+      body: Column(
+        children: [
+          _buildScanner(),
+          Expanded(child: _buildTable()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '请扫描单号',
+      clearOnSubmit: true,
+    );
+
+    return ScannerWidget(
+      config: config,
+      controller: _scannerController,
+      onScanResult: (value) {
+        _bloc.add(InventoryTaskEvent.scanned(value));
+      },
+      onSubmit: (value) {
+        _bloc.add(InventoryTaskEvent.searchSubmitted(value));
+      },
+      onError: (message) {
+        LoadingDialogManager.instance.showErrorDialog(context, message);
+      },
+      suffix: IconButton(
+        icon: SvgPicture.asset('assets/images/icon_filter.svg'),
+        onPressed: () {
+          // 占位：后续可接入筛选对话框
+        },
+      ),
+    );
+  }
+
+  Widget _buildTable() {
+    return BlocConsumer<InventoryTaskBloc, InventoryTaskState>(
+      listener: (context, state) {
+        if (state.status == InventoryTaskListStatus.loading) {
+          LoadingDialogManager.instance.showLoadingDialog(context);
+        } else {
+          LoadingDialogManager.instance.hideLoadingDialog(context);
+        }
+        if (state.status == InventoryTaskListStatus.failure && state.message != null) {
+          LoadingDialogManager.instance.showErrorDialog(
+            context,
+            state.message!,
+          );
+        }
+        if (state.status == InventoryTaskListStatus.success && state.message != null) {
+          LoadingDialogManager.instance.showSuccessDialog(
+            context,
+            state.message!,
+          );
+        }
+      },
+      builder: (context, state) {
+        return BlocProvider.value(
+          value: _gridBloc,
+          child: BlocBuilder<CommonDataGridBloc<InventoryTask>,
+              CommonDataGridState<InventoryTask>>(
+            builder: (context, gridState) {
+              return CommonDataGrid<InventoryTask>(
+                columns: InventoryTaskGridConfig.columns((task, type) {
+                  if (type == 0) {
+                    _navigateToCollect(task);
+                  } else {
+                    _confirmCancel(task);
+                  }
+                }),
+                datas: gridState.data,
+                currentPage: gridState.currentPage,
+                totalPages: gridState.totalPages,
+                onLoadData: (pageIndex) async {
+                  _gridBloc.add(LoadDataEvent(pageIndex));
+                },
+                selectedRows: gridState.selectedRows,
+                onSelectionChanged: (rows) {
+                  _gridBloc.add(ChangeSelectedRowsEvent(rows));
+                },
+                allowPager: false,
+                allowSelect: false,
+                headerHeight: 44,
+                rowHeight: 48,
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  void _navigateToCollect(InventoryTask task) {
+    final userManager = Modular.get<UserManager>();
+    final userInfo = userManager.userInfo;
+    if (userInfo == null) {
+      LoadingDialogManager.instance
+          .showErrorDialog(context, '用户信息缺失，请重新登录');
+      return;
+    }
+
+    Modular.to.pushNamed(
+      '/inventory/collect/${task.checkTaskNo}',
+      arguments: {'task': task, 'user': userInfo},
+    ).then((_) {
+      _bloc.add(const InventoryTaskEvent.refreshRequested());
+    });
+  }
+
+  void _confirmCancel(InventoryTask task) {
+    showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('撤销确认'),
+          content: const Text('是否执行撤销操作？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _bloc.add(InventoryTaskEvent.cancelTaskRequested(task));
+              },
+              child: const Text('确认'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/modules/inventory_task/task_list/models/inventory_task.dart
+++ b/lib/modules/inventory_task/task_list/models/inventory_task.dart
@@ -1,0 +1,87 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_task.freezed.dart';
+part 'inventory_task.g.dart';
+
+/// 平库盘点任务查询参数
+@freezed
+class InventoryTaskQuery with _$InventoryTaskQuery {
+  const factory InventoryTaskQuery({
+    /// 排序方向
+    @JsonKey(name: 'sortType') @Default('desc') String sortType,
+
+    /// 排序字段
+    @JsonKey(name: 'sortColumn') @Default('createdate') String sortColumn,
+
+    /// 搜索关键字
+    @JsonKey(name: 'searchKey') @Default('') String searchKey,
+
+    /// 用户ID
+    @JsonKey(name: 'userId') required String userId,
+
+    /// 角色或用户ID
+    @JsonKey(name: 'roleoRuserId') required String roleOrUserId,
+
+    /// 库房标签（0-平库、1-立库）
+    @JsonKey(name: 'roomTag') @Default('0') String roomTag,
+
+    /// 完成标识：0-未完成，1-全部
+    @JsonKey(name: 'finshFlg') @Default('0') String finishFlag,
+
+    /// 当前页码（1 开始）
+    @JsonKey(name: 'PageIndex') @Default(1) int pageIndex,
+
+    /// 每页条目数
+    @JsonKey(name: 'PageSize') @Default(100) int pageSize,
+  }) = _InventoryTaskQuery;
+
+  factory InventoryTaskQuery.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskQueryFromJson(json);
+}
+
+/// 平库盘点任务摘要
+@freezed
+class InventoryTask with _$InventoryTask {
+  const factory InventoryTask({
+    /// 盘库单号
+    @JsonKey(name: 'taskcomment') required String taskComment,
+
+    /// 库房号
+    @JsonKey(name: 'storeroomno') required String storeRoomNo,
+
+    /// 库房名称
+    @JsonKey(name: 'storeroomname') required String storeRoomName,
+
+    /// 任务号
+    @JsonKey(name: 'checktaskno') required String checkTaskNo,
+
+    /// 任务主键
+    @JsonKey(name: 'checktaskid') int? checkTaskId,
+
+    /// 当前状态
+    @JsonKey(name: 'status') String? status,
+
+    /// 工位/拣选位
+    @JsonKey(name: 'workstation') String? workStation,
+
+    /// 任务备注
+    @JsonKey(name: 'memo') String? memo,
+  }) = _InventoryTask;
+
+  factory InventoryTask.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskFromJson(json);
+}
+
+/// 平库盘点任务列表响应
+@freezed
+class InventoryTaskListResponse with _$InventoryTaskListResponse {
+  const factory InventoryTaskListResponse({
+    @JsonKey(name: 'rows')
+    @Default(<InventoryTask>[])
+    List<InventoryTask> rows,
+    @JsonKey(name: 'total') @Default(0) int total,
+  }) = _InventoryTaskListResponse;
+
+  factory InventoryTaskListResponse.fromJson(Map<String, dynamic> json) =>
+      _$InventoryTaskListResponseFromJson(json);
+}

--- a/lib/modules/inventory_task/task_list/models/inventory_task.freezed.dart
+++ b/lib/modules/inventory_task/task_list/models/inventory_task.freezed.dart
@@ -1,0 +1,943 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_task.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+InventoryTaskQuery _$InventoryTaskQueryFromJson(Map<String, dynamic> json) {
+  return _InventoryTaskQuery.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskQuery {
+  /// 排序方向
+  @JsonKey(name: 'sortType')
+  String get sortType => throw _privateConstructorUsedError;
+
+  /// 排序字段
+  @JsonKey(name: 'sortColumn')
+  String get sortColumn => throw _privateConstructorUsedError;
+
+  /// 搜索关键字
+  @JsonKey(name: 'searchKey')
+  String get searchKey => throw _privateConstructorUsedError;
+
+  /// 用户ID
+  @JsonKey(name: 'userId')
+  String get userId => throw _privateConstructorUsedError;
+
+  /// 角色或用户ID
+  @JsonKey(name: 'roleoRuserId')
+  String get roleOrUserId => throw _privateConstructorUsedError;
+
+  /// 库房标签（0-平库、1-立库）
+  @JsonKey(name: 'roomTag')
+  String get roomTag => throw _privateConstructorUsedError;
+
+  /// 完成标识：0-未完成，1-全部
+  @JsonKey(name: 'finshFlg')
+  String get finishFlag => throw _privateConstructorUsedError;
+
+  /// 当前页码（1 开始）
+  @JsonKey(name: 'PageIndex')
+  int get pageIndex => throw _privateConstructorUsedError;
+
+  /// 每页条目数
+  @JsonKey(name: 'PageSize')
+  int get pageSize => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskQueryCopyWith<InventoryTaskQuery> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskQueryCopyWith<$Res> {
+  factory $InventoryTaskQueryCopyWith(
+          InventoryTaskQuery value, $Res Function(InventoryTaskQuery) then) =
+      _$InventoryTaskQueryCopyWithImpl<$Res, InventoryTaskQuery>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'sortType') String sortType,
+      @JsonKey(name: 'sortColumn') String sortColumn,
+      @JsonKey(name: 'searchKey') String searchKey,
+      @JsonKey(name: 'userId') String userId,
+      @JsonKey(name: 'roleoRuserId') String roleOrUserId,
+      @JsonKey(name: 'roomTag') String roomTag,
+      @JsonKey(name: 'finshFlg') String finishFlag,
+      @JsonKey(name: 'PageIndex') int pageIndex,
+      @JsonKey(name: 'PageSize') int pageSize});
+}
+
+/// @nodoc
+class _$InventoryTaskQueryCopyWithImpl<$Res, $Val extends InventoryTaskQuery>
+    implements $InventoryTaskQueryCopyWith<$Res> {
+  _$InventoryTaskQueryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sortType = null,
+    Object? sortColumn = null,
+    Object? searchKey = null,
+    Object? userId = null,
+    Object? roleOrUserId = null,
+    Object? roomTag = null,
+    Object? finishFlag = null,
+    Object? pageIndex = null,
+    Object? pageSize = null,
+  }) {
+    return _then(_value.copyWith(
+      sortType: null == sortType
+          ? _value.sortType
+          : sortType // ignore: cast_nullable_to_non_nullable
+              as String,
+      sortColumn: null == sortColumn
+          ? _value.sortColumn
+          : sortColumn // ignore: cast_nullable_to_non_nullable
+              as String,
+      searchKey: null == searchKey
+          ? _value.searchKey
+          : searchKey // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roleOrUserId: null == roleOrUserId
+          ? _value.roleOrUserId
+          : roleOrUserId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roomTag: null == roomTag
+          ? _value.roomTag
+          : roomTag // ignore: cast_nullable_to_non_nullable
+              as String,
+      finishFlag: null == finishFlag
+          ? _value.finishFlag
+          : finishFlag // ignore: cast_nullable_to_non_nullable
+              as String,
+      pageIndex: null == pageIndex
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+      pageSize: null == pageSize
+          ? _value.pageSize
+          : pageSize // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskQueryImplCopyWith<$Res>
+    implements $InventoryTaskQueryCopyWith<$Res> {
+  factory _$$InventoryTaskQueryImplCopyWith(_$InventoryTaskQueryImpl value,
+          $Res Function(_$InventoryTaskQueryImpl) then) =
+      __$$InventoryTaskQueryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'sortType') String sortType,
+      @JsonKey(name: 'sortColumn') String sortColumn,
+      @JsonKey(name: 'searchKey') String searchKey,
+      @JsonKey(name: 'userId') String userId,
+      @JsonKey(name: 'roleoRuserId') String roleOrUserId,
+      @JsonKey(name: 'roomTag') String roomTag,
+      @JsonKey(name: 'finshFlg') String finishFlag,
+      @JsonKey(name: 'PageIndex') int pageIndex,
+      @JsonKey(name: 'PageSize') int pageSize});
+}
+
+/// @nodoc
+class __$$InventoryTaskQueryImplCopyWithImpl<$Res>
+    extends _$InventoryTaskQueryCopyWithImpl<$Res, _$InventoryTaskQueryImpl>
+    implements _$$InventoryTaskQueryImplCopyWith<$Res> {
+  __$$InventoryTaskQueryImplCopyWithImpl(_$InventoryTaskQueryImpl _value,
+      $Res Function(_$InventoryTaskQueryImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sortType = null,
+    Object? sortColumn = null,
+    Object? searchKey = null,
+    Object? userId = null,
+    Object? roleOrUserId = null,
+    Object? roomTag = null,
+    Object? finishFlag = null,
+    Object? pageIndex = null,
+    Object? pageSize = null,
+  }) {
+    return _then(_$InventoryTaskQueryImpl(
+      sortType: null == sortType
+          ? _value.sortType
+          : sortType // ignore: cast_nullable_to_non_nullable
+              as String,
+      sortColumn: null == sortColumn
+          ? _value.sortColumn
+          : sortColumn // ignore: cast_nullable_to_non_nullable
+              as String,
+      searchKey: null == searchKey
+          ? _value.searchKey
+          : searchKey // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roleOrUserId: null == roleOrUserId
+          ? _value.roleOrUserId
+          : roleOrUserId // ignore: cast_nullable_to_non_nullable
+              as String,
+      roomTag: null == roomTag
+          ? _value.roomTag
+          : roomTag // ignore: cast_nullable_to_non_nullable
+              as String,
+      finishFlag: null == finishFlag
+          ? _value.finishFlag
+          : finishFlag // ignore: cast_nullable_to_non_nullable
+              as String,
+      pageIndex: null == pageIndex
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+      pageSize: null == pageSize
+          ? _value.pageSize
+          : pageSize // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskQueryImpl implements _InventoryTaskQuery {
+  const _$InventoryTaskQueryImpl(
+      {@JsonKey(name: 'sortType') this.sortType = 'desc',
+      @JsonKey(name: 'sortColumn') this.sortColumn = 'createdate',
+      @JsonKey(name: 'searchKey') this.searchKey = '',
+      @JsonKey(name: 'userId') required this.userId,
+      @JsonKey(name: 'roleoRuserId') required this.roleOrUserId,
+      @JsonKey(name: 'roomTag') this.roomTag = '0',
+      @JsonKey(name: 'finshFlg') this.finishFlag = '0',
+      @JsonKey(name: 'PageIndex') this.pageIndex = 1,
+      @JsonKey(name: 'PageSize') this.pageSize = 100});
+
+  factory _$InventoryTaskQueryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskQueryImplFromJson(json);
+
+  /// 排序方向
+  @override
+  @JsonKey(name: 'sortType')
+  final String sortType;
+
+  /// 排序字段
+  @override
+  @JsonKey(name: 'sortColumn')
+  final String sortColumn;
+
+  /// 搜索关键字
+  @override
+  @JsonKey(name: 'searchKey')
+  final String searchKey;
+
+  /// 用户ID
+  @override
+  @JsonKey(name: 'userId')
+  final String userId;
+
+  /// 角色或用户ID
+  @override
+  @JsonKey(name: 'roleoRuserId')
+  final String roleOrUserId;
+
+  /// 库房标签（0-平库、1-立库）
+  @override
+  @JsonKey(name: 'roomTag')
+  final String roomTag;
+
+  /// 完成标识：0-未完成，1-全部
+  @override
+  @JsonKey(name: 'finshFlg')
+  final String finishFlag;
+
+  /// 当前页码（1 开始）
+  @override
+  @JsonKey(name: 'PageIndex')
+  final int pageIndex;
+
+  /// 每页条目数
+  @override
+  @JsonKey(name: 'PageSize')
+  final int pageSize;
+
+  @override
+  String toString() {
+    return 'InventoryTaskQuery(sortType: $sortType, sortColumn: $sortColumn, searchKey: $searchKey, userId: $userId, roleOrUserId: $roleOrUserId, roomTag: $roomTag, finishFlag: $finishFlag, pageIndex: $pageIndex, pageSize: $pageSize)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskQueryImpl &&
+            (identical(other.sortType, sortType) ||
+                other.sortType == sortType) &&
+            (identical(other.sortColumn, sortColumn) ||
+                other.sortColumn == sortColumn) &&
+            (identical(other.searchKey, searchKey) ||
+                other.searchKey == searchKey) &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.roleOrUserId, roleOrUserId) ||
+                other.roleOrUserId == roleOrUserId) &&
+            (identical(other.roomTag, roomTag) || other.roomTag == roomTag) &&
+            (identical(other.finishFlag, finishFlag) ||
+                other.finishFlag == finishFlag) &&
+            (identical(other.pageIndex, pageIndex) ||
+                other.pageIndex == pageIndex) &&
+            (identical(other.pageSize, pageSize) ||
+                other.pageSize == pageSize));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, sortType, sortColumn, searchKey,
+      userId, roleOrUserId, roomTag, finishFlag, pageIndex, pageSize);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskQueryImplCopyWith<_$InventoryTaskQueryImpl> get copyWith =>
+      __$$InventoryTaskQueryImplCopyWithImpl<_$InventoryTaskQueryImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskQueryImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskQuery implements InventoryTaskQuery {
+  const factory _InventoryTaskQuery(
+          {@JsonKey(name: 'sortType') final String sortType,
+          @JsonKey(name: 'sortColumn') final String sortColumn,
+          @JsonKey(name: 'searchKey') final String searchKey,
+          @JsonKey(name: 'userId') required final String userId,
+          @JsonKey(name: 'roleoRuserId') required final String roleOrUserId,
+          @JsonKey(name: 'roomTag') final String roomTag,
+          @JsonKey(name: 'finshFlg') final String finishFlag,
+          @JsonKey(name: 'PageIndex') final int pageIndex,
+          @JsonKey(name: 'PageSize') final int pageSize}) =
+      _$InventoryTaskQueryImpl;
+
+  factory _InventoryTaskQuery.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskQueryImpl.fromJson;
+
+  @override
+
+  /// 排序方向
+  @JsonKey(name: 'sortType')
+  String get sortType;
+  @override
+
+  /// 排序字段
+  @JsonKey(name: 'sortColumn')
+  String get sortColumn;
+  @override
+
+  /// 搜索关键字
+  @JsonKey(name: 'searchKey')
+  String get searchKey;
+  @override
+
+  /// 用户ID
+  @JsonKey(name: 'userId')
+  String get userId;
+  @override
+
+  /// 角色或用户ID
+  @JsonKey(name: 'roleoRuserId')
+  String get roleOrUserId;
+  @override
+
+  /// 库房标签（0-平库、1-立库）
+  @JsonKey(name: 'roomTag')
+  String get roomTag;
+  @override
+
+  /// 完成标识：0-未完成，1-全部
+  @JsonKey(name: 'finshFlg')
+  String get finishFlag;
+  @override
+
+  /// 当前页码（1 开始）
+  @JsonKey(name: 'PageIndex')
+  int get pageIndex;
+  @override
+
+  /// 每页条目数
+  @JsonKey(name: 'PageSize')
+  int get pageSize;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskQueryImplCopyWith<_$InventoryTaskQueryImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventoryTask _$InventoryTaskFromJson(Map<String, dynamic> json) {
+  return _InventoryTask.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTask {
+  /// 盘库单号
+  @JsonKey(name: 'taskcomment')
+  String get taskComment => throw _privateConstructorUsedError;
+
+  /// 库房号
+  @JsonKey(name: 'storeroomno')
+  String get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 库房名称
+  @JsonKey(name: 'storeroomname')
+  String get storeRoomName => throw _privateConstructorUsedError;
+
+  /// 任务号
+  @JsonKey(name: 'checktaskno')
+  String get checkTaskNo => throw _privateConstructorUsedError;
+
+  /// 任务主键
+  @JsonKey(name: 'checktaskid')
+  int? get checkTaskId => throw _privateConstructorUsedError;
+
+  /// 当前状态
+  @JsonKey(name: 'status')
+  String? get status => throw _privateConstructorUsedError;
+
+  /// 工位/拣选位
+  @JsonKey(name: 'workstation')
+  String? get workStation => throw _privateConstructorUsedError;
+
+  /// 任务备注
+  @JsonKey(name: 'memo')
+  String? get memo => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskCopyWith<InventoryTask> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskCopyWith<$Res> {
+  factory $InventoryTaskCopyWith(
+          InventoryTask value, $Res Function(InventoryTask) then) =
+      _$InventoryTaskCopyWithImpl<$Res, InventoryTask>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskcomment') String taskComment,
+      @JsonKey(name: 'storeroomno') String storeRoomNo,
+      @JsonKey(name: 'storeroomname') String storeRoomName,
+      @JsonKey(name: 'checktaskno') String checkTaskNo,
+      @JsonKey(name: 'checktaskid') int? checkTaskId,
+      @JsonKey(name: 'status') String? status,
+      @JsonKey(name: 'workstation') String? workStation,
+      @JsonKey(name: 'memo') String? memo});
+}
+
+/// @nodoc
+class _$InventoryTaskCopyWithImpl<$Res, $Val extends InventoryTask>
+    implements $InventoryTaskCopyWith<$Res> {
+  _$InventoryTaskCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskComment = null,
+    Object? storeRoomNo = null,
+    Object? storeRoomName = null,
+    Object? checkTaskNo = null,
+    Object? checkTaskId = freezed,
+    Object? status = freezed,
+    Object? workStation = freezed,
+    Object? memo = freezed,
+  }) {
+    return _then(_value.copyWith(
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: null == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomName: null == storeRoomName
+          ? _value.storeRoomName
+          : storeRoomName // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskNo: null == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskId: freezed == checkTaskId
+          ? _value.checkTaskId
+          : checkTaskId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      status: freezed == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as String?,
+      workStation: freezed == workStation
+          ? _value.workStation
+          : workStation // ignore: cast_nullable_to_non_nullable
+              as String?,
+      memo: freezed == memo
+          ? _value.memo
+          : memo // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskImplCopyWith<$Res>
+    implements $InventoryTaskCopyWith<$Res> {
+  factory _$$InventoryTaskImplCopyWith(
+          _$InventoryTaskImpl value, $Res Function(_$InventoryTaskImpl) then) =
+      __$$InventoryTaskImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'taskcomment') String taskComment,
+      @JsonKey(name: 'storeroomno') String storeRoomNo,
+      @JsonKey(name: 'storeroomname') String storeRoomName,
+      @JsonKey(name: 'checktaskno') String checkTaskNo,
+      @JsonKey(name: 'checktaskid') int? checkTaskId,
+      @JsonKey(name: 'status') String? status,
+      @JsonKey(name: 'workstation') String? workStation,
+      @JsonKey(name: 'memo') String? memo});
+}
+
+/// @nodoc
+class __$$InventoryTaskImplCopyWithImpl<$Res>
+    extends _$InventoryTaskCopyWithImpl<$Res, _$InventoryTaskImpl>
+    implements _$$InventoryTaskImplCopyWith<$Res> {
+  __$$InventoryTaskImplCopyWithImpl(
+      _$InventoryTaskImpl _value, $Res Function(_$InventoryTaskImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskComment = null,
+    Object? storeRoomNo = null,
+    Object? storeRoomName = null,
+    Object? checkTaskNo = null,
+    Object? checkTaskId = freezed,
+    Object? status = freezed,
+    Object? workStation = freezed,
+    Object? memo = freezed,
+  }) {
+    return _then(_$InventoryTaskImpl(
+      taskComment: null == taskComment
+          ? _value.taskComment
+          : taskComment // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: null == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomName: null == storeRoomName
+          ? _value.storeRoomName
+          : storeRoomName // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskNo: null == checkTaskNo
+          ? _value.checkTaskNo
+          : checkTaskNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      checkTaskId: freezed == checkTaskId
+          ? _value.checkTaskId
+          : checkTaskId // ignore: cast_nullable_to_non_nullable
+              as int?,
+      status: freezed == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as String?,
+      workStation: freezed == workStation
+          ? _value.workStation
+          : workStation // ignore: cast_nullable_to_non_nullable
+              as String?,
+      memo: freezed == memo
+          ? _value.memo
+          : memo // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskImpl implements _InventoryTask {
+  const _$InventoryTaskImpl(
+      {@JsonKey(name: 'taskcomment') required this.taskComment,
+      @JsonKey(name: 'storeroomno') required this.storeRoomNo,
+      @JsonKey(name: 'storeroomname') required this.storeRoomName,
+      @JsonKey(name: 'checktaskno') required this.checkTaskNo,
+      @JsonKey(name: 'checktaskid') this.checkTaskId,
+      @JsonKey(name: 'status') this.status,
+      @JsonKey(name: 'workstation') this.workStation,
+      @JsonKey(name: 'memo') this.memo});
+
+  factory _$InventoryTaskImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskImplFromJson(json);
+
+  /// 盘库单号
+  @override
+  @JsonKey(name: 'taskcomment')
+  final String taskComment;
+
+  /// 库房号
+  @override
+  @JsonKey(name: 'storeroomno')
+  final String storeRoomNo;
+
+  /// 库房名称
+  @override
+  @JsonKey(name: 'storeroomname')
+  final String storeRoomName;
+
+  /// 任务号
+  @override
+  @JsonKey(name: 'checktaskno')
+  final String checkTaskNo;
+
+  /// 任务主键
+  @override
+  @JsonKey(name: 'checktaskid')
+  final int? checkTaskId;
+
+  /// 当前状态
+  @override
+  @JsonKey(name: 'status')
+  final String? status;
+
+  /// 工位/拣选位
+  @override
+  @JsonKey(name: 'workstation')
+  final String? workStation;
+
+  /// 任务备注
+  @override
+  @JsonKey(name: 'memo')
+  final String? memo;
+
+  @override
+  String toString() {
+    return 'InventoryTask(taskComment: $taskComment, storeRoomNo: $storeRoomNo, storeRoomName: $storeRoomName, checkTaskNo: $checkTaskNo, checkTaskId: $checkTaskId, status: $status, workStation: $workStation, memo: $memo)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskImpl &&
+            (identical(other.taskComment, taskComment) ||
+                other.taskComment == taskComment) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeRoomName, storeRoomName) ||
+                other.storeRoomName == storeRoomName) &&
+            (identical(other.checkTaskNo, checkTaskNo) ||
+                other.checkTaskNo == checkTaskNo) &&
+            (identical(other.checkTaskId, checkTaskId) ||
+                other.checkTaskId == checkTaskId) &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.workStation, workStation) ||
+                other.workStation == workStation) &&
+            (identical(other.memo, memo) || other.memo == memo));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, taskComment, storeRoomNo,
+      storeRoomName, checkTaskNo, checkTaskId, status, workStation, memo);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskImplCopyWith<_$InventoryTaskImpl> get copyWith =>
+      __$$InventoryTaskImplCopyWithImpl<_$InventoryTaskImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTask implements InventoryTask {
+  const factory _InventoryTask(
+      {@JsonKey(name: 'taskcomment') required final String taskComment,
+      @JsonKey(name: 'storeroomno') required final String storeRoomNo,
+      @JsonKey(name: 'storeroomname') required final String storeRoomName,
+      @JsonKey(name: 'checktaskno') required final String checkTaskNo,
+      @JsonKey(name: 'checktaskid') final int? checkTaskId,
+      @JsonKey(name: 'status') final String? status,
+      @JsonKey(name: 'workstation') final String? workStation,
+      @JsonKey(name: 'memo') final String? memo}) = _$InventoryTaskImpl;
+
+  factory _InventoryTask.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskImpl.fromJson;
+
+  @override
+
+  /// 盘库单号
+  @JsonKey(name: 'taskcomment')
+  String get taskComment;
+  @override
+
+  /// 库房号
+  @JsonKey(name: 'storeroomno')
+  String get storeRoomNo;
+  @override
+
+  /// 库房名称
+  @JsonKey(name: 'storeroomname')
+  String get storeRoomName;
+  @override
+
+  /// 任务号
+  @JsonKey(name: 'checktaskno')
+  String get checkTaskNo;
+  @override
+
+  /// 任务主键
+  @JsonKey(name: 'checktaskid')
+  int? get checkTaskId;
+  @override
+
+  /// 当前状态
+  @JsonKey(name: 'status')
+  String? get status;
+  @override
+
+  /// 工位/拣选位
+  @JsonKey(name: 'workstation')
+  String? get workStation;
+  @override
+
+  /// 任务备注
+  @JsonKey(name: 'memo')
+  String? get memo;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskImplCopyWith<_$InventoryTaskImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventoryTaskListResponse _$InventoryTaskListResponseFromJson(
+    Map<String, dynamic> json) {
+  return _InventoryTaskListResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryTaskListResponse {
+  @JsonKey(name: 'rows')
+  List<InventoryTask> get rows => throw _privateConstructorUsedError;
+  @JsonKey(name: 'total')
+  int get total => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryTaskListResponseCopyWith<InventoryTaskListResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryTaskListResponseCopyWith<$Res> {
+  factory $InventoryTaskListResponseCopyWith(InventoryTaskListResponse value,
+          $Res Function(InventoryTaskListResponse) then) =
+      _$InventoryTaskListResponseCopyWithImpl<$Res, InventoryTaskListResponse>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'rows') List<InventoryTask> rows,
+      @JsonKey(name: 'total') int total});
+}
+
+/// @nodoc
+class _$InventoryTaskListResponseCopyWithImpl<$Res,
+        $Val extends InventoryTaskListResponse>
+    implements $InventoryTaskListResponseCopyWith<$Res> {
+  _$InventoryTaskListResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? rows = null,
+    Object? total = null,
+  }) {
+    return _then(_value.copyWith(
+      rows: null == rows
+          ? _value.rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTask>,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryTaskListResponseImplCopyWith<$Res>
+    implements $InventoryTaskListResponseCopyWith<$Res> {
+  factory _$$InventoryTaskListResponseImplCopyWith(
+          _$InventoryTaskListResponseImpl value,
+          $Res Function(_$InventoryTaskListResponseImpl) then) =
+      __$$InventoryTaskListResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'rows') List<InventoryTask> rows,
+      @JsonKey(name: 'total') int total});
+}
+
+/// @nodoc
+class __$$InventoryTaskListResponseImplCopyWithImpl<$Res>
+    extends _$InventoryTaskListResponseCopyWithImpl<$Res,
+        _$InventoryTaskListResponseImpl>
+    implements _$$InventoryTaskListResponseImplCopyWith<$Res> {
+  __$$InventoryTaskListResponseImplCopyWithImpl(
+      _$InventoryTaskListResponseImpl _value,
+      $Res Function(_$InventoryTaskListResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? rows = null,
+    Object? total = null,
+  }) {
+    return _then(_$InventoryTaskListResponseImpl(
+      rows: null == rows
+          ? _value._rows
+          : rows // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTask>,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryTaskListResponseImpl implements _InventoryTaskListResponse {
+  const _$InventoryTaskListResponseImpl(
+      {@JsonKey(name: 'rows')
+      final List<InventoryTask> rows = const <InventoryTask>[],
+      @JsonKey(name: 'total') this.total = 0})
+      : _rows = rows;
+
+  factory _$InventoryTaskListResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryTaskListResponseImplFromJson(json);
+
+  final List<InventoryTask> _rows;
+  @override
+  @JsonKey(name: 'rows')
+  List<InventoryTask> get rows {
+    if (_rows is EqualUnmodifiableListView) return _rows;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_rows);
+  }
+
+  @override
+  @JsonKey(name: 'total')
+  final int total;
+
+  @override
+  String toString() {
+    return 'InventoryTaskListResponse(rows: $rows, total: $total)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryTaskListResponseImpl &&
+            const DeepCollectionEquality().equals(other._rows, _rows) &&
+            (identical(other.total, total) || other.total == total));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(_rows), total);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryTaskListResponseImplCopyWith<_$InventoryTaskListResponseImpl>
+      get copyWith => __$$InventoryTaskListResponseImplCopyWithImpl<
+          _$InventoryTaskListResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryTaskListResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InventoryTaskListResponse implements InventoryTaskListResponse {
+  const factory _InventoryTaskListResponse(
+          {@JsonKey(name: 'rows') final List<InventoryTask> rows,
+          @JsonKey(name: 'total') final int total}) =
+      _$InventoryTaskListResponseImpl;
+
+  factory _InventoryTaskListResponse.fromJson(Map<String, dynamic> json) =
+      _$InventoryTaskListResponseImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'rows')
+  List<InventoryTask> get rows;
+  @override
+  @JsonKey(name: 'total')
+  int get total;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryTaskListResponseImplCopyWith<_$InventoryTaskListResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_task/task_list/models/inventory_task.g.dart
+++ b/lib/modules/inventory_task/task_list/models/inventory_task.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_task.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryTaskQueryImpl _$$InventoryTaskQueryImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskQueryImpl(
+      sortType: json['sortType'] as String? ?? 'desc',
+      sortColumn: json['sortColumn'] as String? ?? 'createdate',
+      searchKey: json['searchKey'] as String? ?? '',
+      userId: json['userId'] as String,
+      roleOrUserId: json['roleoRuserId'] as String,
+      roomTag: json['roomTag'] as String? ?? '0',
+      finishFlag: json['finshFlg'] as String? ?? '0',
+      pageIndex: (json['PageIndex'] as num?)?.toInt() ?? 1,
+      pageSize: (json['PageSize'] as num?)?.toInt() ?? 100,
+    );
+
+Map<String, dynamic> _$$InventoryTaskQueryImplToJson(
+        _$InventoryTaskQueryImpl instance) =>
+    <String, dynamic>{
+      'sortType': instance.sortType,
+      'sortColumn': instance.sortColumn,
+      'searchKey': instance.searchKey,
+      'userId': instance.userId,
+      'roleoRuserId': instance.roleOrUserId,
+      'roomTag': instance.roomTag,
+      'finshFlg': instance.finishFlag,
+      'PageIndex': instance.pageIndex,
+      'PageSize': instance.pageSize,
+    };
+
+_$InventoryTaskImpl _$$InventoryTaskImplFromJson(Map<String, dynamic> json) =>
+    _$InventoryTaskImpl(
+      taskComment: json['taskcomment'] as String,
+      storeRoomNo: json['storeroomno'] as String,
+      storeRoomName: json['storeroomname'] as String,
+      checkTaskNo: json['checktaskno'] as String,
+      checkTaskId: (json['checktaskid'] as num?)?.toInt(),
+      status: json['status'] as String?,
+      workStation: json['workstation'] as String?,
+      memo: json['memo'] as String?,
+    );
+
+Map<String, dynamic> _$$InventoryTaskImplToJson(_$InventoryTaskImpl instance) =>
+    <String, dynamic>{
+      'taskcomment': instance.taskComment,
+      'storeroomno': instance.storeRoomNo,
+      'storeroomname': instance.storeRoomName,
+      'checktaskno': instance.checkTaskNo,
+      'checktaskid': instance.checkTaskId,
+      'status': instance.status,
+      'workstation': instance.workStation,
+      'memo': instance.memo,
+    };
+
+_$InventoryTaskListResponseImpl _$$InventoryTaskListResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$InventoryTaskListResponseImpl(
+      rows: (json['rows'] as List<dynamic>?)
+              ?.map((e) => InventoryTask.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <InventoryTask>[],
+      total: (json['total'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$$InventoryTaskListResponseImplToJson(
+        _$InventoryTaskListResponseImpl instance) =>
+    <String, dynamic>{
+      'rows': instance.rows,
+      'total': instance.total,
+    };

--- a/lib/modules/inventory_task/task_receive/bloc/inventory_receive_bloc.dart
+++ b/lib/modules/inventory_task/task_receive/bloc/inventory_receive_bloc.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:meta/meta.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_bloc.dart';
+import 'package:wms_app/common_widgets/common_grid/grid_event.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+import '../../services/inventory_task_service.dart';
+import '../../task_list/models/inventory_task.dart';
+import 'inventory_receive_event.dart';
+import 'inventory_receive_state.dart';
+
+@immutable
+class InventoryReceiveBloc
+    extends Bloc<InventoryReceiveEvent, InventoryReceiveState> {
+  InventoryReceiveBloc({
+    required InventoryTaskService taskService,
+    required UserManager userManager,
+  })  : _taskService = taskService,
+        _userManager = userManager,
+        super(
+          InventoryReceiveState(
+            filter: InventoryTaskQuery(
+              userId: 'ALL',
+              roleOrUserId: '${userManager.userInfo?.userId ?? ''}',
+            ),
+          ),
+        ) {
+    on<_Started>(_onStarted);
+    on<_Scanned>(_onScanned);
+    on<_SearchSubmitted>(_onSearchSubmitted);
+    on<_PageChanged>(_onPageChanged);
+    on<_ReceiveRequested>(_onReceiveRequested);
+
+    _gridBloc = CommonDataGridBloc<InventoryTask>(
+      dataLoader: _createLoader(),
+    );
+  }
+
+  final InventoryTaskService _taskService;
+  final UserManager _userManager;
+
+  late final CommonDataGridBloc<InventoryTask> _gridBloc;
+  CommonDataGridBloc<InventoryTask> get gridBloc => _gridBloc;
+
+  int _latestTotal = 0;
+  bool _ignoreNextPageChange = false;
+
+  DataGridLoader<InventoryTask> _createLoader() {
+    return (pageIndex) async {
+      final filter = state.filter.copyWith(pageIndex: pageIndex);
+      final response =
+          await _taskService.fetchReceivableTasks(query: filter);
+      _latestTotal = response.total;
+      final totalPages = response.total == 0
+          ? 1
+          : (response.total / filter.pageSize).ceil().clamp(1, 999999);
+      return DataGridResponseData(
+        totalPages: totalPages,
+        data: response.rows,
+      );
+    };
+  }
+
+  Future<void> _onStarted(
+    _Started event,
+    Emitter<InventoryReceiveState> emit,
+  ) async {
+    _ignoreNextPageChange = true;
+    await _loadPage(emit, pageIndex: state.filter.pageIndex);
+  }
+
+  Future<void> _onScanned(
+    _Scanned event,
+    Emitter<InventoryReceiveState> emit,
+  ) async {
+    if (event.content.isEmpty) {
+      return;
+    }
+    final updatedFilter = state.filter.copyWith(
+      searchKey: event.content,
+      pageIndex: 1,
+    );
+    emit(state.copyWith(filter: updatedFilter));
+    await _loadPage(emit, pageIndex: 1);
+  }
+
+  Future<void> _onSearchSubmitted(
+    _SearchSubmitted event,
+    Emitter<InventoryReceiveState> emit,
+  ) async {
+    final updatedFilter = state.filter.copyWith(
+      searchKey: event.keyword,
+      pageIndex: 1,
+    );
+    emit(state.copyWith(filter: updatedFilter));
+    await _loadPage(emit, pageIndex: 1);
+  }
+
+  Future<void> _onPageChanged(
+    _PageChanged event,
+    Emitter<InventoryReceiveState> emit,
+  ) async {
+    if (_ignoreNextPageChange) {
+      _ignoreNextPageChange = false;
+      return;
+    }
+    emit(
+      state.copyWith(
+        filter: state.filter.copyWith(pageIndex: event.pageIndex),
+      ),
+    );
+    await _loadPage(emit, pageIndex: event.pageIndex);
+  }
+
+  Future<void> _onReceiveRequested(
+    _ReceiveRequested event,
+    Emitter<InventoryReceiveState> emit,
+  ) async {
+    final userId = _userManager.userInfo?.userId;
+    if (userId == null) {
+      emit(
+        state.copyWith(
+          status: InventoryReceiveStatus.failure,
+          message: '用户信息缺失，请重新登录',
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: InventoryReceiveStatus.actionInProgress));
+    try {
+      await _taskService.receiveTask(
+        taskComment: event.task.taskComment,
+        userId: userId.toString(),
+      );
+      await _loadPage(
+        emit,
+        pageIndex: state.filter.pageIndex,
+        successMessage: '单据接收成功',
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryReceiveStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  Future<void> _loadPage(
+    Emitter<InventoryReceiveState> emit, {
+    required int pageIndex,
+    String? successMessage,
+  }) async {
+    emit(
+      state.copyWith(
+        status: InventoryReceiveStatus.loading,
+        message: null,
+      ),
+    );
+
+    final completer = Completer<DataGridResponseData<InventoryTask>>();
+    _gridBloc.add(LoadDataEvent(pageIndex, completer: completer));
+
+    try {
+      final result = await completer.future;
+      emit(
+        state.copyWith(
+          status: InventoryReceiveStatus.success,
+          tasks: result.data,
+          currentPage: pageIndex,
+          totalPages: result.totalPages,
+          total: _latestTotal,
+          message: successMessage,
+          filter: state.filter.copyWith(pageIndex: pageIndex),
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: InventoryReceiveStatus.failure,
+          message: error.toString(),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _gridBloc.close();
+    return super.close();
+  }
+}

--- a/lib/modules/inventory_task/task_receive/bloc/inventory_receive_event.dart
+++ b/lib/modules/inventory_task/task_receive/bloc/inventory_receive_event.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../task_list/models/inventory_task.dart';
+
+part 'inventory_receive_event.freezed.dart';
+
+@freezed
+class InventoryReceiveEvent with _$InventoryReceiveEvent {
+  const factory InventoryReceiveEvent.started() = _Started;
+  const factory InventoryReceiveEvent.scanned(String content) = _Scanned;
+  const factory InventoryReceiveEvent.searchSubmitted(String keyword) =
+      _SearchSubmitted;
+  const factory InventoryReceiveEvent.pageChanged(int pageIndex) =
+      _PageChanged;
+  const factory InventoryReceiveEvent.receiveRequested(InventoryTask task) =
+      _ReceiveRequested;
+}

--- a/lib/modules/inventory_task/task_receive/bloc/inventory_receive_event.freezed.dart
+++ b/lib/modules/inventory_task/task_receive/bloc/inventory_receive_event.freezed.dart
@@ -1,0 +1,832 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_receive_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$InventoryReceiveEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function(InventoryTask task) receiveRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function(InventoryTask task)? receiveRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function(InventoryTask task)? receiveRequested,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ReceiveRequested value) receiveRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ReceiveRequested value)? receiveRequested,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ReceiveRequested value)? receiveRequested,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryReceiveEventCopyWith<$Res> {
+  factory $InventoryReceiveEventCopyWith(InventoryReceiveEvent value,
+          $Res Function(InventoryReceiveEvent) then) =
+      _$InventoryReceiveEventCopyWithImpl<$Res, InventoryReceiveEvent>;
+}
+
+/// @nodoc
+class _$InventoryReceiveEventCopyWithImpl<$Res,
+        $Val extends InventoryReceiveEvent>
+    implements $InventoryReceiveEventCopyWith<$Res> {
+  _$InventoryReceiveEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$StartedImplCopyWith<$Res> {
+  factory _$$StartedImplCopyWith(
+          _$StartedImpl value, $Res Function(_$StartedImpl) then) =
+      __$$StartedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$StartedImplCopyWithImpl<$Res>
+    extends _$InventoryReceiveEventCopyWithImpl<$Res, _$StartedImpl>
+    implements _$$StartedImplCopyWith<$Res> {
+  __$$StartedImplCopyWithImpl(
+      _$StartedImpl _value, $Res Function(_$StartedImpl) _then)
+      : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$StartedImpl implements _Started {
+  const _$StartedImpl();
+
+  @override
+  String toString() {
+    return 'InventoryReceiveEvent.started()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$StartedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function(InventoryTask task) receiveRequested,
+  }) {
+    return started();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function(InventoryTask task)? receiveRequested,
+  }) {
+    return started?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function(InventoryTask task)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ReceiveRequested value) receiveRequested,
+  }) {
+    return started(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ReceiveRequested value)? receiveRequested,
+  }) {
+    return started?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ReceiveRequested value)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (started != null) {
+      return started(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Started implements InventoryReceiveEvent {
+  const factory _Started() = _$StartedImpl;
+}
+
+/// @nodoc
+abstract class _$$ScannedImplCopyWith<$Res> {
+  factory _$$ScannedImplCopyWith(
+          _$ScannedImpl value, $Res Function(_$ScannedImpl) then) =
+      __$$ScannedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String content});
+}
+
+/// @nodoc
+class __$$ScannedImplCopyWithImpl<$Res>
+    extends _$InventoryReceiveEventCopyWithImpl<$Res, _$ScannedImpl>
+    implements _$$ScannedImplCopyWith<$Res> {
+  __$$ScannedImplCopyWithImpl(
+      _$ScannedImpl _value, $Res Function(_$ScannedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? content = null,
+  }) {
+    return _then(_$ScannedImpl(
+      null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$ScannedImpl implements _Scanned {
+  const _$ScannedImpl(this.content);
+
+  @override
+  final String content;
+
+  @override
+  String toString() {
+    return 'InventoryReceiveEvent.scanned(content: $content)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ScannedImpl &&
+            (identical(other.content, content) || other.content == content));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, content);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ScannedImplCopyWith<_$ScannedImpl> get copyWith =>
+      __$$ScannedImplCopyWithImpl<_$ScannedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function(InventoryTask task) receiveRequested,
+  }) {
+    return scanned(content);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function(InventoryTask task)? receiveRequested,
+  }) {
+    return scanned?.call(content);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function(InventoryTask task)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (scanned != null) {
+      return scanned(content);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ReceiveRequested value) receiveRequested,
+  }) {
+    return scanned(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ReceiveRequested value)? receiveRequested,
+  }) {
+    return scanned?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ReceiveRequested value)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (scanned != null) {
+      return scanned(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Scanned implements InventoryReceiveEvent {
+  const factory _Scanned(final String content) = _$ScannedImpl;
+
+  String get content;
+  @JsonKey(ignore: true)
+  _$$ScannedImplCopyWith<_$ScannedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SearchSubmittedImplCopyWith<$Res> {
+  factory _$$SearchSubmittedImplCopyWith(_$SearchSubmittedImpl value,
+          $Res Function(_$SearchSubmittedImpl) then) =
+      __$$SearchSubmittedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String keyword});
+}
+
+/// @nodoc
+class __$$SearchSubmittedImplCopyWithImpl<$Res>
+    extends _$InventoryReceiveEventCopyWithImpl<$Res, _$SearchSubmittedImpl>
+    implements _$$SearchSubmittedImplCopyWith<$Res> {
+  __$$SearchSubmittedImplCopyWithImpl(
+      _$SearchSubmittedImpl _value, $Res Function(_$SearchSubmittedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? keyword = null,
+  }) {
+    return _then(_$SearchSubmittedImpl(
+      null == keyword
+          ? _value.keyword
+          : keyword // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$SearchSubmittedImpl implements _SearchSubmitted {
+  const _$SearchSubmittedImpl(this.keyword);
+
+  @override
+  final String keyword;
+
+  @override
+  String toString() {
+    return 'InventoryReceiveEvent.searchSubmitted(keyword: $keyword)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SearchSubmittedImpl &&
+            (identical(other.keyword, keyword) || other.keyword == keyword));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, keyword);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SearchSubmittedImplCopyWith<_$SearchSubmittedImpl> get copyWith =>
+      __$$SearchSubmittedImplCopyWithImpl<_$SearchSubmittedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function(InventoryTask task) receiveRequested,
+  }) {
+    return searchSubmitted(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function(InventoryTask task)? receiveRequested,
+  }) {
+    return searchSubmitted?.call(keyword);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function(InventoryTask task)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (searchSubmitted != null) {
+      return searchSubmitted(keyword);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ReceiveRequested value) receiveRequested,
+  }) {
+    return searchSubmitted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ReceiveRequested value)? receiveRequested,
+  }) {
+    return searchSubmitted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ReceiveRequested value)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (searchSubmitted != null) {
+      return searchSubmitted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _SearchSubmitted implements InventoryReceiveEvent {
+  const factory _SearchSubmitted(final String keyword) = _$SearchSubmittedImpl;
+
+  String get keyword;
+  @JsonKey(ignore: true)
+  _$$SearchSubmittedImplCopyWith<_$SearchSubmittedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PageChangedImplCopyWith<$Res> {
+  factory _$$PageChangedImplCopyWith(
+          _$PageChangedImpl value, $Res Function(_$PageChangedImpl) then) =
+      __$$PageChangedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int pageIndex});
+}
+
+/// @nodoc
+class __$$PageChangedImplCopyWithImpl<$Res>
+    extends _$InventoryReceiveEventCopyWithImpl<$Res, _$PageChangedImpl>
+    implements _$$PageChangedImplCopyWith<$Res> {
+  __$$PageChangedImplCopyWithImpl(
+      _$PageChangedImpl _value, $Res Function(_$PageChangedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? pageIndex = null,
+  }) {
+    return _then(_$PageChangedImpl(
+      null == pageIndex
+          ? _value.pageIndex
+          : pageIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$PageChangedImpl implements _PageChanged {
+  const _$PageChangedImpl(this.pageIndex);
+
+  @override
+  final int pageIndex;
+
+  @override
+  String toString() {
+    return 'InventoryReceiveEvent.pageChanged(pageIndex: $pageIndex)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageChangedImpl &&
+            (identical(other.pageIndex, pageIndex) ||
+                other.pageIndex == pageIndex));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, pageIndex);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      __$$PageChangedImplCopyWithImpl<_$PageChangedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function(InventoryTask task) receiveRequested,
+  }) {
+    return pageChanged(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function(InventoryTask task)? receiveRequested,
+  }) {
+    return pageChanged?.call(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function(InventoryTask task)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(pageIndex);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ReceiveRequested value) receiveRequested,
+  }) {
+    return pageChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ReceiveRequested value)? receiveRequested,
+  }) {
+    return pageChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ReceiveRequested value)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _PageChanged implements InventoryReceiveEvent {
+  const factory _PageChanged(final int pageIndex) = _$PageChangedImpl;
+
+  int get pageIndex;
+  @JsonKey(ignore: true)
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ReceiveRequestedImplCopyWith<$Res> {
+  factory _$$ReceiveRequestedImplCopyWith(_$ReceiveRequestedImpl value,
+          $Res Function(_$ReceiveRequestedImpl) then) =
+      __$$ReceiveRequestedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({InventoryTask task});
+
+  $InventoryTaskCopyWith<$Res> get task;
+}
+
+/// @nodoc
+class __$$ReceiveRequestedImplCopyWithImpl<$Res>
+    extends _$InventoryReceiveEventCopyWithImpl<$Res, _$ReceiveRequestedImpl>
+    implements _$$ReceiveRequestedImplCopyWith<$Res> {
+  __$$ReceiveRequestedImplCopyWithImpl(_$ReceiveRequestedImpl _value,
+      $Res Function(_$ReceiveRequestedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? task = null,
+  }) {
+    return _then(_$ReceiveRequestedImpl(
+      null == task
+          ? _value.task
+          : task // ignore: cast_nullable_to_non_nullable
+              as InventoryTask,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryTaskCopyWith<$Res> get task {
+    return $InventoryTaskCopyWith<$Res>(_value.task, (value) {
+      return _then(_value.copyWith(task: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$ReceiveRequestedImpl implements _ReceiveRequested {
+  const _$ReceiveRequestedImpl(this.task);
+
+  @override
+  final InventoryTask task;
+
+  @override
+  String toString() {
+    return 'InventoryReceiveEvent.receiveRequested(task: $task)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ReceiveRequestedImpl &&
+            (identical(other.task, task) || other.task == task));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, task);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ReceiveRequestedImplCopyWith<_$ReceiveRequestedImpl> get copyWith =>
+      __$$ReceiveRequestedImplCopyWithImpl<_$ReceiveRequestedImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() started,
+    required TResult Function(String content) scanned,
+    required TResult Function(String keyword) searchSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function(InventoryTask task) receiveRequested,
+  }) {
+    return receiveRequested(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? started,
+    TResult? Function(String content)? scanned,
+    TResult? Function(String keyword)? searchSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function(InventoryTask task)? receiveRequested,
+  }) {
+    return receiveRequested?.call(task);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? started,
+    TResult Function(String content)? scanned,
+    TResult Function(String keyword)? searchSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function(InventoryTask task)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (receiveRequested != null) {
+      return receiveRequested(task);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Started value) started,
+    required TResult Function(_Scanned value) scanned,
+    required TResult Function(_SearchSubmitted value) searchSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ReceiveRequested value) receiveRequested,
+  }) {
+    return receiveRequested(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Started value)? started,
+    TResult? Function(_Scanned value)? scanned,
+    TResult? Function(_SearchSubmitted value)? searchSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ReceiveRequested value)? receiveRequested,
+  }) {
+    return receiveRequested?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Started value)? started,
+    TResult Function(_Scanned value)? scanned,
+    TResult Function(_SearchSubmitted value)? searchSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ReceiveRequested value)? receiveRequested,
+    required TResult orElse(),
+  }) {
+    if (receiveRequested != null) {
+      return receiveRequested(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ReceiveRequested implements InventoryReceiveEvent {
+  const factory _ReceiveRequested(final InventoryTask task) =
+      _$ReceiveRequestedImpl;
+
+  InventoryTask get task;
+  @JsonKey(ignore: true)
+  _$$ReceiveRequestedImplCopyWith<_$ReceiveRequestedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_task/task_receive/bloc/inventory_receive_state.dart
+++ b/lib/modules/inventory_task/task_receive/bloc/inventory_receive_state.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../task_list/models/inventory_task.dart';
+
+part 'inventory_receive_state.freezed.dart';
+
+enum InventoryReceiveStatus { initial, loading, success, failure, actionInProgress }
+
+@freezed
+class InventoryReceiveState with _$InventoryReceiveState {
+  const factory InventoryReceiveState({
+    @Default(InventoryReceiveStatus.initial) InventoryReceiveStatus status,
+    @Default(InventoryTaskQuery(userId: 'ALL', roleOrUserId: 'ALL'))
+    InventoryTaskQuery filter,
+    @Default(<InventoryTask>[]) List<InventoryTask> tasks,
+    @Default(1) int currentPage,
+    @Default(1) int totalPages,
+    @Default(0) int total,
+    String? message,
+  }) = _InventoryReceiveState;
+}

--- a/lib/modules/inventory_task/task_receive/bloc/inventory_receive_state.freezed.dart
+++ b/lib/modules/inventory_task/task_receive/bloc/inventory_receive_state.freezed.dart
@@ -1,0 +1,297 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_receive_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+/// @nodoc
+mixin _$InventoryReceiveState {
+  InventoryReceiveStatus get status => throw _privateConstructorUsedError;
+  InventoryTaskQuery get filter => throw _privateConstructorUsedError;
+  List<InventoryTask> get tasks => throw _privateConstructorUsedError;
+  int get currentPage => throw _privateConstructorUsedError;
+  int get totalPages => throw _privateConstructorUsedError;
+  int get total => throw _privateConstructorUsedError;
+  String? get message => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $InventoryReceiveStateCopyWith<InventoryReceiveState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryReceiveStateCopyWith<$Res> {
+  factory $InventoryReceiveStateCopyWith(InventoryReceiveState value,
+          $Res Function(InventoryReceiveState) then) =
+      _$InventoryReceiveStateCopyWithImpl<$Res, InventoryReceiveState>;
+  @useResult
+  $Res call(
+      {InventoryReceiveStatus status,
+      InventoryTaskQuery filter,
+      List<InventoryTask> tasks,
+      int currentPage,
+      int totalPages,
+      int total,
+      String? message});
+
+  $InventoryTaskQueryCopyWith<$Res> get filter;
+}
+
+/// @nodoc
+class _$InventoryReceiveStateCopyWithImpl<$Res,
+        $Val extends InventoryReceiveState>
+    implements $InventoryReceiveStateCopyWith<$Res> {
+  _$InventoryReceiveStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? filter = null,
+    Object? tasks = null,
+    Object? currentPage = null,
+    Object? totalPages = null,
+    Object? total = null,
+    Object? message = freezed,
+  }) {
+    return _then(_value.copyWith(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as InventoryReceiveStatus,
+      filter: null == filter
+          ? _value.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskQuery,
+      tasks: null == tasks
+          ? _value.tasks
+          : tasks // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTask>,
+      currentPage: null == currentPage
+          ? _value.currentPage
+          : currentPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryTaskQueryCopyWith<$Res> get filter {
+    return $InventoryTaskQueryCopyWith<$Res>(_value.filter, (value) {
+      return _then(_value.copyWith(filter: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryReceiveStateImplCopyWith<$Res>
+    implements $InventoryReceiveStateCopyWith<$Res> {
+  factory _$$InventoryReceiveStateImplCopyWith(
+          _$InventoryReceiveStateImpl value,
+          $Res Function(_$InventoryReceiveStateImpl) then) =
+      __$$InventoryReceiveStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {InventoryReceiveStatus status,
+      InventoryTaskQuery filter,
+      List<InventoryTask> tasks,
+      int currentPage,
+      int totalPages,
+      int total,
+      String? message});
+
+  @override
+  $InventoryTaskQueryCopyWith<$Res> get filter;
+}
+
+/// @nodoc
+class __$$InventoryReceiveStateImplCopyWithImpl<$Res>
+    extends _$InventoryReceiveStateCopyWithImpl<$Res,
+        _$InventoryReceiveStateImpl>
+    implements _$$InventoryReceiveStateImplCopyWith<$Res> {
+  __$$InventoryReceiveStateImplCopyWithImpl(_$InventoryReceiveStateImpl _value,
+      $Res Function(_$InventoryReceiveStateImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? filter = null,
+    Object? tasks = null,
+    Object? currentPage = null,
+    Object? totalPages = null,
+    Object? total = null,
+    Object? message = freezed,
+  }) {
+    return _then(_$InventoryReceiveStateImpl(
+      status: null == status
+          ? _value.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as InventoryReceiveStatus,
+      filter: null == filter
+          ? _value.filter
+          : filter // ignore: cast_nullable_to_non_nullable
+              as InventoryTaskQuery,
+      tasks: null == tasks
+          ? _value._tasks
+          : tasks // ignore: cast_nullable_to_non_nullable
+              as List<InventoryTask>,
+      currentPage: null == currentPage
+          ? _value.currentPage
+          : currentPage // ignore: cast_nullable_to_non_nullable
+              as int,
+      totalPages: null == totalPages
+          ? _value.totalPages
+          : totalPages // ignore: cast_nullable_to_non_nullable
+              as int,
+      total: null == total
+          ? _value.total
+          : total // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$InventoryReceiveStateImpl implements _InventoryReceiveState {
+  const _$InventoryReceiveStateImpl(
+      {this.status = InventoryReceiveStatus.initial,
+      this.filter =
+          const InventoryTaskQuery(userId: 'ALL', roleOrUserId: 'ALL'),
+      final List<InventoryTask> tasks = const <InventoryTask>[],
+      this.currentPage = 1,
+      this.totalPages = 1,
+      this.total = 0,
+      this.message})
+      : _tasks = tasks;
+
+  @override
+  @JsonKey()
+  final InventoryReceiveStatus status;
+  @override
+  @JsonKey()
+  final InventoryTaskQuery filter;
+  final List<InventoryTask> _tasks;
+  @override
+  @JsonKey()
+  List<InventoryTask> get tasks {
+    if (_tasks is EqualUnmodifiableListView) return _tasks;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_tasks);
+  }
+
+  @override
+  @JsonKey()
+  final int currentPage;
+  @override
+  @JsonKey()
+  final int totalPages;
+  @override
+  @JsonKey()
+  final int total;
+  @override
+  final String? message;
+
+  @override
+  String toString() {
+    return 'InventoryReceiveState(status: $status, filter: $filter, tasks: $tasks, currentPage: $currentPage, totalPages: $totalPages, total: $total, message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryReceiveStateImpl &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.filter, filter) || other.filter == filter) &&
+            const DeepCollectionEquality().equals(other._tasks, _tasks) &&
+            (identical(other.currentPage, currentPage) ||
+                other.currentPage == currentPage) &&
+            (identical(other.totalPages, totalPages) ||
+                other.totalPages == totalPages) &&
+            (identical(other.total, total) || other.total == total) &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      status,
+      filter,
+      const DeepCollectionEquality().hash(_tasks),
+      currentPage,
+      totalPages,
+      total,
+      message);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryReceiveStateImplCopyWith<_$InventoryReceiveStateImpl>
+      get copyWith => __$$InventoryReceiveStateImplCopyWithImpl<
+          _$InventoryReceiveStateImpl>(this, _$identity);
+}
+
+abstract class _InventoryReceiveState implements InventoryReceiveState {
+  const factory _InventoryReceiveState(
+      {final InventoryReceiveStatus status,
+      final InventoryTaskQuery filter,
+      final List<InventoryTask> tasks,
+      final int currentPage,
+      final int totalPages,
+      final int total,
+      final String? message}) = _$InventoryReceiveStateImpl;
+
+  @override
+  InventoryReceiveStatus get status;
+  @override
+  InventoryTaskQuery get filter;
+  @override
+  List<InventoryTask> get tasks;
+  @override
+  int get currentPage;
+  @override
+  int get totalPages;
+  @override
+  int get total;
+  @override
+  String? get message;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryReceiveStateImplCopyWith<_$InventoryReceiveStateImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_task/task_receive/inventory_task_receive_page.dart
+++ b/lib/modules/inventory_task/task_receive/inventory_task_receive_page.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../../common_widgets/common_grid/common_data_grid.dart';
+import '../../../common_widgets/common_grid/grid_bloc.dart';
+import '../../../common_widgets/common_grid/grid_event.dart';
+import '../../../common_widgets/common_grid/grid_state.dart';
+import '../../../common_widgets/custom_app_bar.dart';
+import '../../../common_widgets/loading_dialog_manager.dart';
+import '../../../common_widgets/scanner_widget/scanner_config.dart';
+import '../../../common_widgets/scanner_widget/scanner_widget.dart';
+import 'bloc/inventory_receive_bloc.dart';
+import 'bloc/inventory_receive_event.dart';
+import 'bloc/inventory_receive_state.dart';
+import '../task_list/config/inventory_task_grid_config.dart';
+import '../task_list/models/inventory_task.dart';
+
+class InventoryTaskReceivePage extends StatefulWidget {
+  const InventoryTaskReceivePage({super.key});
+
+  @override
+  State<InventoryTaskReceivePage> createState() =>
+      _InventoryTaskReceivePageState();
+}
+
+class _InventoryTaskReceivePageState extends State<InventoryTaskReceivePage> {
+  late final InventoryReceiveBloc _bloc;
+  late final CommonDataGridBloc<InventoryTask> _gridBloc;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<InventoryReceiveBloc>(context);
+    _gridBloc = _bloc.gridBloc;
+    _bloc.add(const InventoryReceiveEvent.started());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F6F6),
+      appBar: CustomAppBar(
+        title: '平库盘点接收',
+        onBackPressed: () => Modular.to.pop(),
+      ).appBar,
+      body: Column(
+        children: [
+          _buildScanner(),
+          Expanded(child: _buildTable()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    final config = ScannerConfig().copyWith(
+      placeholder: '请扫描单号',
+      clearOnSubmit: true,
+    );
+
+    return ScannerWidget(
+      config: config,
+      controller: _scannerController,
+      onScanResult: (value) {
+        _bloc.add(InventoryReceiveEvent.scanned(value));
+      },
+      onSubmit: (value) {
+        _bloc.add(InventoryReceiveEvent.searchSubmitted(value));
+      },
+      onError: (message) {
+        LoadingDialogManager.instance.showErrorDialog(context, message);
+      },
+    );
+  }
+
+  Widget _buildTable() {
+    return BlocConsumer<InventoryReceiveBloc, InventoryReceiveState>(
+      listener: (context, state) {
+        if (state.status == InventoryReceiveStatus.loading) {
+          LoadingDialogManager.instance.showLoadingDialog(context);
+        } else {
+          LoadingDialogManager.instance.hideLoadingDialog(context);
+        }
+        if (state.status == InventoryReceiveStatus.failure &&
+            state.message != null) {
+          LoadingDialogManager.instance.showErrorDialog(
+            context,
+            state.message!,
+          );
+        }
+        if (state.status == InventoryReceiveStatus.success &&
+            state.message != null) {
+          LoadingDialogManager.instance.showSuccessDialog(
+            context,
+            state.message!,
+          );
+        }
+      },
+      builder: (context, state) {
+        return BlocProvider.value(
+          value: _gridBloc,
+          child: BlocBuilder<CommonDataGridBloc<InventoryTask>,
+              CommonDataGridState<InventoryTask>>(
+            builder: (context, gridState) {
+              return CommonDataGrid<InventoryTask>(
+                columns: InventoryTaskGridConfig.columns((task, type) {
+                  // 只保留接收按钮
+                  if (type == 0) {
+                    _showReceiveConfirm(task);
+                  }
+                }, showCancel: false),
+                datas: gridState.data,
+                currentPage: gridState.currentPage,
+                totalPages: gridState.totalPages,
+                onLoadData: (pageIndex) async {
+                  _gridBloc.add(LoadDataEvent(pageIndex));
+                },
+                selectedRows: gridState.selectedRows,
+                onSelectionChanged: (rows) {
+                  _gridBloc.add(ChangeSelectedRowsEvent(rows));
+                },
+                allowPager: false,
+                allowSelect: false,
+                headerHeight: 44,
+                rowHeight: 48,
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  void _showReceiveConfirm(InventoryTask task) {
+    showDialog<void>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('接收确认'),
+          content: const Text('确认接收该盘点任务吗？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('取消'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _bloc.add(InventoryReceiveEvent.receiveRequested(task));
+              },
+              child: const Text('确认'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- Implemented a full Flutter “平库盘点” module under `lib/modules/inventory_task`, including task list, receive list, and collection pages, associated BLoCs, Freezed models, Hive-backed cache repository, and service wrapper for `/system/terminal` APIs.
- Added Freezed data models, generated `*.freezed.dart`/`*.g.dart` files for new entities and BLoC events/states.
- Created inventory task service encapsulating list, detail, commit, barcode, and site validation calls.
- Wired module routing in `lib/app_module.dart` so `/inventory` now opens the new module.
- Updated docs checklists in `docs/inventory_task_refactor/` to mark completed items; tests remain unchecked.
- Refined the inventory task service with dedicated helpers for receivable queries plus cancel/receive flows and updated the receive BLoC and TODO checklist accordingly.

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f0d24858288330a9acea651c82fdd2