### PR TITLE
feat: implement pull feeding module and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Flutter 版本的仓储管理系统应用，替换原有 UniApp 平库作业。�
 - `/goods-up`：平库上架（任务列表、明细、采集、接收）。
   - `/goods-up/receive`：上架接收任务列表。
   - `/goods-up/receive/detail/:inTaskId`：接收任务明细，支持多选批量接收。
+- `/mtl-senter`：拉式发料采集（库位/物料扫码、数量采集、批量提交）。
 
 首页功能卡片会跳转到上述模块；在上架任务列表页面的右上角「接收」入口会直达接收任务列表。
 
@@ -24,7 +25,7 @@ Flutter 版本的仓储管理系统应用，替换原有 UniApp 平库作业。�
    flutter test
    ```
 
-本仓库在 `test/modules/goods_up` 下提供了服务与接收 BLoC 的基础用例，可在本地验证 API 参数映射与状态流转。
+本仓库在 `test/modules/goods_up` 与 `test/modules/mtl_senter` 下提供服务与采集流程的测试用例，可在本地验证 API 参数映射与状态流转。
 
 ## 相关文档
 - `docs/goods_up_todo.md`：平库上架重构任务清单及完成标记。

--- a/docs/mtl_senter_module_guide.md
+++ b/docs/mtl_senter_module_guide.md
@@ -1,0 +1,46 @@
+# Flutter 拉式发料模块使用说明
+
+本指南概述 `lib/modules/mtl_senter` 下拉式发料功能的架构、依赖与自测流程，便于后续维护人员快速上手。
+
+## 模块概览
+- **入口路由**：`/mtl-senter`，在 `AppModule` 中注册，并由首页卡片进入。
+- **核心页面**：`MtlSenterCollectionPage`，覆盖库位扫码、物料扫码、数量输入、明细列表、删除与提交。
+- **状态管理**：`MtlSenterCollectionBloc` 负责扫码顺序控制、库存校验、提交工作流。
+- **服务层**：`MtlSenterService` 对接接口
+  - `getPmMaterialInfoByQR`
+  - `getLSMtlRepertoryByStoresiteNo`
+  - `getMtlQtyByMtlCode`
+  - `commitMtlSender`
+- **数据模型**：`mtl_senter_models.dart` 基于 `freezed` 生成不可变实体和 JSON 序列化代码。
+
+## 依赖与命令
+- 依赖：`bloc`、`flutter_bloc`、`dio`、`freezed_annotation`、`json_serializable`、`uuid`。
+- 代码生成：
+  ```bash
+  flutter pub run build_runner build --delete-conflicting-outputs
+  ```
+- 单元测试：
+  ```bash
+  flutter test test/modules/mtl_senter
+  ```
+- 分析工具：
+  ```bash
+  flutter analyze
+  ```
+
+## 自测清单
+1. 执行 `flutter analyze`，关注新增告警或格式问题。
+2. 运行 `flutter test test/modules/mtl_senter`，确保 BLoC 和 Service 测试通过。
+3. 如调整模型或 DTO，需要重新执行 `build_runner` 并提交生成文件。
+4. 手动验证扫码流程：库位 → 物料 → 数量，确认库存超限时的错误提示。
+5. 提交成功后返回首页或继续采集，确认状态已清空。
+
+## 常见问题
+- **数量超限提示**：检查 `availableQty` 来源，必要时调用 `fetchInventoryByLocation` 重新同步库存。
+- **接口错误信息**：`MtlSenterService.commitSender` 会抛出后端返回的 `msg`，UI 层需弹出 `SnackBar` 或对话框提示。
+- **焦点丢失**：使用 `MtlSenterResetStatus` 与 `MtlSenterFocusConsumed` 事件控制输入框焦点，避免扫码后无法继续输入。
+
+## 相关文档
+- `docs/refactor_todos/mtlsenter_todo.md`：重构任务清单与进度标记。
+- `api.md`：接口字段及示例。
+- UniApp 参考：`GlodWind-Wms-App/pages/mtlsenter/mtlSenterTaskItem.nvue`。

--- a/docs/refactor_todos/mtlsenter_todo.md
+++ b/docs/refactor_todos/mtlsenter_todo.md
@@ -1,34 +1,95 @@
 # 拉式发料模块重构 TODO
 
-## UniApp 现状
-- 页面结构：单页 `pages/mtlsenter/mtlSenterTaskItem.nvue`，提供按工单/产线拉式发料的扫码提交功能。
-- API 依赖：使用 `api/system/goodsUp.js` 中的 `CommitMtlSender`、`getMtlQtyByMtlCode` 等接口获取库存与提交发料信息。
+> 目标：将 UniApp `pages/mtlsenter/mtlSenterTaskItem.nvue` 拉式发料采集页重构为 Flutter 模块，保持扫码顺序、库存校验与批量提交逻辑，并与现有平库出入库模块保持一致的架构风格。
 
-## Flutter 重构策略
-- **模块结构**：创建 `mtl_senter_module`，包含主采集页与历史记录（可选）。
-- **逻辑复用**：
-  - 采集流程可直接复用 `CollectionBloc` 的扫码、数量校验、缓存与提交机制，针对发料业务调整事件与请求结构。【F:lib/modules/outbound/collection_task/bloc/collection_bloc.dart†L1-L200】
-  - Service 层参考 `CollectionService`，封装 `CommitMtlSender`、`getMtlQtyByMtlCode` 等调用，并统一错误处理。【F:lib/modules/outbound/collection_task/services/collection_service.dart†L1-L193】
-- **UI 设计**：
-  - 页面顶部 `CustomAppBar`，主体区域包含工单/产线选择、库位/物料扫码、数量录入、待提交列表。
-  - 提供待提交明细卡片，可编辑数量/批次，支持批量提交与清空。
+## 现状分析
+- 页面：单页 `mtlSenterTaskItem.nvue`，包含库位扫码、物料扫码、数量录入、明细列表、删除/提交等功能。【F:GlodWind-Wms-App/pages/mtlsenter/mtlSenterTaskItem.nvue†L1-L208】【F:GlodWind-Wms-App/pages/mtlsenter/mtlSenterTaskItem.nvue†L320-L481】
+- 接口：依赖 `CommitMtlSender`、`getMtlQtyByMtlCode`、`getLSMtlRepertoryByStoresiteNo`、`getStoreSiteByRoom` 等 API（参考 `api.md` 与原 UniApp 调用）。【F:GlodWind-Wms-App/pages/mtlsenter/mtlSenterTaskItem.nvue†L72-L110】
+- Flutter 参考：平库出库采集页使用 `CollectionBloc` 协调扫码、Tab 切换与明细管理；平库入库模块复用类似模式，可作为 UI、BLoC、Service 的设计模板。【F:lib/modules/outbound/collection_task/outbound_collection_page.dart†L1-L119】
 
-## 待办清单
-1. 新建 `lib/modules/mtl_senter` 目录与模块入口。
-2. 实现 `MtlSenterService`：
-   - `CommitMtlSender`、`getMtlQtyByMtlCode`、`getStoreSiteByRoom` 等辅助接口。
-3. 定义数据模型：
-   - 发料任务头（工单、产线、需求时间等）。
-   - 发料明细（物料、批次、需求量、实发量、库位）。
-   - 提交请求结构（明细数组、过滤条件）。
-4. 构建采集页：
-   - 设计扫码顺序（库位→物料→数量），支持批次选择、数量验证。
-   - 待提交列表支持修改/删除，提交成功后清空或保留。
-   - 采用 Hive 缓存暂存未提交数据。
-5. 可选：发料历史或异常记录页面。
-6. 路由注册：`/mtl-senter`、`/mtl-senter/history`（可选）。
-7. 测试：
-   - BLoC 测试覆盖正常提交、库存不足、重复扫码、缓存恢复。
-   - Service 测试验证接口参数与异常处理。
-8. 文档：
-   - 更新拉式发料业务说明、扫码顺序、库存校验逻辑、异常处理方案。
+## 通用约束
+- 全部数据模型使用 `freezed` + `json_serializable` 生成不可变实体与序列化代码。
+- 状态管理沿用 BLoC 架构，事件/状态拆分，遵循 `lib/modules/outbound/goods_up` 既有命名与层次。
+- 遵循已有的扫描组件（`ScannerWidget`）、列表组件（`CommonDataGrid`）和 Loading/提示机制。
+- Todo 列表完成后请将 `[ ]` 改为 `[x]` 以标记完成。
+
+## 模块结构规划
+- 目录建议：`lib/modules/mtl_senter/`
+  ```
+  mtl_senter_module.dart
+  collection_task/
+    bloc/
+    models/
+    services/
+    widgets/
+    mtl_senter_collection_page.dart
+  ```
+- 可选拓展：历史记录、异常记录子页面与公共组件。
+
+## 任务清单
+
+### 1. 需求澄清与接口确认
+- [x] 对照 `api.md` 中的拉式发料接口与 UniApp 逻辑，确认所有字段、参数命名及成功/失败返回结构。
+- [ ] 与后端确认是否需要新增或复用现有 `goods_up`、`outbound` 服务中的认证、头信息、分页参数。
+
+### 2. 模块骨架与路由
+- [x] 新建 `lib/modules/mtl_senter/mtl_senter_module.dart`，注册依赖（BLoC、Service）与路由。
+- [x] 在主模块中添加入口路由（例如 `/pull-feeding/collection`），接入 `home_page` 的功能入口卡片。
+- [x] 参考 `outbound`、`goods_up` 模块的模块化注册方式，配置路由守卫与依赖注入。
+
+### 3. 数据模型（Freezed）
+- [x] 定义 `MtlSenterTask`（任务头信息：工单/产线、车间、计划数量、需求时间等）。
+- [x] 定义 `MtlSenterMaterial`（库存查询结果：库位、物料编码、现有库存、最小包装、默认配送量等）。
+- [x] 定义 `MtlSenterCollectItem`（本次采集记录：库位、物料、批次/序列、数量、唯一标识）。
+- [x] 定义 `MtlSenterSubmitRequest` 与 `MtlSenterSubmitResponse`，确保字段与 `CommitMtlSender` 接口契合。
+- [x] 定义必要的异常/状态模型（例如 `MtlSenterStatus` 或重用通用状态），生成 `*.freezed.dart`、`*.g.dart` 文件。
+
+### 4. Service 层
+- [x] 创建 `MtlSenterService`，封装：
+  - [x] `fetchMaterialByQr`（对接 `getPmMaterialInfoByQR`）。
+  - [x] `fetchInventoryByLocation`（对接 `getLSMtlRepertoryByStoresiteNo`）。
+  - [x] `fetchMtlQty`（对接 `getMtlQtyByMtlCode` 并填充最小包装/默认配送量）。
+  - [x] `commitSender`（对接 `CommitMtlSender`，支持批量提交）。
+- [x] 统一错误处理、超时与 token 刷新逻辑，复用 `ApiService`/`DioClient`。
+- [x] 若接口需要组合请求，编写 DTO 映射（model ↔ API 请求/响应）。
+
+### 5. BLoC 设计
+- [x] 定义事件：初始化、扫码（库位/物料/数量）、删除、提交、重置焦点、刷新库存等。
+- [x] 定义状态：
+  - [x] 当前扫码步骤提示（类似 UniApp `placeholder`）。
+  - [x] 当前选择库位/物料/数量与库存信息。
+  - [x] `stocks` 列表（待提交记录，含唯一 ID）。
+  - [x] 校验/错误信息、加载状态。
+- [x] 在 `CollectionBloc` 中实现与 UniApp 一致的工作流：
+  - [x] 校验扫码顺序（库位 → 物料 → 数量）。
+  - [x] 校验库存是否充足（累计数量 ≤ 库存）。
+  - [x] 同物料+库位合并数量，支持再次扫码叠加。
+  - [x] 删除选中行时同步更新本地字典与库存校验。
+- [ ] 引入 Hive 或本地缓存存储未提交记录（可选需求）。
+
+### 6. UI - `mtlSenterTaskItem` 对应 Flutter 页
+- [x] 页面骨架：`Scaffold` + `AppBar`，拦截返回逻辑（未提交数据弹窗确认）。
+- [x] 顶部扫码输入区使用 `ScannerWidget`，根据状态动态更新 placeholder 与焦点。【F:lib/modules/outbound/collection_task/outbound_collection_page.dart†L28-L119】
+- [x] 显示信息卡片：库位、库存、物料信息、采集数量、最小包装/默认配送量。
+- [x] 待提交列表：
+  - [x] 使用 `CommonDataGrid` 或 `DataTable` 展示库位、物料、数量，支持勾选删除。
+  - [x] 与 BLoC `stocks` 状态绑定，删除后刷新。
+- [x] 底部操作条：删除/提交按钮，状态不可时禁用。
+- [x] 成功/失败反馈：结合 LoadingDialogManager、SnackBar/Dialog 实现。
+
+### 7. 提交与异常处理
+- [x] 实现删除确认弹窗、提交前确认。
+- [x] 提交成功后清理状态并返回首页或刷新任务。
+- [x] 处理接口异常、扫码异常、库存不足提示，确保与 UniApp 体验一致。
+
+### 8. 集成测试与自测
+- [x] 编写 BLoC 单元测试，覆盖：扫码流程、库存不足、重复扫码合并、删除记录、提交成功/失败。（`test/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_bloc_test.dart`）
+- [x] 编写 Service 层单元测试或 Mock 测试，验证请求参数与响应处理。（`test/modules/mtl_senter/collection_task/services/mtl_senter_service_test.dart`）
+- [ ] 如集成 Hive 缓存，测试缓存读写与恢复流程。
+
+### 9. 文档与交付
+- [x] 更新 `docs` 中的业务说明与操作手册，新增 Flutter 拉式发料使用说明。（`docs/mtl_senter_module_guide.md`）
+- [x] 在 README 或模块文档中记录模块依赖、运行命令、测试方式。（README 新增拉式发料说明）
+- [x] 提交代码前执行 `flutter analyze`、`flutter test`、`flutter pub run build_runner build --delete-conflicting-outputs`。（存在历史告警，已记录输出供后续修复）
+
+> 完成项请在复选框内打勾，确保任务闭环。

--- a/lib/app_module.dart
+++ b/lib/app_module.dart
@@ -11,6 +11,7 @@ import 'modules/goods_up/goods_up_module.dart';
 import 'modules/arrival_sign/arrival_sign_module.dart';
 import 'modules/aswh_inventory/aswh_inventory_module.dart';
 import 'modules/inventory_task/inventory_task_module.dart';
+import 'modules/mtl_senter/mtl_senter_module.dart';
 
 /// 应用主模块
 class AppModule extends Module {
@@ -56,5 +57,8 @@ class AppModule extends Module {
 
     // 平库盘点模块
     r.module('/inventory', module: InventoryTaskModule());
+
+    // 拉式发料模块
+    r.module('/mtl-senter', module: MtlSenterModule());
   }
 }

--- a/lib/modules/aswh_inventory/collection_task/models/inventory_collect_detail_models.freezed.dart
+++ b/lib/modules/aswh_inventory/collection_task/models/inventory_collect_detail_models.freezed.dart
@@ -1,10 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package,
-// use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null,
-// invalid_override_different_default_values_named, prefer_expression_function_bodies,
-// annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'inventory_collect_detail_models.dart';
 
@@ -80,19 +77,18 @@ abstract class $InventoryCollectedItemCopyWith<$Res> {
           $Res Function(InventoryCollectedItem) then) =
       _$InventoryCollectedItemCopyWithImpl<$Res, InventoryCollectedItem>;
   @useResult
-  $Res call({
-    @JsonKey(name: 'stockid') String stockId,
-    @JsonKey(name: 'InvTaskItemid') String invTaskItemId,
-    @JsonKey(name: 'InventoryQty') double sourceQty,
-    @JsonKey(name: 'matcode') String materialCode,
-    @JsonKey(name: 'matname') String? materialName,
-    @JsonKey(name: 'batchno') String? batchNo,
-    @JsonKey(name: 'sn') String? serialNo,
-    @JsonKey(name: 'storeRoom') String storeRoomNo,
-    @JsonKey(name: 'storeSite') String storeSiteNo,
-    @JsonKey(name: 'TrayNo') String? trayNo,
-    @JsonKey(name: 'MatId') String? materialId,
-  });
+  $Res call(
+      {@JsonKey(name: 'stockid') String stockId,
+      @JsonKey(name: 'InvTaskItemid') String invTaskItemId,
+      @JsonKey(name: 'InventoryQty') double sourceQty,
+      @JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'storeRoom') String storeRoomNo,
+      @JsonKey(name: 'storeSite') String storeSiteNo,
+      @JsonKey(name: 'TrayNo') String? trayNo,
+      @JsonKey(name: 'MatId') String? materialId});
 }
 
 /// @nodoc
@@ -101,7 +97,9 @@ class _$InventoryCollectedItemCopyWithImpl<$Res,
     implements $InventoryCollectedItemCopyWith<$Res> {
   _$InventoryCollectedItemCopyWithImpl(this._value, this._then);
 
+  // ignore: unused_field
   final $Val _value;
+  // ignore: unused_field
   final $Res Function($Val) _then;
 
   @pragma('vm:prefer-inline')
@@ -177,19 +175,18 @@ abstract class _$$InventoryCollectedItemImplCopyWith<$Res>
       __$$InventoryCollectedItemImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({
-    @JsonKey(name: 'stockid') String stockId,
-    @JsonKey(name: 'InvTaskItemid') String invTaskItemId,
-    @JsonKey(name: 'InventoryQty') double sourceQty,
-    @JsonKey(name: 'matcode') String materialCode,
-    @JsonKey(name: 'matname') String? materialName,
-    @JsonKey(name: 'batchno') String? batchNo,
-    @JsonKey(name: 'sn') String? serialNo,
-    @JsonKey(name: 'storeRoom') String storeRoomNo,
-    @JsonKey(name: 'storeSite') String storeSiteNo,
-    @JsonKey(name: 'TrayNo') String? trayNo,
-    @JsonKey(name: 'MatId') String? materialId,
-  });
+  $Res call(
+      {@JsonKey(name: 'stockid') String stockId,
+      @JsonKey(name: 'InvTaskItemid') String invTaskItemId,
+      @JsonKey(name: 'InventoryQty') double sourceQty,
+      @JsonKey(name: 'matcode') String materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'batchno') String? batchNo,
+      @JsonKey(name: 'sn') String? serialNo,
+      @JsonKey(name: 'storeRoom') String storeRoomNo,
+      @JsonKey(name: 'storeSite') String storeSiteNo,
+      @JsonKey(name: 'TrayNo') String? trayNo,
+      @JsonKey(name: 'MatId') String? materialId});
 }
 
 /// @nodoc
@@ -269,53 +266,73 @@ class __$$InventoryCollectedItemImplCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$InventoryCollectedItemImpl implements _InventoryCollectedItem {
-  const _$InventoryCollectedItemImpl({
-    @JsonKey(name: 'stockid') required this.stockId,
-    @JsonKey(name: 'InvTaskItemid') required this.invTaskItemId,
-    @JsonKey(name: 'InventoryQty') this.sourceQty = 0,
-    @JsonKey(name: 'matcode') required this.materialCode,
-    @JsonKey(name: 'matname') this.materialName,
-    @JsonKey(name: 'batchno') this.batchNo,
-    @JsonKey(name: 'sn') this.serialNo,
-    @JsonKey(name: 'storeRoom') required this.storeRoomNo,
-    @JsonKey(name: 'storeSite') required this.storeSiteNo,
-    @JsonKey(name: 'TrayNo') this.trayNo,
-    @JsonKey(name: 'MatId') this.materialId,
-  });
+  const _$InventoryCollectedItemImpl(
+      {@JsonKey(name: 'stockid') required this.stockId,
+      @JsonKey(name: 'InvTaskItemid') required this.invTaskItemId,
+      @JsonKey(name: 'InventoryQty') this.sourceQty = 0,
+      @JsonKey(name: 'matcode') required this.materialCode,
+      @JsonKey(name: 'matname') this.materialName,
+      @JsonKey(name: 'batchno') this.batchNo,
+      @JsonKey(name: 'sn') this.serialNo,
+      @JsonKey(name: 'storeRoom') required this.storeRoomNo,
+      @JsonKey(name: 'storeSite') required this.storeSiteNo,
+      @JsonKey(name: 'TrayNo') this.trayNo,
+      @JsonKey(name: 'MatId') this.materialId});
 
   factory _$InventoryCollectedItemImpl.fromJson(Map<String, dynamic> json) =>
       _$$InventoryCollectedItemImplFromJson(json);
 
+  /// 本地缓存记录ID
   @override
   @JsonKey(name: 'stockid')
   final String stockId;
+
+  /// 对应的盘点任务明细ID
   @override
   @JsonKey(name: 'InvTaskItemid')
   final String invTaskItemId;
+
+  /// 采集数量（源数量）
   @override
   @JsonKey(name: 'InventoryQty')
   final double sourceQty;
+
+  /// 物料编码
   @override
   @JsonKey(name: 'matcode')
   final String materialCode;
+
+  /// 物料名称
   @override
   @JsonKey(name: 'matname')
   final String? materialName;
+
+  /// 批次号
   @override
   @JsonKey(name: 'batchno')
   final String? batchNo;
+
+  /// 序列号
   @override
   @JsonKey(name: 'sn')
   final String? serialNo;
+
+  /// 库房编码
   @override
   @JsonKey(name: 'storeRoom')
   final String storeRoomNo;
+
+  /// 库位编码
   @override
   @JsonKey(name: 'storeSite')
   final String storeSiteNo;
+
+  /// 托盘号
   @override
   @JsonKey(name: 'TrayNo')
   final String? trayNo;
+
+  /// 物料主数据ID
   @override
   @JsonKey(name: 'MatId')
   final String? materialId;
@@ -354,19 +371,18 @@ class _$InventoryCollectedItemImpl implements _InventoryCollectedItem {
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-        runtimeType,
-        stockId,
-        invTaskItemId,
-        sourceQty,
-        materialCode,
-        materialName,
-        batchNo,
-        serialNo,
-        storeRoomNo,
-        storeSiteNo,
-        trayNo,
-        materialId,
-      );
+      runtimeType,
+      stockId,
+      invTaskItemId,
+      sourceQty,
+      materialCode,
+      materialName,
+      batchNo,
+      serialNo,
+      storeRoomNo,
+      storeSiteNo,
+      trayNo,
+      materialId);
 
   @JsonKey(ignore: true)
   @override
@@ -383,56 +399,77 @@ class _$InventoryCollectedItemImpl implements _InventoryCollectedItem {
   }
 }
 
-/// @nodoc
 abstract class _InventoryCollectedItem implements InventoryCollectedItem {
-  const factory _InventoryCollectedItem({
-    @JsonKey(name: 'stockid') required final String stockId,
-    @JsonKey(name: 'InvTaskItemid') required final String invTaskItemId,
-    @JsonKey(name: 'InventoryQty') final double sourceQty,
-    @JsonKey(name: 'matcode') required final String materialCode,
-    @JsonKey(name: 'matname') final String? materialName,
-    @JsonKey(name: 'batchno') final String? batchNo,
-    @JsonKey(name: 'sn') final String? serialNo,
-    @JsonKey(name: 'storeRoom') required final String storeRoomNo,
-    @JsonKey(name: 'storeSite') required final String storeSiteNo,
-    @JsonKey(name: 'TrayNo') final String? trayNo,
-    @JsonKey(name: 'MatId') final String? materialId,
-  }) = _$InventoryCollectedItemImpl;
+  const factory _InventoryCollectedItem(
+          {@JsonKey(name: 'stockid') required final String stockId,
+          @JsonKey(name: 'InvTaskItemid') required final String invTaskItemId,
+          @JsonKey(name: 'InventoryQty') final double sourceQty,
+          @JsonKey(name: 'matcode') required final String materialCode,
+          @JsonKey(name: 'matname') final String? materialName,
+          @JsonKey(name: 'batchno') final String? batchNo,
+          @JsonKey(name: 'sn') final String? serialNo,
+          @JsonKey(name: 'storeRoom') required final String storeRoomNo,
+          @JsonKey(name: 'storeSite') required final String storeSiteNo,
+          @JsonKey(name: 'TrayNo') final String? trayNo,
+          @JsonKey(name: 'MatId') final String? materialId}) =
+      _$InventoryCollectedItemImpl;
 
   factory _InventoryCollectedItem.fromJson(Map<String, dynamic> json) =
       _$InventoryCollectedItemImpl.fromJson;
 
   @override
+
+  /// 本地缓存记录ID
   @JsonKey(name: 'stockid')
   String get stockId;
   @override
+
+  /// 对应的盘点任务明细ID
   @JsonKey(name: 'InvTaskItemid')
   String get invTaskItemId;
   @override
+
+  /// 采集数量（源数量）
   @JsonKey(name: 'InventoryQty')
   double get sourceQty;
   @override
+
+  /// 物料编码
   @JsonKey(name: 'matcode')
   String get materialCode;
   @override
+
+  /// 物料名称
   @JsonKey(name: 'matname')
   String? get materialName;
   @override
+
+  /// 批次号
   @JsonKey(name: 'batchno')
   String? get batchNo;
   @override
+
+  /// 序列号
   @JsonKey(name: 'sn')
   String? get serialNo;
   @override
+
+  /// 库房编码
   @JsonKey(name: 'storeRoom')
   String get storeRoomNo;
   @override
+
+  /// 库位编码
   @JsonKey(name: 'storeSite')
   String get storeSiteNo;
   @override
+
+  /// 托盘号
   @JsonKey(name: 'TrayNo')
   String? get trayNo;
   @override
+
+  /// 物料主数据ID
   @JsonKey(name: 'MatId')
   String? get materialId;
   @override

--- a/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.freezed.dart
+++ b/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.freezed.dart
@@ -1,17 +1,18 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'inventory_pallet_item.dart';
 
 // **************************************************************************
-// FreezedGenerator (manually crafted stub)
+// FreezedGenerator
 // **************************************************************************
 
-// ignore: unnecessary_import
-import 'package:collection/collection.dart';
-
 T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 InventoryPalletItem _$InventoryPalletItemFromJson(Map<String, dynamic> json) {
   return _InventoryPalletItem.fromJson(json);
@@ -48,32 +49,35 @@ mixin _$InventoryPalletItem {
 
 /// @nodoc
 abstract class $InventoryPalletItemCopyWith<$Res> {
-  factory $InventoryPalletItemCopyWith(InventoryPalletItem value,
-          $Res Function(InventoryPalletItem) then) =
-      _$InventoryPalletItemCopyWithImpl<$Res>;
-  $Res call({
-    @JsonKey(name: 'palletNo') String? palletNo,
-    @JsonKey(name: 'matcode') String? materialCode,
-    @JsonKey(name: 'matname') String? materialName,
-    @JsonKey(name: 'itemBatch') String? batchNo,
-    @JsonKey(name: 'itemSn') String? serialNo,
-    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
-    double? quantity,
-    @JsonKey(name: 'proofno') String? proofNo,
-    @JsonKey(name: 'proofNo') String? proofNoAlt,
-    @JsonKey(name: 'storesite') String? storeSite,
-    @JsonKey(name: 'storeroomno') String? storeRoom,
-  });
+  factory $InventoryPalletItemCopyWith(
+          InventoryPalletItem value, $Res Function(InventoryPalletItem) then) =
+      _$InventoryPalletItemCopyWithImpl<$Res, InventoryPalletItem>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'palletNo') String? palletNo,
+      @JsonKey(name: 'matcode') String? materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'itemBatch') String? batchNo,
+      @JsonKey(name: 'itemSn') String? serialNo,
+      @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+      double? quantity,
+      @JsonKey(name: 'proofno') String? proofNo,
+      @JsonKey(name: 'proofNo') String? proofNoAlt,
+      @JsonKey(name: 'storesite') String? storeSite,
+      @JsonKey(name: 'storeroomno') String? storeRoom});
 }
 
 /// @nodoc
-class _$InventoryPalletItemCopyWithImpl<$Res>
+class _$InventoryPalletItemCopyWithImpl<$Res, $Val extends InventoryPalletItem>
     implements $InventoryPalletItemCopyWith<$Res> {
   _$InventoryPalletItemCopyWithImpl(this._value, this._then);
 
-  final InventoryPalletItem _value;
-  final $Res Function(InventoryPalletItem) _then;
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? palletNo = freezed,
@@ -88,83 +92,81 @@ class _$InventoryPalletItemCopyWithImpl<$Res>
     Object? storeRoom = freezed,
   }) {
     return _then(_value.copyWith(
-      palletNo: palletNo == freezed
+      palletNo: freezed == palletNo
           ? _value.palletNo
           : palletNo // ignore: cast_nullable_to_non_nullable
               as String?,
-      materialCode: materialCode == freezed
+      materialCode: freezed == materialCode
           ? _value.materialCode
           : materialCode // ignore: cast_nullable_to_non_nullable
               as String?,
-      materialName: materialName == freezed
+      materialName: freezed == materialName
           ? _value.materialName
           : materialName // ignore: cast_nullable_to_non_nullable
               as String?,
-      batchNo: batchNo == freezed
+      batchNo: freezed == batchNo
           ? _value.batchNo
           : batchNo // ignore: cast_nullable_to_non_nullable
               as String?,
-      serialNo: serialNo == freezed
+      serialNo: freezed == serialNo
           ? _value.serialNo
           : serialNo // ignore: cast_nullable_to_non_nullable
               as String?,
-      quantity: quantity == freezed
+      quantity: freezed == quantity
           ? _value.quantity
           : quantity // ignore: cast_nullable_to_non_nullable
               as double?,
-      proofNo: proofNo == freezed
+      proofNo: freezed == proofNo
           ? _value.proofNo
           : proofNo // ignore: cast_nullable_to_non_nullable
               as String?,
-      proofNoAlt: proofNoAlt == freezed
+      proofNoAlt: freezed == proofNoAlt
           ? _value.proofNoAlt
           : proofNoAlt // ignore: cast_nullable_to_non_nullable
               as String?,
-      storeSite: storeSite == freezed
+      storeSite: freezed == storeSite
           ? _value.storeSite
           : storeSite // ignore: cast_nullable_to_non_nullable
               as String?,
-      storeRoom: storeRoom == freezed
+      storeRoom: freezed == storeRoom
           ? _value.storeRoom
           : storeRoom // ignore: cast_nullable_to_non_nullable
               as String?,
-    ));
+    ) as $Val);
   }
 }
 
 /// @nodoc
-abstract class _$$_InventoryPalletItemCopyWith<$Res>
+abstract class _$$InventoryPalletItemImplCopyWith<$Res>
     implements $InventoryPalletItemCopyWith<$Res> {
-  factory _$$_InventoryPalletItemCopyWith(_$_InventoryPalletItem value,
-          $Res Function(_$_InventoryPalletItem) then) =
-      __$$_InventoryPalletItemCopyWithImpl<$Res>;
+  factory _$$InventoryPalletItemImplCopyWith(_$InventoryPalletItemImpl value,
+          $Res Function(_$InventoryPalletItemImpl) then) =
+      __$$InventoryPalletItemImplCopyWithImpl<$Res>;
   @override
-  $Res call({
-    @JsonKey(name: 'palletNo') String? palletNo,
-    @JsonKey(name: 'matcode') String? materialCode,
-    @JsonKey(name: 'matname') String? materialName,
-    @JsonKey(name: 'itemBatch') String? batchNo,
-    @JsonKey(name: 'itemSn') String? serialNo,
-    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
-    double? quantity,
-    @JsonKey(name: 'proofno') String? proofNo,
-    @JsonKey(name: 'proofNo') String? proofNoAlt,
-    @JsonKey(name: 'storesite') String? storeSite,
-    @JsonKey(name: 'storeroomno') String? storeRoom,
-  });
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'palletNo') String? palletNo,
+      @JsonKey(name: 'matcode') String? materialCode,
+      @JsonKey(name: 'matname') String? materialName,
+      @JsonKey(name: 'itemBatch') String? batchNo,
+      @JsonKey(name: 'itemSn') String? serialNo,
+      @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+      double? quantity,
+      @JsonKey(name: 'proofno') String? proofNo,
+      @JsonKey(name: 'proofNo') String? proofNoAlt,
+      @JsonKey(name: 'storesite') String? storeSite,
+      @JsonKey(name: 'storeroomno') String? storeRoom});
 }
 
 /// @nodoc
-class __$$_InventoryPalletItemCopyWithImpl<$Res>
-    extends _$InventoryPalletItemCopyWithImpl<$Res>
-    implements _$$_InventoryPalletItemCopyWith<$Res> {
-  __$$_InventoryPalletItemCopyWithImpl(_$_InventoryPalletItem _value,
-      $Res Function(_$_InventoryPalletItem) _then)
-      : super(_value, (v) => _then(v as _$_InventoryPalletItem));
+class __$$InventoryPalletItemImplCopyWithImpl<$Res>
+    extends _$InventoryPalletItemCopyWithImpl<$Res, _$InventoryPalletItemImpl>
+    implements _$$InventoryPalletItemImplCopyWith<$Res> {
+  __$$InventoryPalletItemImplCopyWithImpl(_$InventoryPalletItemImpl _value,
+      $Res Function(_$InventoryPalletItemImpl) _then)
+      : super(_value, _then);
 
-  @override
-  _$_InventoryPalletItem get _value => super._value as _$_InventoryPalletItem;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? palletNo = freezed,
@@ -178,44 +180,44 @@ class __$$_InventoryPalletItemCopyWithImpl<$Res>
     Object? storeSite = freezed,
     Object? storeRoom = freezed,
   }) {
-    return _then(_$_InventoryPalletItem(
-      palletNo: palletNo == freezed
+    return _then(_$InventoryPalletItemImpl(
+      palletNo: freezed == palletNo
           ? _value.palletNo
           : palletNo // ignore: cast_nullable_to_non_nullable
               as String?,
-      materialCode: materialCode == freezed
+      materialCode: freezed == materialCode
           ? _value.materialCode
           : materialCode // ignore: cast_nullable_to_non_nullable
               as String?,
-      materialName: materialName == freezed
+      materialName: freezed == materialName
           ? _value.materialName
           : materialName // ignore: cast_nullable_to_non_nullable
               as String?,
-      batchNo: batchNo == freezed
+      batchNo: freezed == batchNo
           ? _value.batchNo
           : batchNo // ignore: cast_nullable_to_non_nullable
               as String?,
-      serialNo: serialNo == freezed
+      serialNo: freezed == serialNo
           ? _value.serialNo
           : serialNo // ignore: cast_nullable_to_non_nullable
               as String?,
-      quantity: quantity == freezed
+      quantity: freezed == quantity
           ? _value.quantity
           : quantity // ignore: cast_nullable_to_non_nullable
               as double?,
-      proofNo: proofNo == freezed
+      proofNo: freezed == proofNo
           ? _value.proofNo
           : proofNo // ignore: cast_nullable_to_non_nullable
               as String?,
-      proofNoAlt: proofNoAlt == freezed
+      proofNoAlt: freezed == proofNoAlt
           ? _value.proofNoAlt
           : proofNoAlt // ignore: cast_nullable_to_non_nullable
               as String?,
-      storeSite: storeSite == freezed
+      storeSite: freezed == storeSite
           ? _value.storeSite
           : storeSite // ignore: cast_nullable_to_non_nullable
               as String?,
-      storeRoom: storeRoom == freezed
+      storeRoom: freezed == storeRoom
           ? _value.storeRoom
           : storeRoom // ignore: cast_nullable_to_non_nullable
               as String?,
@@ -225,23 +227,23 @@ class __$$_InventoryPalletItemCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$_InventoryPalletItem extends _InventoryPalletItem {
-  const _$_InventoryPalletItem({
-    @JsonKey(name: 'palletNo') this.palletNo,
-    @JsonKey(name: 'matcode') this.materialCode,
-    @JsonKey(name: 'matname') this.materialName,
-    @JsonKey(name: 'itemBatch') this.batchNo,
-    @JsonKey(name: 'itemSn') this.serialNo,
-    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
-    this.quantity,
-    @JsonKey(name: 'proofno') this.proofNo,
-    @JsonKey(name: 'proofNo') this.proofNoAlt,
-    @JsonKey(name: 'storesite') this.storeSite,
-    @JsonKey(name: 'storeroomno') this.storeRoom,
-  }) : super._();
+class _$InventoryPalletItemImpl extends _InventoryPalletItem {
+  const _$InventoryPalletItemImpl(
+      {@JsonKey(name: 'palletNo') this.palletNo,
+      @JsonKey(name: 'matcode') this.materialCode,
+      @JsonKey(name: 'matname') this.materialName,
+      @JsonKey(name: 'itemBatch') this.batchNo,
+      @JsonKey(name: 'itemSn') this.serialNo,
+      @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+      this.quantity,
+      @JsonKey(name: 'proofno') this.proofNo,
+      @JsonKey(name: 'proofNo') this.proofNoAlt,
+      @JsonKey(name: 'storesite') this.storeSite,
+      @JsonKey(name: 'storeroomno') this.storeRoom})
+      : super._();
 
-  factory _$_InventoryPalletItem.fromJson(Map<String, dynamic> json) =>
-      _$$_InventoryPalletItemFromJson(json);
+  factory _$InventoryPalletItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryPalletItemImplFromJson(json);
 
   @override
   @JsonKey(name: 'palletNo')
@@ -283,72 +285,108 @@ class _$_InventoryPalletItem extends _InventoryPalletItem {
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$_InventoryPalletItem &&
-            const DeepCollectionEquality().equals(other.palletNo, palletNo) &&
-            const DeepCollectionEquality()
-                .equals(other.materialCode, materialCode) &&
-            const DeepCollectionEquality()
-                .equals(other.materialName, materialName) &&
-            const DeepCollectionEquality().equals(other.batchNo, batchNo) &&
-            const DeepCollectionEquality().equals(other.serialNo, serialNo) &&
-            const DeepCollectionEquality().equals(other.quantity, quantity) &&
-            const DeepCollectionEquality().equals(other.proofNo, proofNo) &&
-            const DeepCollectionEquality().equals(other.proofNoAlt, proofNoAlt) &&
-            const DeepCollectionEquality().equals(other.storeSite, storeSite) &&
-            const DeepCollectionEquality().equals(other.storeRoom, storeRoom));
+            other is _$InventoryPalletItemImpl &&
+            (identical(other.palletNo, palletNo) ||
+                other.palletNo == palletNo) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo) &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity) &&
+            (identical(other.proofNo, proofNo) || other.proofNo == proofNo) &&
+            (identical(other.proofNoAlt, proofNoAlt) ||
+                other.proofNoAlt == proofNoAlt) &&
+            (identical(other.storeSite, storeSite) ||
+                other.storeSite == storeSite) &&
+            (identical(other.storeRoom, storeRoom) ||
+                other.storeRoom == storeRoom));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
-        runtimeType,
-        const DeepCollectionEquality().hash(palletNo),
-        const DeepCollectionEquality().hash(materialCode),
-        const DeepCollectionEquality().hash(materialName),
-        const DeepCollectionEquality().hash(batchNo),
-        const DeepCollectionEquality().hash(serialNo),
-        const DeepCollectionEquality().hash(quantity),
-        const DeepCollectionEquality().hash(proofNo),
-        const DeepCollectionEquality().hash(proofNoAlt),
-        const DeepCollectionEquality().hash(storeSite),
-        const DeepCollectionEquality().hash(storeRoom),
-      );
+      runtimeType,
+      palletNo,
+      materialCode,
+      materialName,
+      batchNo,
+      serialNo,
+      quantity,
+      proofNo,
+      proofNoAlt,
+      storeSite,
+      storeRoom);
 
   @JsonKey(ignore: true)
   @override
-  _$$_InventoryPalletItemCopyWith<_$_InventoryPalletItem> get copyWith =>
-      __$$_InventoryPalletItemCopyWithImpl<_$_InventoryPalletItem>(
+  @pragma('vm:prefer-inline')
+  _$$InventoryPalletItemImplCopyWith<_$InventoryPalletItemImpl> get copyWith =>
+      __$$InventoryPalletItemImplCopyWithImpl<_$InventoryPalletItemImpl>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_InventoryPalletItemToJson(
+    return _$$InventoryPalletItemImplToJson(
       this,
     );
   }
 }
 
-/// @nodoc
 abstract class _InventoryPalletItem extends InventoryPalletItem {
-  const factory _InventoryPalletItem({
-    @JsonKey(name: 'palletNo') final String? palletNo,
-    @JsonKey(name: 'matcode') final String? materialCode,
-    @JsonKey(name: 'matname') final String? materialName,
-    @JsonKey(name: 'itemBatch') final String? batchNo,
-    @JsonKey(name: 'itemSn') final String? serialNo,
-    @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
-    final double? quantity,
-    @JsonKey(name: 'proofno') final String? proofNo,
-    @JsonKey(name: 'proofNo') final String? proofNoAlt,
-    @JsonKey(name: 'storesite') final String? storeSite,
-    @JsonKey(name: 'storeroomno') final String? storeRoom,
-  }) = _$_InventoryPalletItem;
+  const factory _InventoryPalletItem(
+          {@JsonKey(name: 'palletNo') final String? palletNo,
+          @JsonKey(name: 'matcode') final String? materialCode,
+          @JsonKey(name: 'matname') final String? materialName,
+          @JsonKey(name: 'itemBatch') final String? batchNo,
+          @JsonKey(name: 'itemSn') final String? serialNo,
+          @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+          final double? quantity,
+          @JsonKey(name: 'proofno') final String? proofNo,
+          @JsonKey(name: 'proofNo') final String? proofNoAlt,
+          @JsonKey(name: 'storesite') final String? storeSite,
+          @JsonKey(name: 'storeroomno') final String? storeRoom}) =
+      _$InventoryPalletItemImpl;
   const _InventoryPalletItem._() : super._();
 
   factory _InventoryPalletItem.fromJson(Map<String, dynamic> json) =
-      _$_InventoryPalletItem.fromJson;
-}
+      _$InventoryPalletItemImpl.fromJson;
 
-const _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.
-Please check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+  @override
+  @JsonKey(name: 'palletNo')
+  String? get palletNo;
+  @override
+  @JsonKey(name: 'matcode')
+  String? get materialCode;
+  @override
+  @JsonKey(name: 'matname')
+  String? get materialName;
+  @override
+  @JsonKey(name: 'itemBatch')
+  String? get batchNo;
+  @override
+  @JsonKey(name: 'itemSn')
+  String? get serialNo;
+  @override
+  @JsonKey(name: 'itemQty', fromJson: _toDouble, toJson: _doubleToJson)
+  double? get quantity;
+  @override
+  @JsonKey(name: 'proofno')
+  String? get proofNo;
+  @override
+  @JsonKey(name: 'proofNo')
+  String? get proofNoAlt;
+  @override
+  @JsonKey(name: 'storesite')
+  String? get storeSite;
+  @override
+  @JsonKey(name: 'storeroomno')
+  String? get storeRoom;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryPalletItemImplCopyWith<_$InventoryPalletItemImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.g.dart
+++ b/lib/modules/aswh_inventory/pallet_item/models/inventory_pallet_item.g.dart
@@ -1,11 +1,14 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint
 
 part of 'inventory_pallet_item.dart';
 
-_$_InventoryPalletItem _$$_InventoryPalletItemFromJson(
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryPalletItemImpl _$$InventoryPalletItemImplFromJson(
         Map<String, dynamic> json) =>
-    _$_InventoryPalletItem(
+    _$InventoryPalletItemImpl(
       palletNo: json['palletNo'] as String?,
       materialCode: json['matcode'] as String?,
       materialName: json['matname'] as String?,
@@ -18,8 +21,8 @@ _$_InventoryPalletItem _$$_InventoryPalletItemFromJson(
       storeRoom: json['storeroomno'] as String?,
     );
 
-Map<String, dynamic> _$$_InventoryPalletItemToJson(
-        _$_InventoryPalletItem instance) =>
+Map<String, dynamic> _$$InventoryPalletItemImplToJson(
+        _$InventoryPalletItemImpl instance) =>
     <String, dynamic>{
       'palletNo': instance.palletNo,
       'matcode': instance.materialCode,

--- a/lib/modules/home/home_page.dart
+++ b/lib/modules/home/home_page.dart
@@ -291,6 +291,8 @@ class _FunctionGrid extends StatelessWidget {
             Modular.to.pushNamed('/outbound');
           } else if (f.title == '平库入库') {
             Modular.to.pushNamed('/goods-up');
+          } else if (f.title == '拉式发料') {
+            Modular.to.pushNamed('/mtl-senter');
           } else {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(

--- a/lib/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_bloc.dart
+++ b/lib/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_bloc.dart
@@ -1,0 +1,444 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:collection/collection.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../models/page_status.dart';
+import '../models/mtl_senter_models.dart';
+import '../services/mtl_senter_service.dart';
+import 'mtl_senter_collection_event.dart';
+import 'mtl_senter_collection_state.dart';
+
+class MtlSenterCollectionBloc
+    extends Bloc<MtlSenterCollectionEvent, MtlSenterCollectionState> {
+  MtlSenterCollectionBloc({required MtlSenterService service})
+      : _service = service,
+        super(const MtlSenterCollectionState()) {
+    on<MtlSenterCollectionStarted>(_onStarted);
+    on<MtlSenterBarcodeScanned>(_onBarcodeScanned);
+    on<MtlSenterDeleteSelected>(_onDeleteSelected);
+    on<MtlSenterToggleSelection>(_onToggleSelection);
+    on<MtlSenterSelectionChanged>(_onSelectionChanged);
+    on<MtlSenterSubmitRequested>(_onSubmit);
+    on<MtlSenterResetStatus>(_onResetStatus);
+    on<MtlSenterClearCurrentInput>(_onClearCurrentInput);
+    on<MtlSenterFocusConsumed>(_onFocusConsumed);
+  }
+
+  final MtlSenterService _service;
+  final Uuid _uuid = const Uuid();
+
+  FutureOr<void> _onStarted(
+    MtlSenterCollectionStarted event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        task: event.task,
+        operatorId: event.operatorId,
+        status: CollectionStatus.normal(),
+        scanStep: MtlSenterScanStep.location,
+        currentLocation: null,
+        currentMaterial: null,
+        currentQuantity: null,
+        availableQty: 0,
+        minPackageQty: null,
+        defaultDeliveryQty: null,
+        stocks: const [],
+        selectedIds: const {},
+        collectedQtyMap: const {},
+        focus: false,
+      ),
+    );
+  }
+
+  FutureOr<void> _onResetStatus(
+    MtlSenterResetStatus event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) {
+    if (!state.status.isNormal) {
+      emit(state.copyWith(status: CollectionStatus.normal()));
+    }
+  }
+
+  FutureOr<void> _onClearCurrentInput(
+    MtlSenterClearCurrentInput event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        currentMaterial: null,
+        currentQuantity: null,
+        availableQty: state.currentLocation != null ? state.availableQty : 0,
+        minPackageQty: null,
+        defaultDeliveryQty: null,
+        scanStep: state.currentLocation != null
+            ? MtlSenterScanStep.material
+            : MtlSenterScanStep.location,
+        focus: state.currentLocation != null,
+      ),
+    );
+  }
+
+  FutureOr<void> _onFocusConsumed(
+    MtlSenterFocusConsumed event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) {
+    if (state.focus) {
+      emit(state.copyWith(focus: false));
+    }
+  }
+
+  Future<void> _onBarcodeScanned(
+    MtlSenterBarcodeScanned event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) async {
+    final barcode = event.barcode.trim();
+    if (barcode.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('采集内容为空，请重新采集'),
+          focus: state.scanStep == MtlSenterScanStep.quantity,
+        ),
+      );
+      return;
+    }
+
+    try {
+      final step = _determineStep(barcode);
+      if (step == null) {
+        throw Exception('采集内容不合法，请确认条码格式');
+      }
+
+      switch (step) {
+        case MtlSenterScanStep.location:
+          await _handleLocationScan(barcode, emit);
+          break;
+        case MtlSenterScanStep.material:
+          await _handleMaterialScan(barcode, emit);
+          break;
+        case MtlSenterScanStep.quantity:
+          await _handleQuantityInput(barcode, emit);
+          break;
+        case MtlSenterScanStep.idle:
+          break;
+      }
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(_normalizeErrorMessage(e)),
+          focus: state.scanStep == MtlSenterScanStep.quantity,
+        ),
+      );
+    }
+  }
+
+  Future<void> _handleLocationScan(
+    String barcode,
+    Emitter<MtlSenterCollectionState> emit,
+  ) async {
+    final parsed = _parseLocation(barcode);
+    if (parsed == null) {
+      throw Exception('库位条码识别失败，请重试');
+    }
+
+    var availableQty = state.availableQty;
+    if (state.currentMaterial != null) {
+      availableQty = await _loadInventoryQty(
+        location: parsed,
+        materialCode: state.currentMaterial!.materialCode,
+      );
+    }
+
+    emit(
+      state.copyWith(
+        currentLocation: parsed,
+        scanStep: state.currentMaterial == null
+            ? MtlSenterScanStep.material
+            : MtlSenterScanStep.quantity,
+        availableQty: availableQty,
+        status: CollectionStatus.normal(),
+        focus: state.currentMaterial != null,
+      ),
+    );
+  }
+
+  Future<void> _handleMaterialScan(
+    String barcode,
+    Emitter<MtlSenterCollectionState> emit,
+  ) async {
+    emit(state.copyWith(status: CollectionStatus.loading()));
+
+    final material = await _service.fetchMaterialByQr(barcode);
+
+    double availableQty = state.availableQty;
+    if (state.currentLocation != null) {
+      availableQty = await _loadInventoryQty(
+        location: state.currentLocation!,
+        materialCode: material.materialCode,
+      );
+    }
+
+    final qtyInfo = await _service.fetchMtlQty(
+      materialCode: material.materialCode,
+      siteNo: state.currentLocation,
+    );
+
+    emit(
+      state.copyWith(
+        status: CollectionStatus.normal(),
+        currentMaterial: material,
+        availableQty: availableQty,
+        minPackageQty: qtyInfo?.minPackageQty ?? material.minPackageQty,
+        defaultDeliveryQty:
+            qtyInfo?.defaultDeliveryQty ?? material.defaultDeliveryQty,
+        scanStep: state.currentLocation == null
+            ? MtlSenterScanStep.location
+            : MtlSenterScanStep.quantity,
+        focus: state.currentLocation != null,
+      ),
+    );
+  }
+
+  Future<void> _handleQuantityInput(
+    String barcode,
+    Emitter<MtlSenterCollectionState> emit,
+  ) async {
+    if (state.currentLocation == null) {
+      throw Exception('请先扫描库位');
+    }
+    if (state.currentMaterial == null) {
+      throw Exception('请先扫描物料二维码');
+    }
+
+    final qty = double.tryParse(barcode);
+    if (qty == null || qty <= 0) {
+      throw Exception('数量格式不正确，请输入正数');
+    }
+
+    final key = _itemKey(
+      materialCode: state.currentMaterial!.materialCode,
+      location: state.currentLocation!,
+    );
+
+    final aggregated = state.collectedQtyMap[key] ?? 0;
+    final newTotal = aggregated + qty;
+
+    if (state.availableQty > 0 && newTotal > state.availableQty + 1e-6) {
+      throw Exception('累计数量超过当前库存，请确认');
+    }
+
+    final existingItem = state.stocks
+        .firstWhereOrNull((item) => _itemKey(
+              materialCode: item.materialCode,
+              location: item.storeSiteNo,
+            ) ==
+            key);
+
+    List<MtlSenterCollectItem> updatedStocks;
+    if (existingItem != null) {
+      updatedStocks = state.stocks
+          .map(
+            (item) => item.id == existingItem.id
+                ? item.copyWith(quantity: item.quantity + qty)
+                : item,
+          )
+          .toList();
+    } else {
+      final newItem = MtlSenterCollectItem(
+        id: _uuid.v4(),
+        storeSiteNo: state.currentLocation!,
+        storeRoomNo: state.currentMaterial?.storeRoomNo,
+        materialCode: state.currentMaterial!.materialCode,
+        materialName: state.currentMaterial!.materialName,
+        batchNo: state.currentMaterial!.batchNo,
+        serialNo: state.currentMaterial!.serialNo,
+        quantity: qty,
+        availableQty: state.availableQty,
+        minPackageQty: state.minPackageQty,
+        defaultDeliveryQty: state.defaultDeliveryQty,
+      );
+      updatedStocks = [...state.stocks, newItem];
+    }
+
+    final updatedMap = Map<String, double>.from(state.collectedQtyMap)
+      ..[key] = newTotal;
+
+    emit(
+      state.copyWith(
+        stocks: updatedStocks,
+        collectedQtyMap: updatedMap,
+        currentMaterial: null,
+        currentQuantity: null,
+        minPackageQty: null,
+        defaultDeliveryQty: null,
+        status: CollectionStatus.success('采集已记录'),
+        scanStep: MtlSenterScanStep.material,
+        focus: true,
+      ),
+    );
+  }
+
+  Future<void> _onDeleteSelected(
+    MtlSenterDeleteSelected event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) async {
+    if (state.selectedIds.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请至少选择一条记录'),
+        ),
+      );
+      return;
+    }
+
+    final updatedStocks =
+        state.stocks.where((item) => !state.selectedIds.contains(item.id)).toList();
+
+    final updatedMap = Map<String, double>.from(state.collectedQtyMap);
+    for (final item in state.stocks) {
+      if (!state.selectedIds.contains(item.id)) continue;
+      final key = _itemKey(
+        materialCode: item.materialCode,
+        location: item.storeSiteNo,
+      );
+      final current = updatedMap[key] ?? 0;
+      final nextValue = current - item.quantity;
+      if (nextValue <= 0) {
+        updatedMap.remove(key);
+      } else {
+        updatedMap[key] = nextValue;
+      }
+    }
+
+    emit(
+      state.copyWith(
+        stocks: updatedStocks,
+        selectedIds: const {},
+        collectedQtyMap: updatedMap,
+        status: CollectionStatus.success('已删除选中记录'),
+      ),
+    );
+  }
+
+  FutureOr<void> _onToggleSelection(
+    MtlSenterToggleSelection event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) {
+    final updated = Set<String>.from(state.selectedIds);
+    if (updated.contains(event.id)) {
+      updated.remove(event.id);
+    } else {
+      updated.add(event.id);
+    }
+
+    emit(state.copyWith(selectedIds: updated));
+  }
+
+  FutureOr<void> _onSelectionChanged(
+    MtlSenterSelectionChanged event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) {
+    emit(state.copyWith(selectedIds: event.ids));
+  }
+
+  Future<void> _onSubmit(
+    MtlSenterSubmitRequested event,
+    Emitter<MtlSenterCollectionState> emit,
+  ) async {
+    if (state.stocks.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('本次无采集明细，请确认'),
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: CollectionStatus.loading()));
+
+    try {
+      final request = MtlSenterSubmitRequest(
+        mtlSenderInfos: state.stocks,
+        taskNo: state.task?.taskId,
+        operatorId: state.operatorId,
+      );
+      await _service.commitSender(request: request);
+
+      emit(
+        state.copyWith(
+          status: CollectionStatus.success('提交成功'),
+          stocks: const [],
+          selectedIds: const {},
+          collectedQtyMap: const {},
+          currentMaterial: null,
+          currentQuantity: null,
+          availableQty: state.currentLocation != null ? state.availableQty : 0,
+          minPackageQty: null,
+          defaultDeliveryQty: null,
+          scanStep: state.currentLocation != null
+              ? MtlSenterScanStep.material
+              : MtlSenterScanStep.location,
+          focus: state.currentLocation != null,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(_normalizeErrorMessage(e)),
+        ),
+      );
+    }
+  }
+
+  Future<double> _loadInventoryQty({
+    required String location,
+    required String materialCode,
+  }) async {
+    final result = await _service.fetchInventoryByLocation(
+      storeSite: location,
+      materialCode: materialCode,
+    );
+    return result ?? 0;
+  }
+
+  static MtlSenterScanStep? _determineStep(String barcode) {
+    final normalized = barcode.trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+    if (_isQuantity(normalized)) {
+      return MtlSenterScanStep.quantity;
+    }
+    if (normalized.contains(r'$KW$')) {
+      return MtlSenterScanStep.location;
+    }
+    if (normalized.toUpperCase().contains('MC')) {
+      return MtlSenterScanStep.material;
+    }
+    return null;
+  }
+
+  static bool _isQuantity(String source) {
+    final regex = RegExp(r'^[0-9]+([.][0-9]+)?$');
+    return regex.hasMatch(source);
+  }
+
+  String? _parseLocation(String barcode) {
+    final parts = barcode.split(r'$');
+    if (parts.length >= 3) {
+      return parts[2].trim();
+    }
+    return null;
+  }
+
+  String _itemKey({required String materialCode, required String location}) {
+    return '$materialCode@$location';
+  }
+
+  String _normalizeErrorMessage(Object error) {
+    final text = error.toString();
+    return text.replaceFirst('Exception: ', '');
+  }
+}

--- a/lib/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_event.dart
+++ b/lib/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_event.dart
@@ -1,0 +1,50 @@
+import '../models/mtl_senter_models.dart';
+
+abstract class MtlSenterCollectionEvent {
+  const MtlSenterCollectionEvent();
+}
+
+class MtlSenterCollectionStarted extends MtlSenterCollectionEvent {
+  const MtlSenterCollectionStarted({this.task, this.operatorId});
+
+  final MtlSenterTask? task;
+  final String? operatorId;
+}
+
+class MtlSenterBarcodeScanned extends MtlSenterCollectionEvent {
+  const MtlSenterBarcodeScanned(this.barcode);
+
+  final String barcode;
+}
+
+class MtlSenterDeleteSelected extends MtlSenterCollectionEvent {
+  const MtlSenterDeleteSelected();
+}
+
+class MtlSenterToggleSelection extends MtlSenterCollectionEvent {
+  const MtlSenterToggleSelection(this.id);
+
+  final String id;
+}
+
+class MtlSenterSelectionChanged extends MtlSenterCollectionEvent {
+  const MtlSenterSelectionChanged(this.ids);
+
+  final Set<String> ids;
+}
+
+class MtlSenterSubmitRequested extends MtlSenterCollectionEvent {
+  const MtlSenterSubmitRequested();
+}
+
+class MtlSenterResetStatus extends MtlSenterCollectionEvent {
+  const MtlSenterResetStatus();
+}
+
+class MtlSenterClearCurrentInput extends MtlSenterCollectionEvent {
+  const MtlSenterClearCurrentInput();
+}
+
+class MtlSenterFocusConsumed extends MtlSenterCollectionEvent {
+  const MtlSenterFocusConsumed();
+}

--- a/lib/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_state.dart
+++ b/lib/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_state.dart
@@ -1,0 +1,96 @@
+import 'package:equatable/equatable.dart';
+
+import '../../../../models/page_status.dart';
+import '../models/mtl_senter_models.dart';
+
+class MtlSenterCollectionState extends Equatable {
+  const MtlSenterCollectionState({
+    this.status = const CollectionStatus(CollectionStatusType.normal),
+    this.task,
+    this.operatorId,
+    this.currentLocation,
+    this.currentMaterial,
+    this.currentQuantity,
+    this.availableQty = 0,
+    this.minPackageQty,
+    this.defaultDeliveryQty,
+    this.stocks = const [],
+    this.selectedIds = const {},
+    this.collectedQtyMap = const {},
+    this.scanStep = MtlSenterScanStep.location,
+    this.focus = false,
+  });
+
+  final CollectionStatus status;
+  final MtlSenterTask? task;
+  final String? operatorId;
+  final String? currentLocation;
+  final MtlSenterMaterial? currentMaterial;
+  final double? currentQuantity;
+  final double availableQty;
+  final double? minPackageQty;
+  final double? defaultDeliveryQty;
+  final List<MtlSenterCollectItem> stocks;
+  final Set<String> selectedIds;
+  final Map<String, double> collectedQtyMap;
+  final MtlSenterScanStep scanStep;
+  final bool focus;
+
+  String get placeholder => scanStep.placeholder;
+
+  bool get canSubmit => stocks.isNotEmpty;
+
+  bool get hasSelection => selectedIds.isNotEmpty;
+
+  MtlSenterCollectionState copyWith({
+    CollectionStatus? status,
+    MtlSenterTask? task,
+    String? operatorId,
+    String? currentLocation,
+    MtlSenterMaterial? currentMaterial,
+    double? currentQuantity,
+    double? availableQty,
+    double? minPackageQty,
+    double? defaultDeliveryQty,
+    List<MtlSenterCollectItem>? stocks,
+    Set<String>? selectedIds,
+    Map<String, double>? collectedQtyMap,
+    MtlSenterScanStep? scanStep,
+    bool? focus,
+  }) {
+    return MtlSenterCollectionState(
+      status: status ?? this.status,
+      task: task ?? this.task,
+      operatorId: operatorId ?? this.operatorId,
+      currentLocation: currentLocation ?? this.currentLocation,
+      currentMaterial: currentMaterial ?? this.currentMaterial,
+      currentQuantity: currentQuantity ?? this.currentQuantity,
+      availableQty: availableQty ?? this.availableQty,
+      minPackageQty: minPackageQty ?? this.minPackageQty,
+      defaultDeliveryQty: defaultDeliveryQty ?? this.defaultDeliveryQty,
+      stocks: stocks ?? this.stocks,
+      selectedIds: selectedIds ?? this.selectedIds,
+      collectedQtyMap: collectedQtyMap ?? this.collectedQtyMap,
+      scanStep: scanStep ?? this.scanStep,
+      focus: focus ?? this.focus,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        task,
+        operatorId,
+        currentLocation,
+        currentMaterial,
+        currentQuantity,
+        availableQty,
+        minPackageQty,
+        defaultDeliveryQty,
+        stocks,
+        selectedIds,
+        collectedQtyMap,
+        scanStep,
+        focus,
+      ];
+}

--- a/lib/modules/mtl_senter/collection_task/models/mtl_senter_models.dart
+++ b/lib/modules/mtl_senter/collection_task/models/mtl_senter_models.dart
@@ -1,0 +1,185 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'mtl_senter_models.freezed.dart';
+part 'mtl_senter_models.g.dart';
+
+/// 扫码步骤
+enum MtlSenterScanStep {
+  /// 待扫描库位
+  location,
+
+  /// 待扫描物料二维码
+  material,
+
+  /// 待输入数量
+  quantity,
+
+  /// 初始/空闲状态
+  idle,
+}
+
+@freezed
+class MtlSenterTask with _$MtlSenterTask {
+  const factory MtlSenterTask({
+    /// 任务 ID
+    required String taskId,
+
+    /// 工单号
+    String? workOrderNo,
+
+    /// 产线/班组
+    String? productionLine,
+
+    /// 需求车间
+    String? workshop,
+
+    /// 计划数量
+    double? planQty,
+
+    /// 需求日期
+    DateTime? requiredDate,
+
+    /// 备注
+    String? remark,
+  }) = _MtlSenterTask;
+
+  factory MtlSenterTask.fromJson(Map<String, dynamic> json) =>
+      _$MtlSenterTaskFromJson(json);
+}
+
+@freezed
+class MtlSenterMaterial with _$MtlSenterMaterial {
+  const factory MtlSenterMaterial({
+    /// 物料编码
+    required String materialCode,
+
+    /// 物料名称
+    String? materialName,
+
+    /// 规格型号
+    String? specification,
+
+    /// 控制方式（批次/序列）
+    String? controlType,
+
+    /// 默认库房
+    String? storeRoomNo,
+
+    /// 默认库位
+    String? storeSiteNo,
+
+    /// 可用库存
+    double? availableQty,
+
+    /// 最小包装数
+    double? minPackageQty,
+
+    /// 默认配送量
+    double? defaultDeliveryQty,
+
+    /// 生产批次
+    String? batchNo,
+
+    /// 序列号
+    String? serialNo,
+  }) = _MtlSenterMaterial;
+
+  factory MtlSenterMaterial.fromJson(Map<String, dynamic> json) =>
+      _$MtlSenterMaterialFromJson(json);
+}
+
+@freezed
+class MtlSenterCollectItem with _$MtlSenterCollectItem {
+  const factory MtlSenterCollectItem({
+    /// 行内唯一标识
+    required String id,
+
+    /// 库位编码
+    required String storeSiteNo,
+
+    /// 库房编码
+    String? storeRoomNo,
+
+    /// 物料编码
+    required String materialCode,
+
+    /// 物料名称
+    String? materialName,
+
+    /// 批次号
+    String? batchNo,
+
+    /// 序列号
+    String? serialNo,
+
+    /// 生产日期
+    DateTime? productionDate,
+
+    /// 失效天数
+    int? validDays,
+
+    /// 采集数量
+    required double quantity,
+
+    /// 当前库位可用库存
+    double? availableQty,
+
+    /// 最小包装
+    double? minPackageQty,
+
+    /// 默认配送量
+    double? defaultDeliveryQty,
+  }) = _MtlSenterCollectItem;
+
+  factory MtlSenterCollectItem.fromJson(Map<String, dynamic> json) =>
+      _$MtlSenterCollectItemFromJson(json);
+}
+
+@freezed
+class MtlSenterSubmitRequest with _$MtlSenterSubmitRequest {
+  const factory MtlSenterSubmitRequest({
+    /// 采集提交列表
+    @Default(<MtlSenterCollectItem>[]) List<MtlSenterCollectItem> mtlSenderInfos,
+
+    /// 提交任务号
+    String? taskNo,
+
+    /// 操作人工号
+    String? operatorId,
+  }) = _MtlSenterSubmitRequest;
+
+  factory MtlSenterSubmitRequest.fromJson(Map<String, dynamic> json) =>
+      _$MtlSenterSubmitRequestFromJson(json);
+}
+
+@freezed
+class MtlSenterSubmitResponse with _$MtlSenterSubmitResponse {
+  const factory MtlSenterSubmitResponse({
+    /// 接口状态码
+    String? code,
+
+    /// 提示信息
+    String? message,
+
+    /// 是否成功
+    bool? success,
+  }) = _MtlSenterSubmitResponse;
+
+  factory MtlSenterSubmitResponse.fromJson(Map<String, dynamic> json) =>
+      _$MtlSenterSubmitResponseFromJson(json);
+}
+
+extension MtlSenterScanStepX on MtlSenterScanStep {
+  String get placeholder {
+    switch (this) {
+      case MtlSenterScanStep.location:
+        return '请扫描货架号';
+      case MtlSenterScanStep.material:
+        return '请扫描二维码';
+      case MtlSenterScanStep.quantity:
+        return '请输入数量';
+      case MtlSenterScanStep.idle:
+        return '请开始采集';
+    }
+  }
+}

--- a/lib/modules/mtl_senter/collection_task/models/mtl_senter_models.freezed.dart
+++ b/lib/modules/mtl_senter/collection_task/models/mtl_senter_models.freezed.dart
@@ -1,0 +1,1640 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'mtl_senter_models.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+MtlSenterTask _$MtlSenterTaskFromJson(Map<String, dynamic> json) {
+  return _MtlSenterTask.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MtlSenterTask {
+  /// 任务 ID
+  String get taskId => throw _privateConstructorUsedError;
+
+  /// 工单号
+  String? get workOrderNo => throw _privateConstructorUsedError;
+
+  /// 产线/班组
+  String? get productionLine => throw _privateConstructorUsedError;
+
+  /// 需求车间
+  String? get workshop => throw _privateConstructorUsedError;
+
+  /// 计划数量
+  double? get planQty => throw _privateConstructorUsedError;
+
+  /// 需求日期
+  DateTime? get requiredDate => throw _privateConstructorUsedError;
+
+  /// 备注
+  String? get remark => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MtlSenterTaskCopyWith<MtlSenterTask> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MtlSenterTaskCopyWith<$Res> {
+  factory $MtlSenterTaskCopyWith(
+          MtlSenterTask value, $Res Function(MtlSenterTask) then) =
+      _$MtlSenterTaskCopyWithImpl<$Res, MtlSenterTask>;
+  @useResult
+  $Res call(
+      {String taskId,
+      String? workOrderNo,
+      String? productionLine,
+      String? workshop,
+      double? planQty,
+      DateTime? requiredDate,
+      String? remark});
+}
+
+/// @nodoc
+class _$MtlSenterTaskCopyWithImpl<$Res, $Val extends MtlSenterTask>
+    implements $MtlSenterTaskCopyWith<$Res> {
+  _$MtlSenterTaskCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskId = null,
+    Object? workOrderNo = freezed,
+    Object? productionLine = freezed,
+    Object? workshop = freezed,
+    Object? planQty = freezed,
+    Object? requiredDate = freezed,
+    Object? remark = freezed,
+  }) {
+    return _then(_value.copyWith(
+      taskId: null == taskId
+          ? _value.taskId
+          : taskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      workOrderNo: freezed == workOrderNo
+          ? _value.workOrderNo
+          : workOrderNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      productionLine: freezed == productionLine
+          ? _value.productionLine
+          : productionLine // ignore: cast_nullable_to_non_nullable
+              as String?,
+      workshop: freezed == workshop
+          ? _value.workshop
+          : workshop // ignore: cast_nullable_to_non_nullable
+              as String?,
+      planQty: freezed == planQty
+          ? _value.planQty
+          : planQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      requiredDate: freezed == requiredDate
+          ? _value.requiredDate
+          : requiredDate // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      remark: freezed == remark
+          ? _value.remark
+          : remark // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MtlSenterTaskImplCopyWith<$Res>
+    implements $MtlSenterTaskCopyWith<$Res> {
+  factory _$$MtlSenterTaskImplCopyWith(
+          _$MtlSenterTaskImpl value, $Res Function(_$MtlSenterTaskImpl) then) =
+      __$$MtlSenterTaskImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String taskId,
+      String? workOrderNo,
+      String? productionLine,
+      String? workshop,
+      double? planQty,
+      DateTime? requiredDate,
+      String? remark});
+}
+
+/// @nodoc
+class __$$MtlSenterTaskImplCopyWithImpl<$Res>
+    extends _$MtlSenterTaskCopyWithImpl<$Res, _$MtlSenterTaskImpl>
+    implements _$$MtlSenterTaskImplCopyWith<$Res> {
+  __$$MtlSenterTaskImplCopyWithImpl(
+      _$MtlSenterTaskImpl _value, $Res Function(_$MtlSenterTaskImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? taskId = null,
+    Object? workOrderNo = freezed,
+    Object? productionLine = freezed,
+    Object? workshop = freezed,
+    Object? planQty = freezed,
+    Object? requiredDate = freezed,
+    Object? remark = freezed,
+  }) {
+    return _then(_$MtlSenterTaskImpl(
+      taskId: null == taskId
+          ? _value.taskId
+          : taskId // ignore: cast_nullable_to_non_nullable
+              as String,
+      workOrderNo: freezed == workOrderNo
+          ? _value.workOrderNo
+          : workOrderNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      productionLine: freezed == productionLine
+          ? _value.productionLine
+          : productionLine // ignore: cast_nullable_to_non_nullable
+              as String?,
+      workshop: freezed == workshop
+          ? _value.workshop
+          : workshop // ignore: cast_nullable_to_non_nullable
+              as String?,
+      planQty: freezed == planQty
+          ? _value.planQty
+          : planQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      requiredDate: freezed == requiredDate
+          ? _value.requiredDate
+          : requiredDate // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      remark: freezed == remark
+          ? _value.remark
+          : remark // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MtlSenterTaskImpl implements _MtlSenterTask {
+  const _$MtlSenterTaskImpl(
+      {required this.taskId,
+      this.workOrderNo,
+      this.productionLine,
+      this.workshop,
+      this.planQty,
+      this.requiredDate,
+      this.remark});
+
+  factory _$MtlSenterTaskImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MtlSenterTaskImplFromJson(json);
+
+  /// 任务 ID
+  @override
+  final String taskId;
+
+  /// 工单号
+  @override
+  final String? workOrderNo;
+
+  /// 产线/班组
+  @override
+  final String? productionLine;
+
+  /// 需求车间
+  @override
+  final String? workshop;
+
+  /// 计划数量
+  @override
+  final double? planQty;
+
+  /// 需求日期
+  @override
+  final DateTime? requiredDate;
+
+  /// 备注
+  @override
+  final String? remark;
+
+  @override
+  String toString() {
+    return 'MtlSenterTask(taskId: $taskId, workOrderNo: $workOrderNo, productionLine: $productionLine, workshop: $workshop, planQty: $planQty, requiredDate: $requiredDate, remark: $remark)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MtlSenterTaskImpl &&
+            (identical(other.taskId, taskId) || other.taskId == taskId) &&
+            (identical(other.workOrderNo, workOrderNo) ||
+                other.workOrderNo == workOrderNo) &&
+            (identical(other.productionLine, productionLine) ||
+                other.productionLine == productionLine) &&
+            (identical(other.workshop, workshop) ||
+                other.workshop == workshop) &&
+            (identical(other.planQty, planQty) || other.planQty == planQty) &&
+            (identical(other.requiredDate, requiredDate) ||
+                other.requiredDate == requiredDate) &&
+            (identical(other.remark, remark) || other.remark == remark));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, taskId, workOrderNo,
+      productionLine, workshop, planQty, requiredDate, remark);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MtlSenterTaskImplCopyWith<_$MtlSenterTaskImpl> get copyWith =>
+      __$$MtlSenterTaskImplCopyWithImpl<_$MtlSenterTaskImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MtlSenterTaskImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MtlSenterTask implements MtlSenterTask {
+  const factory _MtlSenterTask(
+      {required final String taskId,
+      final String? workOrderNo,
+      final String? productionLine,
+      final String? workshop,
+      final double? planQty,
+      final DateTime? requiredDate,
+      final String? remark}) = _$MtlSenterTaskImpl;
+
+  factory _MtlSenterTask.fromJson(Map<String, dynamic> json) =
+      _$MtlSenterTaskImpl.fromJson;
+
+  @override
+
+  /// 任务 ID
+  String get taskId;
+  @override
+
+  /// 工单号
+  String? get workOrderNo;
+  @override
+
+  /// 产线/班组
+  String? get productionLine;
+  @override
+
+  /// 需求车间
+  String? get workshop;
+  @override
+
+  /// 计划数量
+  double? get planQty;
+  @override
+
+  /// 需求日期
+  DateTime? get requiredDate;
+  @override
+
+  /// 备注
+  String? get remark;
+  @override
+  @JsonKey(ignore: true)
+  _$$MtlSenterTaskImplCopyWith<_$MtlSenterTaskImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+MtlSenterMaterial _$MtlSenterMaterialFromJson(Map<String, dynamic> json) {
+  return _MtlSenterMaterial.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MtlSenterMaterial {
+  /// 物料编码
+  String get materialCode => throw _privateConstructorUsedError;
+
+  /// 物料名称
+  String? get materialName => throw _privateConstructorUsedError;
+
+  /// 规格型号
+  String? get specification => throw _privateConstructorUsedError;
+
+  /// 控制方式（批次/序列）
+  String? get controlType => throw _privateConstructorUsedError;
+
+  /// 默认库房
+  String? get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 默认库位
+  String? get storeSiteNo => throw _privateConstructorUsedError;
+
+  /// 可用库存
+  double? get availableQty => throw _privateConstructorUsedError;
+
+  /// 最小包装数
+  double? get minPackageQty => throw _privateConstructorUsedError;
+
+  /// 默认配送量
+  double? get defaultDeliveryQty => throw _privateConstructorUsedError;
+
+  /// 生产批次
+  String? get batchNo => throw _privateConstructorUsedError;
+
+  /// 序列号
+  String? get serialNo => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MtlSenterMaterialCopyWith<MtlSenterMaterial> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MtlSenterMaterialCopyWith<$Res> {
+  factory $MtlSenterMaterialCopyWith(
+          MtlSenterMaterial value, $Res Function(MtlSenterMaterial) then) =
+      _$MtlSenterMaterialCopyWithImpl<$Res, MtlSenterMaterial>;
+  @useResult
+  $Res call(
+      {String materialCode,
+      String? materialName,
+      String? specification,
+      String? controlType,
+      String? storeRoomNo,
+      String? storeSiteNo,
+      double? availableQty,
+      double? minPackageQty,
+      double? defaultDeliveryQty,
+      String? batchNo,
+      String? serialNo});
+}
+
+/// @nodoc
+class _$MtlSenterMaterialCopyWithImpl<$Res, $Val extends MtlSenterMaterial>
+    implements $MtlSenterMaterialCopyWith<$Res> {
+  _$MtlSenterMaterialCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? specification = freezed,
+    Object? controlType = freezed,
+    Object? storeRoomNo = freezed,
+    Object? storeSiteNo = freezed,
+    Object? availableQty = freezed,
+    Object? minPackageQty = freezed,
+    Object? defaultDeliveryQty = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+  }) {
+    return _then(_value.copyWith(
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      specification: freezed == specification
+          ? _value.specification
+          : specification // ignore: cast_nullable_to_non_nullable
+              as String?,
+      controlType: freezed == controlType
+          ? _value.controlType
+          : controlType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: freezed == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      availableQty: freezed == availableQty
+          ? _value.availableQty
+          : availableQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      minPackageQty: freezed == minPackageQty
+          ? _value.minPackageQty
+          : minPackageQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      defaultDeliveryQty: freezed == defaultDeliveryQty
+          ? _value.defaultDeliveryQty
+          : defaultDeliveryQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MtlSenterMaterialImplCopyWith<$Res>
+    implements $MtlSenterMaterialCopyWith<$Res> {
+  factory _$$MtlSenterMaterialImplCopyWith(_$MtlSenterMaterialImpl value,
+          $Res Function(_$MtlSenterMaterialImpl) then) =
+      __$$MtlSenterMaterialImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String materialCode,
+      String? materialName,
+      String? specification,
+      String? controlType,
+      String? storeRoomNo,
+      String? storeSiteNo,
+      double? availableQty,
+      double? minPackageQty,
+      double? defaultDeliveryQty,
+      String? batchNo,
+      String? serialNo});
+}
+
+/// @nodoc
+class __$$MtlSenterMaterialImplCopyWithImpl<$Res>
+    extends _$MtlSenterMaterialCopyWithImpl<$Res, _$MtlSenterMaterialImpl>
+    implements _$$MtlSenterMaterialImplCopyWith<$Res> {
+  __$$MtlSenterMaterialImplCopyWithImpl(_$MtlSenterMaterialImpl _value,
+      $Res Function(_$MtlSenterMaterialImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? specification = freezed,
+    Object? controlType = freezed,
+    Object? storeRoomNo = freezed,
+    Object? storeSiteNo = freezed,
+    Object? availableQty = freezed,
+    Object? minPackageQty = freezed,
+    Object? defaultDeliveryQty = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+  }) {
+    return _then(_$MtlSenterMaterialImpl(
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      specification: freezed == specification
+          ? _value.specification
+          : specification // ignore: cast_nullable_to_non_nullable
+              as String?,
+      controlType: freezed == controlType
+          ? _value.controlType
+          : controlType // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      storeSiteNo: freezed == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      availableQty: freezed == availableQty
+          ? _value.availableQty
+          : availableQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      minPackageQty: freezed == minPackageQty
+          ? _value.minPackageQty
+          : minPackageQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      defaultDeliveryQty: freezed == defaultDeliveryQty
+          ? _value.defaultDeliveryQty
+          : defaultDeliveryQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MtlSenterMaterialImpl implements _MtlSenterMaterial {
+  const _$MtlSenterMaterialImpl(
+      {required this.materialCode,
+      this.materialName,
+      this.specification,
+      this.controlType,
+      this.storeRoomNo,
+      this.storeSiteNo,
+      this.availableQty,
+      this.minPackageQty,
+      this.defaultDeliveryQty,
+      this.batchNo,
+      this.serialNo});
+
+  factory _$MtlSenterMaterialImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MtlSenterMaterialImplFromJson(json);
+
+  /// 物料编码
+  @override
+  final String materialCode;
+
+  /// 物料名称
+  @override
+  final String? materialName;
+
+  /// 规格型号
+  @override
+  final String? specification;
+
+  /// 控制方式（批次/序列）
+  @override
+  final String? controlType;
+
+  /// 默认库房
+  @override
+  final String? storeRoomNo;
+
+  /// 默认库位
+  @override
+  final String? storeSiteNo;
+
+  /// 可用库存
+  @override
+  final double? availableQty;
+
+  /// 最小包装数
+  @override
+  final double? minPackageQty;
+
+  /// 默认配送量
+  @override
+  final double? defaultDeliveryQty;
+
+  /// 生产批次
+  @override
+  final String? batchNo;
+
+  /// 序列号
+  @override
+  final String? serialNo;
+
+  @override
+  String toString() {
+    return 'MtlSenterMaterial(materialCode: $materialCode, materialName: $materialName, specification: $specification, controlType: $controlType, storeRoomNo: $storeRoomNo, storeSiteNo: $storeSiteNo, availableQty: $availableQty, minPackageQty: $minPackageQty, defaultDeliveryQty: $defaultDeliveryQty, batchNo: $batchNo, serialNo: $serialNo)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MtlSenterMaterialImpl &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.specification, specification) ||
+                other.specification == specification) &&
+            (identical(other.controlType, controlType) ||
+                other.controlType == controlType) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.availableQty, availableQty) ||
+                other.availableQty == availableQty) &&
+            (identical(other.minPackageQty, minPackageQty) ||
+                other.minPackageQty == minPackageQty) &&
+            (identical(other.defaultDeliveryQty, defaultDeliveryQty) ||
+                other.defaultDeliveryQty == defaultDeliveryQty) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      materialCode,
+      materialName,
+      specification,
+      controlType,
+      storeRoomNo,
+      storeSiteNo,
+      availableQty,
+      minPackageQty,
+      defaultDeliveryQty,
+      batchNo,
+      serialNo);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MtlSenterMaterialImplCopyWith<_$MtlSenterMaterialImpl> get copyWith =>
+      __$$MtlSenterMaterialImplCopyWithImpl<_$MtlSenterMaterialImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MtlSenterMaterialImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MtlSenterMaterial implements MtlSenterMaterial {
+  const factory _MtlSenterMaterial(
+      {required final String materialCode,
+      final String? materialName,
+      final String? specification,
+      final String? controlType,
+      final String? storeRoomNo,
+      final String? storeSiteNo,
+      final double? availableQty,
+      final double? minPackageQty,
+      final double? defaultDeliveryQty,
+      final String? batchNo,
+      final String? serialNo}) = _$MtlSenterMaterialImpl;
+
+  factory _MtlSenterMaterial.fromJson(Map<String, dynamic> json) =
+      _$MtlSenterMaterialImpl.fromJson;
+
+  @override
+
+  /// 物料编码
+  String get materialCode;
+  @override
+
+  /// 物料名称
+  String? get materialName;
+  @override
+
+  /// 规格型号
+  String? get specification;
+  @override
+
+  /// 控制方式（批次/序列）
+  String? get controlType;
+  @override
+
+  /// 默认库房
+  String? get storeRoomNo;
+  @override
+
+  /// 默认库位
+  String? get storeSiteNo;
+  @override
+
+  /// 可用库存
+  double? get availableQty;
+  @override
+
+  /// 最小包装数
+  double? get minPackageQty;
+  @override
+
+  /// 默认配送量
+  double? get defaultDeliveryQty;
+  @override
+
+  /// 生产批次
+  String? get batchNo;
+  @override
+
+  /// 序列号
+  String? get serialNo;
+  @override
+  @JsonKey(ignore: true)
+  _$$MtlSenterMaterialImplCopyWith<_$MtlSenterMaterialImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+MtlSenterCollectItem _$MtlSenterCollectItemFromJson(Map<String, dynamic> json) {
+  return _MtlSenterCollectItem.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MtlSenterCollectItem {
+  /// 行内唯一标识
+  String get id => throw _privateConstructorUsedError;
+
+  /// 库位编码
+  String get storeSiteNo => throw _privateConstructorUsedError;
+
+  /// 库房编码
+  String? get storeRoomNo => throw _privateConstructorUsedError;
+
+  /// 物料编码
+  String get materialCode => throw _privateConstructorUsedError;
+
+  /// 物料名称
+  String? get materialName => throw _privateConstructorUsedError;
+
+  /// 批次号
+  String? get batchNo => throw _privateConstructorUsedError;
+
+  /// 序列号
+  String? get serialNo => throw _privateConstructorUsedError;
+
+  /// 生产日期
+  DateTime? get productionDate => throw _privateConstructorUsedError;
+
+  /// 失效天数
+  int? get validDays => throw _privateConstructorUsedError;
+
+  /// 采集数量
+  double get quantity => throw _privateConstructorUsedError;
+
+  /// 当前库位可用库存
+  double? get availableQty => throw _privateConstructorUsedError;
+
+  /// 最小包装
+  double? get minPackageQty => throw _privateConstructorUsedError;
+
+  /// 默认配送量
+  double? get defaultDeliveryQty => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MtlSenterCollectItemCopyWith<MtlSenterCollectItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MtlSenterCollectItemCopyWith<$Res> {
+  factory $MtlSenterCollectItemCopyWith(MtlSenterCollectItem value,
+          $Res Function(MtlSenterCollectItem) then) =
+      _$MtlSenterCollectItemCopyWithImpl<$Res, MtlSenterCollectItem>;
+  @useResult
+  $Res call(
+      {String id,
+      String storeSiteNo,
+      String? storeRoomNo,
+      String materialCode,
+      String? materialName,
+      String? batchNo,
+      String? serialNo,
+      DateTime? productionDate,
+      int? validDays,
+      double quantity,
+      double? availableQty,
+      double? minPackageQty,
+      double? defaultDeliveryQty});
+}
+
+/// @nodoc
+class _$MtlSenterCollectItemCopyWithImpl<$Res,
+        $Val extends MtlSenterCollectItem>
+    implements $MtlSenterCollectItemCopyWith<$Res> {
+  _$MtlSenterCollectItemCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? storeSiteNo = null,
+    Object? storeRoomNo = freezed,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? quantity = null,
+    Object? availableQty = freezed,
+    Object? minPackageQty = freezed,
+    Object? defaultDeliveryQty = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as int?,
+      quantity: null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      availableQty: freezed == availableQty
+          ? _value.availableQty
+          : availableQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      minPackageQty: freezed == minPackageQty
+          ? _value.minPackageQty
+          : minPackageQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      defaultDeliveryQty: freezed == defaultDeliveryQty
+          ? _value.defaultDeliveryQty
+          : defaultDeliveryQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MtlSenterCollectItemImplCopyWith<$Res>
+    implements $MtlSenterCollectItemCopyWith<$Res> {
+  factory _$$MtlSenterCollectItemImplCopyWith(_$MtlSenterCollectItemImpl value,
+          $Res Function(_$MtlSenterCollectItemImpl) then) =
+      __$$MtlSenterCollectItemImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String storeSiteNo,
+      String? storeRoomNo,
+      String materialCode,
+      String? materialName,
+      String? batchNo,
+      String? serialNo,
+      DateTime? productionDate,
+      int? validDays,
+      double quantity,
+      double? availableQty,
+      double? minPackageQty,
+      double? defaultDeliveryQty});
+}
+
+/// @nodoc
+class __$$MtlSenterCollectItemImplCopyWithImpl<$Res>
+    extends _$MtlSenterCollectItemCopyWithImpl<$Res, _$MtlSenterCollectItemImpl>
+    implements _$$MtlSenterCollectItemImplCopyWith<$Res> {
+  __$$MtlSenterCollectItemImplCopyWithImpl(_$MtlSenterCollectItemImpl _value,
+      $Res Function(_$MtlSenterCollectItemImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? storeSiteNo = null,
+    Object? storeRoomNo = freezed,
+    Object? materialCode = null,
+    Object? materialName = freezed,
+    Object? batchNo = freezed,
+    Object? serialNo = freezed,
+    Object? productionDate = freezed,
+    Object? validDays = freezed,
+    Object? quantity = null,
+    Object? availableQty = freezed,
+    Object? minPackageQty = freezed,
+    Object? defaultDeliveryQty = freezed,
+  }) {
+    return _then(_$MtlSenterCollectItemImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeSiteNo: null == storeSiteNo
+          ? _value.storeSiteNo
+          : storeSiteNo // ignore: cast_nullable_to_non_nullable
+              as String,
+      storeRoomNo: freezed == storeRoomNo
+          ? _value.storeRoomNo
+          : storeRoomNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      materialCode: null == materialCode
+          ? _value.materialCode
+          : materialCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      materialName: freezed == materialName
+          ? _value.materialName
+          : materialName // ignore: cast_nullable_to_non_nullable
+              as String?,
+      batchNo: freezed == batchNo
+          ? _value.batchNo
+          : batchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      serialNo: freezed == serialNo
+          ? _value.serialNo
+          : serialNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      productionDate: freezed == productionDate
+          ? _value.productionDate
+          : productionDate // ignore: cast_nullable_to_non_nullable
+              as DateTime?,
+      validDays: freezed == validDays
+          ? _value.validDays
+          : validDays // ignore: cast_nullable_to_non_nullable
+              as int?,
+      quantity: null == quantity
+          ? _value.quantity
+          : quantity // ignore: cast_nullable_to_non_nullable
+              as double,
+      availableQty: freezed == availableQty
+          ? _value.availableQty
+          : availableQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      minPackageQty: freezed == minPackageQty
+          ? _value.minPackageQty
+          : minPackageQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+      defaultDeliveryQty: freezed == defaultDeliveryQty
+          ? _value.defaultDeliveryQty
+          : defaultDeliveryQty // ignore: cast_nullable_to_non_nullable
+              as double?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MtlSenterCollectItemImpl implements _MtlSenterCollectItem {
+  const _$MtlSenterCollectItemImpl(
+      {required this.id,
+      required this.storeSiteNo,
+      this.storeRoomNo,
+      required this.materialCode,
+      this.materialName,
+      this.batchNo,
+      this.serialNo,
+      this.productionDate,
+      this.validDays,
+      required this.quantity,
+      this.availableQty,
+      this.minPackageQty,
+      this.defaultDeliveryQty});
+
+  factory _$MtlSenterCollectItemImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MtlSenterCollectItemImplFromJson(json);
+
+  /// 行内唯一标识
+  @override
+  final String id;
+
+  /// 库位编码
+  @override
+  final String storeSiteNo;
+
+  /// 库房编码
+  @override
+  final String? storeRoomNo;
+
+  /// 物料编码
+  @override
+  final String materialCode;
+
+  /// 物料名称
+  @override
+  final String? materialName;
+
+  /// 批次号
+  @override
+  final String? batchNo;
+
+  /// 序列号
+  @override
+  final String? serialNo;
+
+  /// 生产日期
+  @override
+  final DateTime? productionDate;
+
+  /// 失效天数
+  @override
+  final int? validDays;
+
+  /// 采集数量
+  @override
+  final double quantity;
+
+  /// 当前库位可用库存
+  @override
+  final double? availableQty;
+
+  /// 最小包装
+  @override
+  final double? minPackageQty;
+
+  /// 默认配送量
+  @override
+  final double? defaultDeliveryQty;
+
+  @override
+  String toString() {
+    return 'MtlSenterCollectItem(id: $id, storeSiteNo: $storeSiteNo, storeRoomNo: $storeRoomNo, materialCode: $materialCode, materialName: $materialName, batchNo: $batchNo, serialNo: $serialNo, productionDate: $productionDate, validDays: $validDays, quantity: $quantity, availableQty: $availableQty, minPackageQty: $minPackageQty, defaultDeliveryQty: $defaultDeliveryQty)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MtlSenterCollectItemImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.storeSiteNo, storeSiteNo) ||
+                other.storeSiteNo == storeSiteNo) &&
+            (identical(other.storeRoomNo, storeRoomNo) ||
+                other.storeRoomNo == storeRoomNo) &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.batchNo, batchNo) || other.batchNo == batchNo) &&
+            (identical(other.serialNo, serialNo) ||
+                other.serialNo == serialNo) &&
+            (identical(other.productionDate, productionDate) ||
+                other.productionDate == productionDate) &&
+            (identical(other.validDays, validDays) ||
+                other.validDays == validDays) &&
+            (identical(other.quantity, quantity) ||
+                other.quantity == quantity) &&
+            (identical(other.availableQty, availableQty) ||
+                other.availableQty == availableQty) &&
+            (identical(other.minPackageQty, minPackageQty) ||
+                other.minPackageQty == minPackageQty) &&
+            (identical(other.defaultDeliveryQty, defaultDeliveryQty) ||
+                other.defaultDeliveryQty == defaultDeliveryQty));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      storeSiteNo,
+      storeRoomNo,
+      materialCode,
+      materialName,
+      batchNo,
+      serialNo,
+      productionDate,
+      validDays,
+      quantity,
+      availableQty,
+      minPackageQty,
+      defaultDeliveryQty);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MtlSenterCollectItemImplCopyWith<_$MtlSenterCollectItemImpl>
+      get copyWith =>
+          __$$MtlSenterCollectItemImplCopyWithImpl<_$MtlSenterCollectItemImpl>(
+              this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MtlSenterCollectItemImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MtlSenterCollectItem implements MtlSenterCollectItem {
+  const factory _MtlSenterCollectItem(
+      {required final String id,
+      required final String storeSiteNo,
+      final String? storeRoomNo,
+      required final String materialCode,
+      final String? materialName,
+      final String? batchNo,
+      final String? serialNo,
+      final DateTime? productionDate,
+      final int? validDays,
+      required final double quantity,
+      final double? availableQty,
+      final double? minPackageQty,
+      final double? defaultDeliveryQty}) = _$MtlSenterCollectItemImpl;
+
+  factory _MtlSenterCollectItem.fromJson(Map<String, dynamic> json) =
+      _$MtlSenterCollectItemImpl.fromJson;
+
+  @override
+
+  /// 行内唯一标识
+  String get id;
+  @override
+
+  /// 库位编码
+  String get storeSiteNo;
+  @override
+
+  /// 库房编码
+  String? get storeRoomNo;
+  @override
+
+  /// 物料编码
+  String get materialCode;
+  @override
+
+  /// 物料名称
+  String? get materialName;
+  @override
+
+  /// 批次号
+  String? get batchNo;
+  @override
+
+  /// 序列号
+  String? get serialNo;
+  @override
+
+  /// 生产日期
+  DateTime? get productionDate;
+  @override
+
+  /// 失效天数
+  int? get validDays;
+  @override
+
+  /// 采集数量
+  double get quantity;
+  @override
+
+  /// 当前库位可用库存
+  double? get availableQty;
+  @override
+
+  /// 最小包装
+  double? get minPackageQty;
+  @override
+
+  /// 默认配送量
+  double? get defaultDeliveryQty;
+  @override
+  @JsonKey(ignore: true)
+  _$$MtlSenterCollectItemImplCopyWith<_$MtlSenterCollectItemImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+MtlSenterSubmitRequest _$MtlSenterSubmitRequestFromJson(
+    Map<String, dynamic> json) {
+  return _MtlSenterSubmitRequest.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MtlSenterSubmitRequest {
+  /// 采集提交列表
+  List<MtlSenterCollectItem> get mtlSenderInfos =>
+      throw _privateConstructorUsedError;
+
+  /// 提交任务号
+  String? get taskNo => throw _privateConstructorUsedError;
+
+  /// 操作人工号
+  String? get operatorId => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MtlSenterSubmitRequestCopyWith<MtlSenterSubmitRequest> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MtlSenterSubmitRequestCopyWith<$Res> {
+  factory $MtlSenterSubmitRequestCopyWith(MtlSenterSubmitRequest value,
+          $Res Function(MtlSenterSubmitRequest) then) =
+      _$MtlSenterSubmitRequestCopyWithImpl<$Res, MtlSenterSubmitRequest>;
+  @useResult
+  $Res call(
+      {List<MtlSenterCollectItem> mtlSenderInfos,
+      String? taskNo,
+      String? operatorId});
+}
+
+/// @nodoc
+class _$MtlSenterSubmitRequestCopyWithImpl<$Res,
+        $Val extends MtlSenterSubmitRequest>
+    implements $MtlSenterSubmitRequestCopyWith<$Res> {
+  _$MtlSenterSubmitRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? mtlSenderInfos = null,
+    Object? taskNo = freezed,
+    Object? operatorId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      mtlSenderInfos: null == mtlSenderInfos
+          ? _value.mtlSenderInfos
+          : mtlSenderInfos // ignore: cast_nullable_to_non_nullable
+              as List<MtlSenterCollectItem>,
+      taskNo: freezed == taskNo
+          ? _value.taskNo
+          : taskNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      operatorId: freezed == operatorId
+          ? _value.operatorId
+          : operatorId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MtlSenterSubmitRequestImplCopyWith<$Res>
+    implements $MtlSenterSubmitRequestCopyWith<$Res> {
+  factory _$$MtlSenterSubmitRequestImplCopyWith(
+          _$MtlSenterSubmitRequestImpl value,
+          $Res Function(_$MtlSenterSubmitRequestImpl) then) =
+      __$$MtlSenterSubmitRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {List<MtlSenterCollectItem> mtlSenderInfos,
+      String? taskNo,
+      String? operatorId});
+}
+
+/// @nodoc
+class __$$MtlSenterSubmitRequestImplCopyWithImpl<$Res>
+    extends _$MtlSenterSubmitRequestCopyWithImpl<$Res,
+        _$MtlSenterSubmitRequestImpl>
+    implements _$$MtlSenterSubmitRequestImplCopyWith<$Res> {
+  __$$MtlSenterSubmitRequestImplCopyWithImpl(
+      _$MtlSenterSubmitRequestImpl _value,
+      $Res Function(_$MtlSenterSubmitRequestImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? mtlSenderInfos = null,
+    Object? taskNo = freezed,
+    Object? operatorId = freezed,
+  }) {
+    return _then(_$MtlSenterSubmitRequestImpl(
+      mtlSenderInfos: null == mtlSenderInfos
+          ? _value._mtlSenderInfos
+          : mtlSenderInfos // ignore: cast_nullable_to_non_nullable
+              as List<MtlSenterCollectItem>,
+      taskNo: freezed == taskNo
+          ? _value.taskNo
+          : taskNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      operatorId: freezed == operatorId
+          ? _value.operatorId
+          : operatorId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MtlSenterSubmitRequestImpl implements _MtlSenterSubmitRequest {
+  const _$MtlSenterSubmitRequestImpl(
+      {final List<MtlSenterCollectItem> mtlSenderInfos =
+          const <MtlSenterCollectItem>[],
+      this.taskNo,
+      this.operatorId})
+      : _mtlSenderInfos = mtlSenderInfos;
+
+  factory _$MtlSenterSubmitRequestImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MtlSenterSubmitRequestImplFromJson(json);
+
+  /// 采集提交列表
+  final List<MtlSenterCollectItem> _mtlSenderInfos;
+
+  /// 采集提交列表
+  @override
+  @JsonKey()
+  List<MtlSenterCollectItem> get mtlSenderInfos {
+    if (_mtlSenderInfos is EqualUnmodifiableListView) return _mtlSenderInfos;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_mtlSenderInfos);
+  }
+
+  /// 提交任务号
+  @override
+  final String? taskNo;
+
+  /// 操作人工号
+  @override
+  final String? operatorId;
+
+  @override
+  String toString() {
+    return 'MtlSenterSubmitRequest(mtlSenderInfos: $mtlSenderInfos, taskNo: $taskNo, operatorId: $operatorId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MtlSenterSubmitRequestImpl &&
+            const DeepCollectionEquality()
+                .equals(other._mtlSenderInfos, _mtlSenderInfos) &&
+            (identical(other.taskNo, taskNo) || other.taskNo == taskNo) &&
+            (identical(other.operatorId, operatorId) ||
+                other.operatorId == operatorId));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(_mtlSenderInfos), taskNo, operatorId);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MtlSenterSubmitRequestImplCopyWith<_$MtlSenterSubmitRequestImpl>
+      get copyWith => __$$MtlSenterSubmitRequestImplCopyWithImpl<
+          _$MtlSenterSubmitRequestImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MtlSenterSubmitRequestImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MtlSenterSubmitRequest implements MtlSenterSubmitRequest {
+  const factory _MtlSenterSubmitRequest(
+      {final List<MtlSenterCollectItem> mtlSenderInfos,
+      final String? taskNo,
+      final String? operatorId}) = _$MtlSenterSubmitRequestImpl;
+
+  factory _MtlSenterSubmitRequest.fromJson(Map<String, dynamic> json) =
+      _$MtlSenterSubmitRequestImpl.fromJson;
+
+  @override
+
+  /// 采集提交列表
+  List<MtlSenterCollectItem> get mtlSenderInfos;
+  @override
+
+  /// 提交任务号
+  String? get taskNo;
+  @override
+
+  /// 操作人工号
+  String? get operatorId;
+  @override
+  @JsonKey(ignore: true)
+  _$$MtlSenterSubmitRequestImplCopyWith<_$MtlSenterSubmitRequestImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+MtlSenterSubmitResponse _$MtlSenterSubmitResponseFromJson(
+    Map<String, dynamic> json) {
+  return _MtlSenterSubmitResponse.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MtlSenterSubmitResponse {
+  /// 接口状态码
+  String? get code => throw _privateConstructorUsedError;
+
+  /// 提示信息
+  String? get message => throw _privateConstructorUsedError;
+
+  /// 是否成功
+  bool? get success => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MtlSenterSubmitResponseCopyWith<MtlSenterSubmitResponse> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MtlSenterSubmitResponseCopyWith<$Res> {
+  factory $MtlSenterSubmitResponseCopyWith(MtlSenterSubmitResponse value,
+          $Res Function(MtlSenterSubmitResponse) then) =
+      _$MtlSenterSubmitResponseCopyWithImpl<$Res, MtlSenterSubmitResponse>;
+  @useResult
+  $Res call({String? code, String? message, bool? success});
+}
+
+/// @nodoc
+class _$MtlSenterSubmitResponseCopyWithImpl<$Res,
+        $Val extends MtlSenterSubmitResponse>
+    implements $MtlSenterSubmitResponseCopyWith<$Res> {
+  _$MtlSenterSubmitResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = freezed,
+    Object? message = freezed,
+    Object? success = freezed,
+  }) {
+    return _then(_value.copyWith(
+      code: freezed == code
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String?,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+      success: freezed == success
+          ? _value.success
+          : success // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MtlSenterSubmitResponseImplCopyWith<$Res>
+    implements $MtlSenterSubmitResponseCopyWith<$Res> {
+  factory _$$MtlSenterSubmitResponseImplCopyWith(
+          _$MtlSenterSubmitResponseImpl value,
+          $Res Function(_$MtlSenterSubmitResponseImpl) then) =
+      __$$MtlSenterSubmitResponseImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? code, String? message, bool? success});
+}
+
+/// @nodoc
+class __$$MtlSenterSubmitResponseImplCopyWithImpl<$Res>
+    extends _$MtlSenterSubmitResponseCopyWithImpl<$Res,
+        _$MtlSenterSubmitResponseImpl>
+    implements _$$MtlSenterSubmitResponseImplCopyWith<$Res> {
+  __$$MtlSenterSubmitResponseImplCopyWithImpl(
+      _$MtlSenterSubmitResponseImpl _value,
+      $Res Function(_$MtlSenterSubmitResponseImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = freezed,
+    Object? message = freezed,
+    Object? success = freezed,
+  }) {
+    return _then(_$MtlSenterSubmitResponseImpl(
+      code: freezed == code
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as String?,
+      message: freezed == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+      success: freezed == success
+          ? _value.success
+          : success // ignore: cast_nullable_to_non_nullable
+              as bool?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MtlSenterSubmitResponseImpl implements _MtlSenterSubmitResponse {
+  const _$MtlSenterSubmitResponseImpl({this.code, this.message, this.success});
+
+  factory _$MtlSenterSubmitResponseImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MtlSenterSubmitResponseImplFromJson(json);
+
+  /// 接口状态码
+  @override
+  final String? code;
+
+  /// 提示信息
+  @override
+  final String? message;
+
+  /// 是否成功
+  @override
+  final bool? success;
+
+  @override
+  String toString() {
+    return 'MtlSenterSubmitResponse(code: $code, message: $message, success: $success)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MtlSenterSubmitResponseImpl &&
+            (identical(other.code, code) || other.code == code) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.success, success) || other.success == success));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, code, message, success);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MtlSenterSubmitResponseImplCopyWith<_$MtlSenterSubmitResponseImpl>
+      get copyWith => __$$MtlSenterSubmitResponseImplCopyWithImpl<
+          _$MtlSenterSubmitResponseImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MtlSenterSubmitResponseImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MtlSenterSubmitResponse implements MtlSenterSubmitResponse {
+  const factory _MtlSenterSubmitResponse(
+      {final String? code,
+      final String? message,
+      final bool? success}) = _$MtlSenterSubmitResponseImpl;
+
+  factory _MtlSenterSubmitResponse.fromJson(Map<String, dynamic> json) =
+      _$MtlSenterSubmitResponseImpl.fromJson;
+
+  @override
+
+  /// 接口状态码
+  String? get code;
+  @override
+
+  /// 提示信息
+  String? get message;
+  @override
+
+  /// 是否成功
+  bool? get success;
+  @override
+  @JsonKey(ignore: true)
+  _$$MtlSenterSubmitResponseImplCopyWith<_$MtlSenterSubmitResponseImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/mtl_senter/collection_task/models/mtl_senter_models.g.dart
+++ b/lib/modules/mtl_senter/collection_task/models/mtl_senter_models.g.dart
@@ -1,0 +1,137 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mtl_senter_models.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$MtlSenterTaskImpl _$$MtlSenterTaskImplFromJson(Map<String, dynamic> json) =>
+    _$MtlSenterTaskImpl(
+      taskId: json['taskId'] as String,
+      workOrderNo: json['workOrderNo'] as String?,
+      productionLine: json['productionLine'] as String?,
+      workshop: json['workshop'] as String?,
+      planQty: (json['planQty'] as num?)?.toDouble(),
+      requiredDate: json['requiredDate'] == null
+          ? null
+          : DateTime.parse(json['requiredDate'] as String),
+      remark: json['remark'] as String?,
+    );
+
+Map<String, dynamic> _$$MtlSenterTaskImplToJson(_$MtlSenterTaskImpl instance) =>
+    <String, dynamic>{
+      'taskId': instance.taskId,
+      'workOrderNo': instance.workOrderNo,
+      'productionLine': instance.productionLine,
+      'workshop': instance.workshop,
+      'planQty': instance.planQty,
+      'requiredDate': instance.requiredDate?.toIso8601String(),
+      'remark': instance.remark,
+    };
+
+_$MtlSenterMaterialImpl _$$MtlSenterMaterialImplFromJson(
+        Map<String, dynamic> json) =>
+    _$MtlSenterMaterialImpl(
+      materialCode: json['materialCode'] as String,
+      materialName: json['materialName'] as String?,
+      specification: json['specification'] as String?,
+      controlType: json['controlType'] as String?,
+      storeRoomNo: json['storeRoomNo'] as String?,
+      storeSiteNo: json['storeSiteNo'] as String?,
+      availableQty: (json['availableQty'] as num?)?.toDouble(),
+      minPackageQty: (json['minPackageQty'] as num?)?.toDouble(),
+      defaultDeliveryQty: (json['defaultDeliveryQty'] as num?)?.toDouble(),
+      batchNo: json['batchNo'] as String?,
+      serialNo: json['serialNo'] as String?,
+    );
+
+Map<String, dynamic> _$$MtlSenterMaterialImplToJson(
+        _$MtlSenterMaterialImpl instance) =>
+    <String, dynamic>{
+      'materialCode': instance.materialCode,
+      'materialName': instance.materialName,
+      'specification': instance.specification,
+      'controlType': instance.controlType,
+      'storeRoomNo': instance.storeRoomNo,
+      'storeSiteNo': instance.storeSiteNo,
+      'availableQty': instance.availableQty,
+      'minPackageQty': instance.minPackageQty,
+      'defaultDeliveryQty': instance.defaultDeliveryQty,
+      'batchNo': instance.batchNo,
+      'serialNo': instance.serialNo,
+    };
+
+_$MtlSenterCollectItemImpl _$$MtlSenterCollectItemImplFromJson(
+        Map<String, dynamic> json) =>
+    _$MtlSenterCollectItemImpl(
+      id: json['id'] as String,
+      storeSiteNo: json['storeSiteNo'] as String,
+      storeRoomNo: json['storeRoomNo'] as String?,
+      materialCode: json['materialCode'] as String,
+      materialName: json['materialName'] as String?,
+      batchNo: json['batchNo'] as String?,
+      serialNo: json['serialNo'] as String?,
+      productionDate: json['productionDate'] == null
+          ? null
+          : DateTime.parse(json['productionDate'] as String),
+      validDays: (json['validDays'] as num?)?.toInt(),
+      quantity: (json['quantity'] as num).toDouble(),
+      availableQty: (json['availableQty'] as num?)?.toDouble(),
+      minPackageQty: (json['minPackageQty'] as num?)?.toDouble(),
+      defaultDeliveryQty: (json['defaultDeliveryQty'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$$MtlSenterCollectItemImplToJson(
+        _$MtlSenterCollectItemImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'storeSiteNo': instance.storeSiteNo,
+      'storeRoomNo': instance.storeRoomNo,
+      'materialCode': instance.materialCode,
+      'materialName': instance.materialName,
+      'batchNo': instance.batchNo,
+      'serialNo': instance.serialNo,
+      'productionDate': instance.productionDate?.toIso8601String(),
+      'validDays': instance.validDays,
+      'quantity': instance.quantity,
+      'availableQty': instance.availableQty,
+      'minPackageQty': instance.minPackageQty,
+      'defaultDeliveryQty': instance.defaultDeliveryQty,
+    };
+
+_$MtlSenterSubmitRequestImpl _$$MtlSenterSubmitRequestImplFromJson(
+        Map<String, dynamic> json) =>
+    _$MtlSenterSubmitRequestImpl(
+      mtlSenderInfos: (json['mtlSenderInfos'] as List<dynamic>?)
+              ?.map((e) =>
+                  MtlSenterCollectItem.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const <MtlSenterCollectItem>[],
+      taskNo: json['taskNo'] as String?,
+      operatorId: json['operatorId'] as String?,
+    );
+
+Map<String, dynamic> _$$MtlSenterSubmitRequestImplToJson(
+        _$MtlSenterSubmitRequestImpl instance) =>
+    <String, dynamic>{
+      'mtlSenderInfos': instance.mtlSenderInfos,
+      'taskNo': instance.taskNo,
+      'operatorId': instance.operatorId,
+    };
+
+_$MtlSenterSubmitResponseImpl _$$MtlSenterSubmitResponseImplFromJson(
+        Map<String, dynamic> json) =>
+    _$MtlSenterSubmitResponseImpl(
+      code: json['code'] as String?,
+      message: json['message'] as String?,
+      success: json['success'] as bool?,
+    );
+
+Map<String, dynamic> _$$MtlSenterSubmitResponseImplToJson(
+        _$MtlSenterSubmitResponseImpl instance) =>
+    <String, dynamic>{
+      'code': instance.code,
+      'message': instance.message,
+      'success': instance.success,
+    };

--- a/lib/modules/mtl_senter/collection_task/mtl_senter_collection_page.dart
+++ b/lib/modules/mtl_senter/collection_task/mtl_senter_collection_page.dart
@@ -1,0 +1,457 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../../common_widgets/common_grid/common_data_grid.dart';
+import '../../../common_widgets/loading_dialog_manager.dart';
+import '../../../common_widgets/scanner_widget/scanner_config.dart';
+import '../../../common_widgets/scanner_widget/scanner_widget.dart';
+import '../../../services/user_manager.dart';
+import 'bloc/mtl_senter_collection_bloc.dart';
+import 'bloc/mtl_senter_collection_event.dart';
+import 'bloc/mtl_senter_collection_state.dart';
+import 'models/mtl_senter_models.dart';
+
+class MtlSenterCollectionPage extends StatefulWidget {
+  const MtlSenterCollectionPage({super.key, this.task});
+
+  final MtlSenterTask? task;
+
+  @override
+  State<MtlSenterCollectionPage> createState() =>
+      _MtlSenterCollectionPageState();
+}
+
+class _MtlSenterCollectionPageState extends State<MtlSenterCollectionPage> {
+  late final MtlSenterCollectionBloc _bloc;
+  final ScannerController _scannerController = ScannerController();
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<MtlSenterCollectionBloc>(context);
+    final user = Modular.get<UserManager>().userInfo;
+    _bloc.add(
+      MtlSenterCollectionStarted(
+        task: widget.task,
+        operatorId: user != null ? '${user.userId}' : null,
+      ),
+    );
+  }
+
+  bool _canPop() => _bloc.state.stocks.isEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: _canPop(),
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        _handleBackPress(context);
+      },
+      child: BlocConsumer<MtlSenterCollectionBloc, MtlSenterCollectionState>(
+        listener: (context, state) {
+          LoadingDialogManager.instance.hideLoadingDialog(context);
+
+          if (state.status.isLoading) {
+            LoadingDialogManager.instance.showLoadingDialog(context);
+          } else if (state.status.isError) {
+            LoadingDialogManager.instance.showErrorDialog(
+              context,
+              state.status.message ?? '操作失败',
+            );
+            _bloc.add(const MtlSenterResetStatus());
+          } else if (state.status.isSuccess &&
+              (state.status.message ?? '').isNotEmpty) {
+            LoadingDialogManager.instance.showSnackSuccessMsg(
+              context,
+              state.status.message!,
+              duration: const Duration(milliseconds: 800),
+            );
+            _bloc.add(const MtlSenterResetStatus());
+          }
+
+          if (state.focus) {
+            _scannerController.requestFocus();
+            _bloc.add(const MtlSenterFocusConsumed());
+          }
+
+          _scannerController.clear();
+        },
+        builder: (context, state) {
+          return Scaffold(
+            backgroundColor: const Color(0xFFF6F6F6),
+            appBar: AppBar(
+              backgroundColor: const Color(0xFF1976D2),
+              centerTitle: true,
+              elevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
+                onPressed: () => _handleBackPress(context),
+              ),
+              title: const Text(
+                '拉式发料采集',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            body: Column(
+              children: [
+                _buildScanner(state),
+                _buildInfoCards(state),
+                Expanded(child: _buildDataGrid(state)),
+              ],
+            ),
+            bottomNavigationBar: _buildBottomBar(state),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildScanner(MtlSenterCollectionState state) {
+    return ScannerWidget(
+      controller: _scannerController,
+      config: ScannerConfig(
+        placeholder: state.placeholder,
+        autoFocus: false,
+        height: 64,
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      ),
+      onScanResult: (value) {
+        _bloc.add(MtlSenterBarcodeScanned(value));
+      },
+      onError: (message) {
+        LoadingDialogManager.instance.showSnackErrorMsg(
+          context,
+          message,
+        );
+      },
+    );
+  }
+
+  Widget _buildInfoCards(MtlSenterCollectionState state) {
+    final TextStyle labelStyle = Theme.of(context)
+        .textTheme
+        .bodySmall!
+        .copyWith(color: const Color(0xFF8A8A8A));
+    final TextStyle valueStyle = Theme.of(context)
+        .textTheme
+        .titleMedium!
+        .copyWith(fontWeight: FontWeight.w600);
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: _infoItem(
+                  label: '库位',
+                  value: state.currentLocation ?? '--',
+                  labelStyle: labelStyle,
+                  valueStyle: valueStyle,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _infoItem(
+                  label: '库存',
+                  value: _formatQuantity(state.availableQty),
+                  labelStyle: labelStyle,
+                  valueStyle: valueStyle,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _infoItem(
+                  label: '物料编码',
+                  value: state.currentMaterial?.materialCode ?? '--',
+                  labelStyle: labelStyle,
+                  valueStyle: valueStyle,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _infoItem(
+                  label: '采集数量',
+                  value: _formatQuantity(
+                    state.collectedQtyMap.values
+                        .fold<double>(0, (prev, e) => prev + e),
+                  ),
+                  labelStyle: labelStyle,
+                  valueStyle: valueStyle,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _infoItem(
+            label: '物料名称',
+            value: state.currentMaterial?.materialName ?? '--',
+            labelStyle: labelStyle,
+            valueStyle: valueStyle.copyWith(fontSize: 14),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _infoItem(
+                  label: '最小包装数',
+                  value: _formatQuantity(state.minPackageQty),
+                  labelStyle: labelStyle,
+                  valueStyle: valueStyle,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _infoItem(
+                  label: '默认配送量',
+                  value: _formatQuantity(state.defaultDeliveryQty),
+                  labelStyle: labelStyle,
+                  valueStyle: valueStyle,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _infoItem({
+    required String label,
+    required String value,
+    required TextStyle labelStyle,
+    required TextStyle valueStyle,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: labelStyle),
+        const SizedBox(height: 4),
+        Text(value, style: valueStyle),
+      ],
+    );
+  }
+
+  Widget _buildDataGrid(MtlSenterCollectionState state) {
+    return CommonDataGrid<MtlSenterCollectItem>(
+      columns: _gridColumns(),
+      datas: state.stocks,
+      allowPager: false,
+      allowSelect: true,
+      currentPage: 1,
+      totalPages: 1,
+      onLoadData: (_) async {},
+      selectedRows: _selectedIndices(state),
+      onSelectionChanged: (indices) {
+        final ids = indices
+            .where((index) => index >= 0 && index < state.stocks.length)
+            .map((index) => state.stocks[index].id)
+            .toSet();
+        _bloc.add(MtlSenterSelectionChanged(ids));
+      },
+    );
+  }
+
+  List<int> _selectedIndices(MtlSenterCollectionState state) {
+    final selected = <int>[];
+    for (var i = 0; i < state.stocks.length; i++) {
+      if (state.selectedIds.contains(state.stocks[i].id)) {
+        selected.add(i);
+      }
+    }
+    return selected;
+  }
+
+  List<GridColumnConfig<MtlSenterCollectItem>> _gridColumns() {
+    return [
+      GridColumnConfig<MtlSenterCollectItem>(
+        name: 'storeSite',
+        headerText: '库位',
+        valueGetter: (row) => row.storeSiteNo,
+        width: 120,
+      ),
+      GridColumnConfig<MtlSenterCollectItem>(
+        name: 'materialCode',
+        headerText: '物料编码',
+        valueGetter: (row) => row.materialCode,
+        width: 160,
+      ),
+      GridColumnConfig<MtlSenterCollectItem>(
+        name: 'materialName',
+        headerText: '物料名称',
+        valueGetter: (row) => row.materialName ?? '',
+        width: 200,
+      ),
+      GridColumnConfig<MtlSenterCollectItem>(
+        name: 'quantity',
+        headerText: '数量',
+        valueGetter: (row) => _formatQuantity(row.quantity),
+        width: 100,
+        textStyle: const TextStyle(color: Color(0xFF1976D2)),
+      ),
+      GridColumnConfig<MtlSenterCollectItem>(
+        name: 'batchNo',
+        headerText: '批次',
+        valueGetter: (row) => row.batchNo ?? '',
+        width: 120,
+      ),
+      GridColumnConfig<MtlSenterCollectItem>(
+        name: 'serialNo',
+        headerText: '序列',
+        valueGetter: (row) => row.serialNo ?? '',
+        width: 120,
+      ),
+    ];
+  }
+
+  String _formatQuantity(num? value) {
+    if (value == null) return '--';
+    final doubleValue = value.toDouble();
+    if (!doubleValue.isFinite) {
+      return '--';
+    }
+    if (doubleValue % 1 == 0) {
+      return doubleValue.toInt().toString();
+    }
+    var text = doubleValue.toStringAsFixed(3);
+    while (text.contains('.') && text.endsWith('0')) {
+      text = text.substring(0, text.length - 1);
+    }
+    if (text.endsWith('.')) {
+      text = text.substring(0, text.length - 1);
+    }
+    return text;
+  }
+
+  Widget _buildBottomBar(MtlSenterCollectionState state) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+      decoration: const BoxDecoration(color: Colors.white),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton.icon(
+              onPressed: state.hasSelection ? _confirmDelete : null,
+              icon: const Icon(Icons.delete_outline),
+              label: const Text('删除'),
+              style: OutlinedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: ElevatedButton.icon(
+              onPressed: state.canSubmit ? _confirmSubmit : null,
+              icon: const Icon(Icons.cloud_upload_outlined),
+              label: const Text('提交'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF1976D2),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete() async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('删除确认'),
+        content: const Text('确定删除选中的采集记录吗？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('确定'),
+          ),
+        ],
+      ),
+    );
+
+    if (result == true) {
+      _bloc.add(const MtlSenterDeleteSelected());
+    }
+  }
+
+  Future<void> _confirmSubmit() async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('提交确认'),
+        content: const Text('请确认是否提交本次采集结果？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('取消'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('确定'),
+          ),
+        ],
+      ),
+    );
+
+    if (result == true) {
+      _bloc.add(const MtlSenterSubmitRequested());
+    }
+  }
+
+  void _handleBackPress(BuildContext context) {
+    if (_bloc.state.stocks.isNotEmpty) {
+      showDialog<void>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('提示'),
+          content: const Text('当前采集记录尚未提交，确定退出采集吗？'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('取消'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(dialogContext).pop();
+                Navigator.of(context).pop();
+              },
+              child: const Text('确定'),
+            ),
+          ],
+        ),
+      );
+    } else {
+      Navigator.of(context).pop();
+    }
+  }
+}

--- a/lib/modules/mtl_senter/collection_task/services/mtl_senter_service.dart
+++ b/lib/modules/mtl_senter/collection_task/services/mtl_senter_service.dart
@@ -1,0 +1,125 @@
+import 'package:dio/dio.dart';
+
+import '../../../../services/api_response_handler.dart';
+import '../models/mtl_senter_models.dart';
+
+class MtlSenterService {
+  MtlSenterService(this._dio);
+
+  final Dio _dio;
+
+  Future<MtlSenterMaterial> fetchMaterialByQr(String qrContent) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/getPmMaterialInfoByQR',
+      data: {'qrContent': qrContent},
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is Map<String, dynamic>) {
+          return MtlSenterMaterial.fromJson(Map<String, dynamic>.from(data));
+        }
+        if (data is List && data.isNotEmpty) {
+          return MtlSenterMaterial.fromJson(
+            Map<String, dynamic>.from(data.first as Map),
+          );
+        }
+        throw Exception('物料条码识别出现问题');
+      },
+    );
+  }
+
+  Future<double?> fetchInventoryByLocation({
+    required String storeSite,
+    required String materialCode,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getLSMtlRepertoryByStoresiteNo',
+      queryParameters: {
+        'storeSite': storeSite,
+        'matCode': materialCode,
+      },
+    );
+
+    return ApiResponseHandler.handleResponse<double?>(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List) {
+          final list = data.cast<Map>();
+          if (list.isEmpty) {
+            return 0;
+          }
+          final first = Map<String, dynamic>.from(list.first as Map);
+          final qty = first['repqty'] ?? first['qty'] ?? first['repertoryQty'];
+          return qty is num ? qty.toDouble() : 0;
+        }
+        if (data is Map) {
+          final qty = data['repqty'] ?? data['qty'] ?? data['repertoryQty'];
+          return qty is num ? qty.toDouble() : 0;
+        }
+        return 0;
+      },
+    );
+  }
+
+  Future<MtlSenterMaterial?> fetchMtlQty({
+    required String materialCode,
+    String? siteNo,
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getMtlQtyByMtlCode',
+      queryParameters: {
+        'mtlCode': materialCode,
+        'siteNo': siteNo,
+      },
+    );
+
+    return ApiResponseHandler.handleResponse<MtlSenterMaterial?>(
+      response: response,
+      dataExtractor: (data) {
+        if (data is List && data.isNotEmpty) {
+          final json = Map<String, dynamic>.from(data.first as Map);
+          return MtlSenterMaterial(
+            materialCode: materialCode,
+            minPackageQty: (json['minQty'] as num?)?.toDouble(),
+            defaultDeliveryQty: (json['deliveryQty'] as num?)?.toDouble(),
+          );
+        }
+        return null;
+      },
+    );
+  }
+
+  Future<void> commitSender({
+    required MtlSenterSubmitRequest request,
+  }) async {
+    final response = await _dio.post<Map<String, dynamic>>(
+      '/system/terminal/commitMtlSender',
+      options: Options(
+        headers: {'content-type': 'application/json;charset=UTF-8'},
+      ),
+      data: {
+        'mtlSenderInfos': request.mtlSenderInfos
+            .map(
+              (item) => {
+                'locationNo': item.storeSiteNo,
+                'matCode': item.materialCode,
+                'qty': item.quantity,
+              },
+            )
+            .toList(),
+        'taskNo': request.taskNo,
+        'operatorId': request.operatorId,
+      },
+    );
+    final body = response.data;
+    if (body is Map<String, dynamic>) {
+      final code = body['code'] as int?;
+      if (code != 200) {
+        final message = body['msg']?.toString() ?? '提交失败';
+        throw Exception(message);
+      }
+    }
+  }
+}

--- a/lib/modules/mtl_senter/mtl_senter_module.dart
+++ b/lib/modules/mtl_senter/mtl_senter_module.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../app_module.dart';
+import '../../services/dio_client.dart';
+import 'collection_task/bloc/mtl_senter_collection_bloc.dart';
+import 'collection_task/mtl_senter_collection_page.dart';
+import 'collection_task/services/mtl_senter_service.dart';
+import 'collection_task/models/mtl_senter_models.dart';
+
+class MtlSenterModule extends Module {
+  @override
+  List<Module> get imports => [AppModule()];
+
+  @override
+  void binds(Injector i) {
+    i.addSingleton<MtlSenterService>(
+      () => MtlSenterService(i.get<DioClient>().dio),
+    );
+
+    i.add<MtlSenterCollectionBloc>(
+      () => MtlSenterCollectionBloc(service: i.get<MtlSenterService>()),
+    );
+  }
+
+  @override
+  void routes(RouteManager r) {
+    r.child(
+      '/',
+      child: (_) {
+        final args = Modular.args.data;
+        final task = args is Map<String, dynamic>
+            ? args['task'] as MtlSenterTask?
+            : args is MtlSenterTask
+                ? args
+                : null;
+        return BlocProvider(
+          create: (_) => Modular.get<MtlSenterCollectionBloc>(),
+          child: MtlSenterCollectionPage(task: task),
+        );
+      },
+    );
+  }
+}

--- a/test/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_bloc_test.dart
+++ b/test/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_bloc_test.dart
@@ -1,0 +1,259 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wms_app/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_bloc.dart';
+import 'package:wms_app/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_event.dart';
+import 'package:wms_app/modules/mtl_senter/collection_task/bloc/mtl_senter_collection_state.dart';
+import 'package:wms_app/modules/mtl_senter/collection_task/models/mtl_senter_models.dart';
+import 'package:wms_app/modules/mtl_senter/collection_task/services/mtl_senter_service.dart';
+
+class StubMtlSenterService extends MtlSenterService {
+  StubMtlSenterService({
+    required this.material,
+    this.qtyInfo,
+    this.inventoryQty = 0,
+    this.commitShouldFail = false,
+  }) : super(Dio());
+
+  final MtlSenterMaterial material;
+  final MtlSenterMaterial? qtyInfo;
+  final double inventoryQty;
+  final bool commitShouldFail;
+
+  String? lastQrContent;
+  String? lastInventoryLocation;
+  String? lastInventoryMaterial;
+  MtlSenterSubmitRequest? lastSubmitRequest;
+
+  @override
+  Future<MtlSenterMaterial> fetchMaterialByQr(String qrContent) async {
+    lastQrContent = qrContent;
+    return material;
+  }
+
+  @override
+  Future<double?> fetchInventoryByLocation({
+    required String storeSite,
+    required String materialCode,
+  }) async {
+    lastInventoryLocation = storeSite;
+    lastInventoryMaterial = materialCode;
+    return inventoryQty;
+  }
+
+  @override
+  Future<MtlSenterMaterial?> fetchMtlQty({
+    required String materialCode,
+    String? siteNo,
+  }) async {
+    return qtyInfo;
+  }
+
+  @override
+  Future<void> commitSender({
+    required MtlSenterSubmitRequest request,
+  }) async {
+    lastSubmitRequest = request;
+    if (commitShouldFail) {
+      throw Exception('commit failed');
+    }
+  }
+}
+
+void main() {
+  late StubMtlSenterService service;
+  late MtlSenterCollectionBloc bloc;
+
+  const task = MtlSenterTask(
+    taskId: 'TASK-001',
+    workOrderNo: 'WO-1',
+  );
+
+  setUp(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    service = StubMtlSenterService(
+      material: const MtlSenterMaterial(
+        materialCode: 'MAT-001',
+        materialName: '轴承',
+        minPackageQty: 2,
+        defaultDeliveryQty: 5,
+      ),
+      qtyInfo: const MtlSenterMaterial(
+        materialCode: 'MAT-001',
+        minPackageQty: 3,
+        defaultDeliveryQty: 6,
+      ),
+      inventoryQty: 10,
+    );
+    bloc = MtlSenterCollectionBloc(service: service);
+  });
+
+  tearDown(() async {
+    await bloc.close();
+  });
+
+  Future<void> _startFlow() async {
+    bloc.add(const MtlSenterCollectionStarted(task: task, operatorId: '10001'));
+    await bloc.stream.firstWhere((state) => state.task == task);
+  }
+
+  Future<MtlSenterCollectionState> _scanLocation() async {
+    bloc.add(const MtlSenterBarcodeScanned('A1\$KW\$LOC-01'));
+    return bloc.stream.firstWhere(
+      (state) =>
+          state.currentLocation == 'LOC-01' &&
+          state.scanStep == MtlSenterScanStep.material,
+    );
+  }
+
+  Future<MtlSenterCollectionState> _scanMaterial() async {
+    bloc.add(const MtlSenterBarcodeScanned('MC123456'));
+    return bloc.stream.firstWhere(
+      (state) =>
+          state.scanStep == MtlSenterScanStep.quantity &&
+          state.currentMaterial?.materialCode == 'MAT-001',
+    );
+  }
+
+  Future<MtlSenterCollectionState> _inputQuantity(String qty) async {
+    bloc.add(MtlSenterBarcodeScanned(qty));
+    return bloc.stream.firstWhere(
+      (state) => state.status.isSuccess && state.stocks.isNotEmpty,
+    );
+  }
+
+  test('start event primes task context and resets state', () async {
+    await _startFlow();
+
+    final state = bloc.state;
+    expect(state.task, equals(task));
+    expect(state.operatorId, equals('10001'));
+    expect(state.scanStep, MtlSenterScanStep.location);
+    expect(state.stocks, isEmpty);
+  });
+
+  test('location scan sets current location and switches to material step', () async {
+    await _startFlow();
+
+    final state = await _scanLocation();
+
+    expect(state.currentLocation, 'LOC-01');
+    expect(state.placeholder, '请扫描二维码');
+    expect(service.lastInventoryLocation, isNull);
+  });
+
+  test('material scan loads metadata and inventory then switches to quantity step', () async {
+    await _startFlow();
+    await _scanLocation();
+
+    final state = await _scanMaterial();
+
+    expect(service.lastQrContent, 'MC123456');
+    expect(service.lastInventoryLocation, 'LOC-01');
+    expect(service.lastInventoryMaterial, 'MAT-001');
+    expect(state.availableQty, 10);
+    expect(state.minPackageQty, 3);
+    expect(state.defaultDeliveryQty, 6);
+    expect(state.placeholder, '请输入数量');
+  });
+
+  test('quantity input aggregates records and keeps focus on material step', () async {
+    await _startFlow();
+    await _scanLocation();
+    await _scanMaterial();
+
+    final first = await _inputQuantity('2');
+    expect(first.stocks.single.quantity, closeTo(2, 1e-6));
+    expect(first.scanStep, MtlSenterScanStep.material);
+    expect(first.focus, isTrue);
+
+    final second = await _inputQuantity('3');
+    expect(second.stocks.single.quantity, closeTo(5, 1e-6));
+    expect(second.collectedQtyMap['MAT-001@LOC-01'], closeTo(5, 1e-6));
+  });
+
+  test('quantity exceeding available stock surfaces error', () async {
+    await _startFlow();
+    await _scanLocation();
+    await _scanMaterial();
+
+    bloc.add(const MtlSenterBarcodeScanned('11'));
+
+    final errorState = await bloc.stream.firstWhere(
+      (state) => state.status.isError,
+    );
+
+    expect(errorState.status.message, contains('超过当前库存'));
+    expect(errorState.focus, isTrue);
+  });
+
+  test('invalid barcode reports error without changing focus', () async {
+    await _startFlow();
+
+    bloc.add(const MtlSenterBarcodeScanned('UNKNOWN'));
+
+    final errorState = await bloc.stream.firstWhere(
+      (state) => state.status.isError,
+    );
+
+    expect(errorState.status.message, contains('采集内容不合法'));
+    expect(errorState.scanStep, MtlSenterScanStep.location);
+  });
+
+  test('delete removes selected records and clears selection set', () async {
+    await _startFlow();
+    await _scanLocation();
+    await _scanMaterial();
+    final recorded = await _inputQuantity('4');
+
+    final targetId = recorded.stocks.first.id;
+    bloc.add(MtlSenterToggleSelection(targetId));
+    await bloc.stream.firstWhere((state) => state.hasSelection);
+
+    bloc.add(const MtlSenterDeleteSelected());
+    final cleared = await bloc.stream.firstWhere(
+      (state) => state.status.isSuccess && state.stocks.isEmpty,
+    );
+
+    expect(cleared.selectedIds, isEmpty);
+    expect(cleared.collectedQtyMap, isEmpty);
+  });
+
+  test('submit sends payload to service and clears working buffers', () async {
+    await _startFlow();
+    await _scanLocation();
+    await _scanMaterial();
+    await _inputQuantity('2');
+
+    bloc.add(const MtlSenterSubmitRequested());
+
+    final submitted = await bloc.stream.firstWhere(
+      (state) => state.status.isSuccess && state.status.message == '提交成功',
+    );
+
+    expect(service.lastSubmitRequest, isNotNull);
+    expect(service.lastSubmitRequest!.mtlSenderInfos, hasLength(1));
+    expect(submitted.stocks, isEmpty);
+    expect(submitted.collectedQtyMap, isEmpty);
+  });
+
+  test('submit surfaces service error and keeps stocks intact', () async {
+    service = StubMtlSenterService(
+      material: const MtlSenterMaterial(materialCode: 'MAT-002'),
+      inventoryQty: 5,
+      commitShouldFail: true,
+    );
+    bloc = MtlSenterCollectionBloc(service: service);
+
+    await _startFlow();
+    await _scanLocation();
+    await _scanMaterial();
+    await _inputQuantity('1');
+
+    bloc.add(const MtlSenterSubmitRequested());
+
+    final errorState = await bloc.stream.firstWhere((state) => state.status.isError);
+
+    expect(errorState.stocks, isNotEmpty);
+    expect(service.lastSubmitRequest, isNotNull);
+  });
+}

--- a/test/modules/mtl_senter/collection_task/services/mtl_senter_service_test.dart
+++ b/test/modules/mtl_senter/collection_task/services/mtl_senter_service_test.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wms_app/modules/mtl_senter/collection_task/models/mtl_senter_models.dart';
+import 'package:wms_app/modules/mtl_senter/collection_task/services/mtl_senter_service.dart';
+
+class FakeHttpClientAdapter implements HttpClientAdapter {
+  FakeHttpClientAdapter(this._handlers);
+
+  final Map<String, ResponseBody Function(RequestOptions)> _handlers;
+  RequestOptions? lastOptions;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastOptions = options;
+    final handler = _handlers[options.path];
+    if (handler == null) {
+      throw Exception('No handler for ${options.path}');
+    }
+    return handler(options);
+  }
+}
+
+ResponseBody jsonBody(Map<String, dynamic> payload) {
+  final data = utf8.encode(jsonEncode(payload));
+  return ResponseBody.fromBytes(
+    data,
+    200,
+    headers: {
+      Headers.contentTypeHeader: ['application/json'],
+    },
+  );
+}
+
+void main() {
+  group('MtlSenterService', () {
+    late Map<String, ResponseBody Function(RequestOptions)> handlers;
+    late FakeHttpClientAdapter adapter;
+    late Dio dio;
+    late MtlSenterService service;
+
+    setUp(() {
+      handlers = {};
+      adapter = FakeHttpClientAdapter(handlers);
+      dio = Dio()..httpClientAdapter = adapter;
+      service = MtlSenterService(dio);
+    });
+
+    test('fetchMaterialByQr parses map payload', () async {
+      handlers['/system/terminal/getPmMaterialInfoByQR'] = (_) => jsonBody({
+            'code': 200,
+            'msg': 'success',
+            'data': {
+              'materialCode': 'MAT-001',
+              'materialName': 'Bearing',
+              'minPackageQty': 2,
+            },
+          });
+
+      final result = await service.fetchMaterialByQr('QR-CONTENT');
+
+      expect(result.materialCode, 'MAT-001');
+      expect(result.materialName, 'Bearing');
+      expect(adapter.lastOptions?.data, {'qrContent': 'QR-CONTENT'});
+    });
+
+    test('fetchInventoryByLocation returns numeric quantity from list', () async {
+      handlers['/system/terminal/getLSMtlRepertoryByStoresiteNo'] = (_) => jsonBody({
+            'code': 200,
+            'msg': 'ok',
+            'data': [
+              {
+                'repqty': 4.5,
+              }
+            ],
+          });
+
+      final result = await service.fetchInventoryByLocation(
+        storeSite: 'LOC-1',
+        materialCode: 'MAT-1',
+      );
+
+      expect(result, closeTo(4.5, 1e-6));
+      expect(adapter.lastOptions?.queryParameters, {
+        'storeSite': 'LOC-1',
+        'matCode': 'MAT-1',
+      });
+    });
+
+    test('fetchMtlQty maps delivery and min package information', () async {
+      handlers['/system/terminal/getMtlQtyByMtlCode'] = (_) => jsonBody({
+            'code': 200,
+            'msg': 'ok',
+            'data': [
+              {
+                'minQty': 3,
+                'deliveryQty': 6,
+              }
+            ],
+          });
+
+      final result = await service.fetchMtlQty(
+        materialCode: 'MAT-001',
+        siteNo: 'LOC-1',
+      );
+
+      expect(result, isNotNull);
+      expect(result!.minPackageQty, closeTo(3, 1e-6));
+      expect(result.defaultDeliveryQty, closeTo(6, 1e-6));
+      expect(adapter.lastOptions?.queryParameters, {
+        'mtlCode': 'MAT-001',
+        'siteNo': 'LOC-1',
+      });
+    });
+
+    test('commitSender sends request body and throws on non-200 code', () async {
+      handlers['/system/terminal/commitMtlSender'] = (options) {
+        final payload = options.data as Map<String, dynamic>;
+        expect(payload['mtlSenderInfos'], hasLength(1));
+        expect(payload['taskNo'], 'TASK-1');
+        expect(payload['operatorId'], 'OP-1');
+        return jsonBody({
+          'code': 500,
+          'msg': 'failed',
+          'data': {},
+        });
+      };
+
+      final request = MtlSenterSubmitRequest(
+        taskNo: 'TASK-1',
+        operatorId: 'OP-1',
+        mtlSenderInfos: const [
+          MtlSenterCollectItem(
+            id: '1',
+            storeSiteNo: 'LOC-1',
+            materialCode: 'MAT-1',
+            quantity: 2,
+          ),
+        ],
+      );
+
+      expect(
+        () => service.commitSender(request: request),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('commitSender completes when backend responds with 200', () async {
+      handlers['/system/terminal/commitMtlSender'] = (_) => jsonBody({
+            'code': 200,
+            'msg': 'ok',
+            'data': {},
+          });
+
+      final request = MtlSenterSubmitRequest(
+        taskNo: 'TASK-1',
+        operatorId: 'OP-1',
+        mtlSenderInfos: const [
+          MtlSenterCollectItem(
+            id: '1',
+            storeSiteNo: 'LOC-1',
+            materialCode: 'MAT-1',
+            quantity: 2,
+          ),
+        ],
+      );
+
+      await service.commitSender(request: request);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement the Flutter 拉式发料 module with Freezed models, bloc workflow, UI page and service wiring
- register the module entry points and extend the home dashboard documentation for the new feature
- add targeted bloc/service unit tests and a module operations guide, updating the refactor checklist

## Testing
- `flutter analyze` *(fails: repo has 577 existing issues across unrelated modules)*
- `flutter test` *(fails: pre-existing goods_up tests and legacy widget specs continue to fail)*
- `flutter pub run build_runner build --delete-conflicting-outputs`

------
https://chatgpt.com/codex/tasks/task_e_68f0e3418e9c8330975ad19e834f81c0