### PR TITLE
feat: add flutter inventory query module

### DIFF
--- a/docs/refactor_todos/queryrepertory_todo.md
+++ b/docs/refactor_todos/queryrepertory_todo.md
@@ -1,35 +1,85 @@
-# 库存查询模块重构 TODO
+# 库存查询模块（Query Repertory）Flutter 重构 TODO
 
-## UniApp 现状
-- 页面结构：单页 `pages/queryrepertory/queryRepertory.nvue`，提供按库位、物料、条码等条件查询库存。
-- API 依赖：分散在 `api/system/goodsUp.js`、`goodsDown.js` 中（库位库存查询、条码查询、库位对调查询等）。
+> **输入来源**：UniApp 页面 `GlodWind-Wms-App/pages/queryrepertory/queryRepertory.nvue`
+>
+> **Flutter 参考**：平库出库模块 `lib/modules/outbound`、平库入库模块 `lib/modules/goods_up`
+>
+> **接口参考**：`api.md`、现有服务 `lib/modules/goods_up/services/goods_up_task_service.dart`、`lib/modules/outbound/services/outbound_task_service.dart`
 
-## Flutter 重构策略
-- **模块结构**：创建 `inventory_query_module`，根据需要划分主查询页、条码查询结果页、库位对调查询页。
-- **逻辑复用**：
-  - 表单与结果展示可借鉴出库模块中 `CommonDataGrid` 的用法，支持分页、筛选、导出。【F:lib/modules/outbound/task_list/outbound_task_list_page.dart†L49-L161】
-  - Service 层参照 `CollectionService`，封装库存查询相关接口，统一异常处理。【F:lib/modules/outbound/collection_task/services/collection_service.dart†L1-L193】
-- **UI 设计**：
-  - 顶部 `CustomAppBar`，中间以表单布局输入库房、库位、物料、批次、条码等条件。
-  - 结果区使用 `CommonDataGrid` 或 `DataTable` 展示库存列表，支持导出、复制、筛选。
-  - 可添加标签页切换不同查询模式（库存、条码、对调记录）。
+## 页面：库存查询首页（queryRepertory.nvue）
 
-## 待办清单
-1. 建立 `lib/modules/inventory_query` 目录与路由。
-2. 实现 `InventoryQueryService`，封装以下接口：
-   - `getMtlRepertoryByStoresiteNo`（含平库/立库版本）、`getMtlRepertoryByStoresiteNosn`、`getMtlRepertoryByStoresiteNoErp`。
-   - 条码查询：`GetRepertoryByBarCode`。
-   - 库位对调：`GetRepertoryByStoresiteNoTransfer`。
-3. 定义数据模型：
-   - 库存记录（库位、物料、批次、数量、托盘、ERP 子库等）。
-   - 条码查询结果、库位对调结果。
-4. 构建查询页面：
-   - 设计筛选表单、查询按钮、扫码快捷入口。
-   - 查询后使用 `CommonDataGrid` 展示结果，提供分页、排序、导出。
-5. 扩展页（可选）：
-   - 条码查询详情、库位对调记录页面。
-6. 测试：
-   - Service 层测试验证参数与响应解析。
-   - UI/BLoC 测试覆盖条件输入、查询、空结果、错误提示。
-7. 文档：
-   - 更新库存查询操作说明，标注不同接口的适用场景（平库/立库、对调查询等）。
+### 1. 模块初始化与路由骨架
+- [x] 新增 `lib/modules/inventory_query` 模块目录，参照 `lib/modules/outbound` 目录结构划分 `pages/`, `bloc/`, `services/`, `models/`, `widgets/` 等子目录。
+- [x] 创建 `inventory_query_module.dart`，实现 `Module` 定义与路由注册（例如 `/inventory/query`），并在 `app_module.dart` 中挂载，保持与 `goods_up_module.dart` 相同的模式。
+- [x] 定义 `InventoryQueryRoute`（或 `InventoryQueryPageRoute`）常量，供主导航与其他页面跳转复用。
+
+### 2. Freezed 数据模型定义
+- [x] 使用 `freezed` + `json_serializable` 创建查询请求模型：`InventoryQueryRequest`（字段：`queryType`、`barcode`、`storeSite`、`trayNo`、`pageIndex`、`pageSize` 等），对照 UniApp 中 `GetRepertoryByBarCode` 及分页参数。
+- [x] 定义库存记录模型：`InventoryRecord`（字段覆盖 `matcode`、`matname`、`repqty`、`batchno`、`sn`、`storesiteno`、`erpStoreroom`、`storeroomno`、`storeroomname` 等），参考 UniApp `detailListView`。
+- [x] 定义条码解析结果模型：`InventoryBarcodeMaterial`，对应 `getPmMaterialInfoByQR` 返回的 `BarcodeContent` 字段。
+- [x] 定义汇总视图模型：`InventorySummary`（如总库存数量、当前库位、托盘号等），用于顶部卡片展示。
+- [x] 为分页响应创建 `InventoryRecordPage`（封装 `rows`, `total`），保持与 `CommonDataGridBloc` 兼容。
+- [x] 更新 `pubspec.yaml` 中 `build_runner` 依赖说明（若已有可跳过），并在 TODO 完成后提示运行 `flutter pub run build_runner build --delete-conflicting-outputs`。
+
+### 3. 服务层（Service）封装
+- [x] 新建 `InventoryQueryService`，注入 `ApiService`/`DioClient`，参考 `CollectionService` 和 `GoodsUpTaskService` 的实现方式。
+- [x] 实现以下方法，并对照 `api.md` 补充接口注释：
+  - `Future<InventoryBarcodeMaterial> getMaterialInfoByQr(String barcode)` → 对应 `getPmMaterialInfoByQR`。
+  - `Future<InventoryRecordPage> getInventoryByBarcode(String code, String queryType, int pageIndex, int pageSize)` → 对应 `GetRepertoryByBarCode`。
+  - 预留库位、托盘、批次等扩展接口（如需与 UniApp 其他入口保持一致）。
+- [x] 统一错误处理：使用 `ErrorHandler.handleError` 或类似工具，保持与入库/出库模块一致。
+
+### 4. 状态管理（Bloc/Cubit）
+- [x] 参考 `lib/modules/outbound/collection_task/bloc`，创建 `InventoryQueryBloc`，以及独立的 `InventoryQueryEvent`/`InventoryQueryState` 文件。
+- [x] 事件设计：
+  - `InventoryQueryInitialized`（页面初始化，加载默认分页设置）。
+  - `InventoryBarcodeScanned`（扫码内容进入，识别 `MC/$KW$/$TP$` 三种步骤）。
+  - `InventoryQuerySubmitted`（手动点击查询按钮）。
+  - `InventoryPageChanged`（分页器切换页码）。
+  - `InventoryResetRequested`（清空当前查询结果）。
+- [x] 状态设计：
+  - 使用 `freezed` 定义 `InventoryQueryState`，包含字段：`pageStatus`（`PageStatus`）、`barcodeMaterial`、`records`、`summary`、`queryType`、`currentPage`、`pageSize`、`total`、`errorMessage`、`inputFocus` 等。
+  - 根据出入库模块的 `PageStatus` 管理 loading/success/error。
+- [x] 在 Bloc 中实现扫码步骤逻辑：
+  - 解析扫码字符串，映射到 `queryType` (`M`、`S`、`P`)，并更新 `summary`（库位、托盘、总库存）。
+  - 触发服务层查询并写入 `records`，计算合计库存数。
+  - 捕获异常并派发错误状态，保证 UI 弹出 `ErrorDialog` 或 `SnackBar`。
+- [x] 为 `loadData`/分页切换复用 Bloc 事件，保持与 UniApp `loadData` 方法一致的效果。
+
+### 5. UI 页面实现
+- [x] 新建 `pages/inventory_query_page.dart`，使用 `BlocProvider` 注入 `InventoryQueryBloc`。
+- [x] AppBar：使用现有 `CustomAppBar`，标题“库存查询”，左侧返回调用 `Navigator.pop` 或重定向到首页。
+- [x] 输入区：
+  - 引入 `common_widgets/scan/scan_input_field.dart`（如有）或复用 `ScanCode` 组件逻辑，实现扫码触发 `InventoryBarcodeScanned`。
+  - 提供手动输入框，支持清除/提交按钮，参照入库/出库模块的表单组件样式。
+- [x] 汇总卡片：
+  - 参照 `goods_up` 模块顶部信息条，展示库位、库存数量、物料信息、托盘号等，绑定 `InventorySummary`。
+- [x] 数据表格：
+  - 使用 `CommonDataGrid<InventoryRecord>` 或 `SyncfusionDataGrid`，定义列（物料编码、名称、批次、数量、库位、ERP 子库、库房编码/名称等）。
+  - 支持排序、分页、空数据占位，与现有模块风格一致。
+- [x] 分页组件：复用 `PaginationFooter` 或构建类似组件，调用 `InventoryPageChanged`。
+- [x] 错误与加载状态：
+  - 当 `PageStatus.loading` 时展示 `LoadingOverlay`。
+  - 当 `PageStatus.error` 时显示错误提示，可参考 `Outbound` 模块的实现。
+- [x] 扫码悬浮按钮 / 底部按钮（如 UniApp 使用的 `<scanCode>` 组件），结合现有扫码服务确保在扫码完成后自动聚焦输入框。
+
+### 6. 模块集成
+- [x] 在主菜单或工作台入口中新增“库存查询”导航，复用 `HomeNavigationBloc`/`modules/home` 的配置方式。
+- [x] 确认用户权限校验逻辑（如需要登陆后才能访问），与入库/出库模块保持一致。
+- [ ] 如需缓存最近查询参数，可接入 `SharedPreferences` 或 Hive，保持与其他模块统一（可选）。
+
+### 7. 测试与验证
+- [x] 编写 `InventoryQueryService` 的单元测试，模拟成功与失败响应（可使用 `mockito`）。
+- [x] 为 `InventoryQueryBloc` 添加事件-状态测试，覆盖扫码解析、分页切换、错误提示。
+- [ ] 进行 UI Golden / Widget 测试，验证表单与数据网格渲染（可选）。
+- [ ] 手动联调：扫码三种类型（物料 MC、库位 `$KW$`、托盘 `$TP$`）、分页跳转、无数据提示、网络错误。
+
+### 8. 文档与发布
+- [ ] 在 `docs` 中新增或更新操作指南，说明 Flutter 版库存查询的使用流程与接口对照。
+- [ ] 更新 `CHANGELOG` 或发布说明，记录库存查询模块 Flutter 化的主要变更。
+- [x] 运行并记录 `flutter analyze`、`flutter test`、`flutter pub run build_runner build --delete-conflicting-outputs` 的结果，确保模块上线前质量可追溯。
+  - `flutter pub run build_runner build --delete-conflicting-outputs` ✅
+  - `flutter analyze --no-pub lib test` ⚠️（返回 604 个历史遗留告警，待全局治理）
+  - `flutter test` ⚠️（因 `StubGoodsUpTaskService.commitUpShelves` 与 `GoodsUpTaskService` 签名不一致导致的既有失败）
+
+> 完成每一项后，请在 TODO 列表中将对应条目由 `[ ]` 改为 `[x]` 以标记完成。

--- a/lib/app_module.dart
+++ b/lib/app_module.dart
@@ -11,6 +11,8 @@ import 'modules/goods_up/goods_up_module.dart';
 import 'modules/arrival_sign/arrival_sign_module.dart';
 import 'modules/aswh_inventory/aswh_inventory_module.dart';
 import 'modules/inventory_task/inventory_task_module.dart';
+import 'modules/inventory_query/inventory_query_module.dart';
+import 'modules/inventory_query/inventory_query_routes.dart';
 import 'modules/mtl_senter/mtl_senter_module.dart';
 
 /// 应用主模块
@@ -57,6 +59,9 @@ class AppModule extends Module {
 
     // 平库盘点模块
     r.module('/inventory', module: InventoryTaskModule());
+
+    // 库存查询模块
+    r.module(InventoryQueryRoutes.module, module: InventoryQueryModule());
 
     // 拉式发料模块
     r.module('/mtl-senter', module: MtlSenterModule());

--- a/lib/common_widgets/scanner_widget/scanner_widget.dart
+++ b/lib/common_widgets/scanner_widget/scanner_widget.dart
@@ -140,6 +140,9 @@ class _ScannerWidgetState extends State<ScannerWidget> {
     _controller.text = text;
   }
 
+  /// 当前输入框内容
+  String get text => _controller.text;
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -238,6 +241,9 @@ class ScannerController {
   void setText(String text) {
     _state?.setText(text);
   }
+
+  /// 获取当前文本内容
+  String get text => _state?.text ?? '';
 
   /// 检查是否已附加到组件
   bool get isAttached => _state != null;

--- a/lib/modules/home/home_page.dart
+++ b/lib/modules/home/home_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
+import '../inventory_query/inventory_query_routes.dart';
+
 /* ---------------- 入口 ---------------- */
 class WMSHomePage extends StatelessWidget {
   const WMSHomePage({super.key});
@@ -293,6 +295,8 @@ class _FunctionGrid extends StatelessWidget {
             Modular.to.pushNamed('/goods-up');
           } else if (f.title == '拉式发料') {
             Modular.to.pushNamed('/mtl-senter');
+          } else if (f.title == '库存查询') {
+            Modular.to.pushNamed(InventoryQueryRoutes.module);
           } else {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(

--- a/lib/modules/inventory_query/bloc/inventory_query_bloc.dart
+++ b/lib/modules/inventory_query/bloc/inventory_query_bloc.dart
@@ -1,0 +1,235 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+
+import '../../../utils/error_handler.dart';
+import '../models/inventory_barcode_material.dart';
+import '../models/inventory_query_request.dart';
+import '../models/inventory_record.dart';
+import '../models/inventory_summary.dart';
+import '../services/inventory_query_service.dart';
+import 'inventory_query_event.dart';
+import 'inventory_query_state.dart';
+
+class InventoryQueryBloc
+    extends Bloc<InventoryQueryEvent, InventoryQueryState> {
+  InventoryQueryBloc({required InventoryQueryService service})
+    : _service = service,
+      super(const InventoryQueryState()) {
+    on<InventoryQueryEvent>(_onEvent);
+  }
+
+  final InventoryQueryService _service;
+
+  Future<void> _onEvent(
+    InventoryQueryEvent event,
+    Emitter<InventoryQueryState> emit,
+  ) async {
+    await event.map(
+      initialized: (_) => _handleInitialized(emit),
+      modeChanged: (value) => _handleModeChanged(value.mode, emit),
+      barcodeScanned: (value) => _handleBarcodeScanned(value.raw, emit),
+      manualSubmitted: (value) => _handleManualSubmitted(value.input, emit),
+      pageChanged: (value) => _handlePageChanged(value.pageIndex, emit),
+      resetRequested: (_) => _handleResetRequested(emit),
+    );
+  }
+
+  Future<void> _handleInitialized(Emitter<InventoryQueryState> emit) async {
+    emit(state.copyWith(focusTick: state.focusTick + 1));
+  }
+
+  Future<void> _handleModeChanged(
+    InventoryQueryMode mode,
+    Emitter<InventoryQueryState> emit,
+  ) async {
+    emit(state.copyWith(selectedMode: mode));
+  }
+
+  Future<void> _handleBarcodeScanned(
+    String raw,
+    Emitter<InventoryQueryState> emit,
+  ) async {
+    await _performQuery(
+      emit: emit,
+      rawInput: raw,
+      detectedMode: null,
+      targetPage: 1,
+    );
+  }
+
+  Future<void> _handleManualSubmitted(
+    String input,
+    Emitter<InventoryQueryState> emit,
+  ) async {
+    final trimmed = input.trim();
+    if (trimmed.isEmpty) {
+      emit(
+        state.copyWith(
+          status: PageStatus.failure,
+          errorMessage: '采集内容为空，请重新采集',
+          records: const [],
+          total: 0,
+          focusTick: state.focusTick + 1,
+        ),
+      );
+      return;
+    }
+
+    await _performQuery(
+      emit: emit,
+      rawInput: trimmed,
+      detectedMode: state.selectedMode,
+      targetPage: 1,
+    );
+  }
+
+  Future<void> _handlePageChanged(
+    int pageIndex,
+    Emitter<InventoryQueryState> emit,
+  ) async {
+    if (state.queryValue == null) {
+      emit(
+        state.copyWith(
+          status: PageStatus.failure,
+          errorMessage: '请先扫描或输入查询条件',
+          focusTick: state.focusTick + 1,
+        ),
+      );
+      return;
+    }
+
+    await _performQuery(
+      emit: emit,
+      rawInput: state.queryValue!,
+      detectedMode: state.selectedMode,
+      targetPage: pageIndex,
+      useCachedValue: true,
+    );
+  }
+
+  Future<void> _handleResetRequested(Emitter<InventoryQueryState> emit) async {
+    emit(const InventoryQueryState());
+    emit(state.copyWith(focusTick: state.focusTick + 1));
+  }
+
+  Future<void> _performQuery({
+    required Emitter<InventoryQueryState> emit,
+    required String rawInput,
+    InventoryQueryMode? detectedMode,
+    required int targetPage,
+    bool useCachedValue = false,
+  }) async {
+    try {
+      final mode = detectedMode ?? _resolveMode(rawInput);
+      String normalizedValue = rawInput;
+      InventoryBarcodeMaterial? barcodeMaterial;
+      InventorySummary summary = const InventorySummary();
+
+      if (!useCachedValue) {
+        switch (mode) {
+          case InventoryQueryMode.material:
+            final material = await _service.getMaterialInfoByQr(rawInput);
+            barcodeMaterial = material;
+            normalizedValue = material.matcode;
+            summary = summary.copyWith(
+              materialCode: material.matcode,
+              materialName: material.matname,
+            );
+            break;
+          case InventoryQueryMode.storeSite:
+            normalizedValue = _extractByDelimiter(rawInput, '库位号不能为空!');
+            summary = summary.copyWith(storeSite: normalizedValue);
+            break;
+          case InventoryQueryMode.tray:
+            normalizedValue = _extractByDelimiter(rawInput, '托盘号不能为空!');
+            summary = summary.copyWith(trayNo: normalizedValue);
+            break;
+        }
+      } else {
+        summary = state.summary;
+        barcodeMaterial = state.barcodeMaterial;
+        normalizedValue = state.queryValue ?? rawInput;
+      }
+
+      if (normalizedValue.isEmpty) {
+        throw Exception('采集内容不合法');
+      }
+
+      emit(
+        state.copyWith(
+          status: PageStatus.loading,
+          errorMessage: null,
+          currentPage: targetPage,
+          records: const [],
+          total: 0,
+          barcodeMaterial: barcodeMaterial,
+          selectedMode: mode,
+          summary: summary,
+        ),
+      );
+
+      final response = await _service.getInventoryByBarcode(
+        InventoryQueryRequest(
+          barcode: normalizedValue,
+          queryType: mode.apiCode,
+          pageIndex: targetPage,
+          pageSize: state.pageSize,
+        ),
+      );
+
+      final totalQuantity = response.rows.fold<double>(
+        0,
+        (previousValue, element) => previousValue + element.repqty,
+      );
+
+      final updatedSummary = summary.copyWith(totalQuantity: totalQuantity);
+
+      emit(
+        state.copyWith(
+          status: PageStatus.success,
+          barcodeMaterial: barcodeMaterial,
+          summary: updatedSummary,
+          records: response.rows,
+          total: response.total,
+          queryValue: normalizedValue,
+          currentPage: targetPage,
+          selectedMode: mode,
+          focusTick: state.focusTick + 1,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: PageStatus.failure,
+          errorMessage: ErrorHandler.handleError(error),
+          records: const [],
+          total: 0,
+          focusTick: state.focusTick + 1,
+        ),
+      );
+    }
+  }
+
+  InventoryQueryMode _resolveMode(String raw) {
+    final upper = raw.toUpperCase();
+    if (upper.contains('MC')) {
+      return InventoryQueryMode.material;
+    }
+    if (upper.contains(r'$KW$')) {
+      return InventoryQueryMode.storeSite;
+    }
+    if (upper.contains(r'$TP$')) {
+      return InventoryQueryMode.tray;
+    }
+    throw Exception('采集内容不合法');
+  }
+
+  String _extractByDelimiter(String raw, String emptyMessage) {
+    final segments = raw.split(r'$');
+    if (segments.length < 3 || segments[2].trim().isEmpty) {
+      throw Exception(emptyMessage);
+    }
+    return segments[2].trim();
+  }
+}

--- a/lib/modules/inventory_query/bloc/inventory_query_event.dart
+++ b/lib/modules/inventory_query/bloc/inventory_query_event.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../models/inventory_query_request.dart';
+
+part 'inventory_query_event.freezed.dart';
+
+@freezed
+class InventoryQueryEvent with _$InventoryQueryEvent {
+  const factory InventoryQueryEvent.initialized() = _Initialized;
+
+  const factory InventoryQueryEvent.barcodeScanned(String raw) =
+      _BarcodeScanned;
+
+  const factory InventoryQueryEvent.manualSubmitted({required String input}) =
+      _ManualSubmitted;
+
+  const factory InventoryQueryEvent.pageChanged(int pageIndex) = _PageChanged;
+
+  const factory InventoryQueryEvent.resetRequested() = _ResetRequested;
+
+  const factory InventoryQueryEvent.modeChanged(InventoryQueryMode mode) =
+      _ModeChanged;
+}

--- a/lib/modules/inventory_query/bloc/inventory_query_event.freezed.dart
+++ b/lib/modules/inventory_query/bloc/inventory_query_event.freezed.dart
@@ -1,0 +1,995 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_query_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$InventoryQueryEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String raw) barcodeScanned,
+    required TResult Function(String input) manualSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() resetRequested,
+    required TResult Function(InventoryQueryMode mode) modeChanged,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String raw)? barcodeScanned,
+    TResult? Function(String input)? manualSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? resetRequested,
+    TResult? Function(InventoryQueryMode mode)? modeChanged,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String raw)? barcodeScanned,
+    TResult Function(String input)? manualSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? resetRequested,
+    TResult Function(InventoryQueryMode mode)? modeChanged,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_BarcodeScanned value) barcodeScanned,
+    required TResult Function(_ManualSubmitted value) manualSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ResetRequested value) resetRequested,
+    required TResult Function(_ModeChanged value) modeChanged,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_BarcodeScanned value)? barcodeScanned,
+    TResult? Function(_ManualSubmitted value)? manualSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ResetRequested value)? resetRequested,
+    TResult? Function(_ModeChanged value)? modeChanged,
+  }) => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_BarcodeScanned value)? barcodeScanned,
+    TResult Function(_ManualSubmitted value)? manualSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ResetRequested value)? resetRequested,
+    TResult Function(_ModeChanged value)? modeChanged,
+    required TResult orElse(),
+  }) => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryQueryEventCopyWith<$Res> {
+  factory $InventoryQueryEventCopyWith(
+    InventoryQueryEvent value,
+    $Res Function(InventoryQueryEvent) then,
+  ) = _$InventoryQueryEventCopyWithImpl<$Res, InventoryQueryEvent>;
+}
+
+/// @nodoc
+class _$InventoryQueryEventCopyWithImpl<$Res, $Val extends InventoryQueryEvent>
+    implements $InventoryQueryEventCopyWith<$Res> {
+  _$InventoryQueryEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$InitializedImplCopyWith<$Res> {
+  factory _$$InitializedImplCopyWith(
+    _$InitializedImpl value,
+    $Res Function(_$InitializedImpl) then,
+  ) = __$$InitializedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$InitializedImplCopyWithImpl<$Res>
+    extends _$InventoryQueryEventCopyWithImpl<$Res, _$InitializedImpl>
+    implements _$$InitializedImplCopyWith<$Res> {
+  __$$InitializedImplCopyWithImpl(
+    _$InitializedImpl _value,
+    $Res Function(_$InitializedImpl) _then,
+  ) : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$InitializedImpl implements _Initialized {
+  const _$InitializedImpl();
+
+  @override
+  String toString() {
+    return 'InventoryQueryEvent.initialized()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$InitializedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String raw) barcodeScanned,
+    required TResult Function(String input) manualSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() resetRequested,
+    required TResult Function(InventoryQueryMode mode) modeChanged,
+  }) {
+    return initialized();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String raw)? barcodeScanned,
+    TResult? Function(String input)? manualSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? resetRequested,
+    TResult? Function(InventoryQueryMode mode)? modeChanged,
+  }) {
+    return initialized?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String raw)? barcodeScanned,
+    TResult Function(String input)? manualSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? resetRequested,
+    TResult Function(InventoryQueryMode mode)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_BarcodeScanned value) barcodeScanned,
+    required TResult Function(_ManualSubmitted value) manualSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ResetRequested value) resetRequested,
+    required TResult Function(_ModeChanged value) modeChanged,
+  }) {
+    return initialized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_BarcodeScanned value)? barcodeScanned,
+    TResult? Function(_ManualSubmitted value)? manualSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ResetRequested value)? resetRequested,
+    TResult? Function(_ModeChanged value)? modeChanged,
+  }) {
+    return initialized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_BarcodeScanned value)? barcodeScanned,
+    TResult Function(_ManualSubmitted value)? manualSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ResetRequested value)? resetRequested,
+    TResult Function(_ModeChanged value)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initialized implements InventoryQueryEvent {
+  const factory _Initialized() = _$InitializedImpl;
+}
+
+/// @nodoc
+abstract class _$$BarcodeScannedImplCopyWith<$Res> {
+  factory _$$BarcodeScannedImplCopyWith(
+    _$BarcodeScannedImpl value,
+    $Res Function(_$BarcodeScannedImpl) then,
+  ) = __$$BarcodeScannedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String raw});
+}
+
+/// @nodoc
+class __$$BarcodeScannedImplCopyWithImpl<$Res>
+    extends _$InventoryQueryEventCopyWithImpl<$Res, _$BarcodeScannedImpl>
+    implements _$$BarcodeScannedImplCopyWith<$Res> {
+  __$$BarcodeScannedImplCopyWithImpl(
+    _$BarcodeScannedImpl _value,
+    $Res Function(_$BarcodeScannedImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? raw = null}) {
+    return _then(
+      _$BarcodeScannedImpl(
+        null == raw
+            ? _value.raw
+            : raw // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$BarcodeScannedImpl implements _BarcodeScanned {
+  const _$BarcodeScannedImpl(this.raw);
+
+  @override
+  final String raw;
+
+  @override
+  String toString() {
+    return 'InventoryQueryEvent.barcodeScanned(raw: $raw)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BarcodeScannedImpl &&
+            (identical(other.raw, raw) || other.raw == raw));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, raw);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BarcodeScannedImplCopyWith<_$BarcodeScannedImpl> get copyWith =>
+      __$$BarcodeScannedImplCopyWithImpl<_$BarcodeScannedImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String raw) barcodeScanned,
+    required TResult Function(String input) manualSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() resetRequested,
+    required TResult Function(InventoryQueryMode mode) modeChanged,
+  }) {
+    return barcodeScanned(raw);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String raw)? barcodeScanned,
+    TResult? Function(String input)? manualSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? resetRequested,
+    TResult? Function(InventoryQueryMode mode)? modeChanged,
+  }) {
+    return barcodeScanned?.call(raw);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String raw)? barcodeScanned,
+    TResult Function(String input)? manualSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? resetRequested,
+    TResult Function(InventoryQueryMode mode)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (barcodeScanned != null) {
+      return barcodeScanned(raw);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_BarcodeScanned value) barcodeScanned,
+    required TResult Function(_ManualSubmitted value) manualSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ResetRequested value) resetRequested,
+    required TResult Function(_ModeChanged value) modeChanged,
+  }) {
+    return barcodeScanned(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_BarcodeScanned value)? barcodeScanned,
+    TResult? Function(_ManualSubmitted value)? manualSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ResetRequested value)? resetRequested,
+    TResult? Function(_ModeChanged value)? modeChanged,
+  }) {
+    return barcodeScanned?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_BarcodeScanned value)? barcodeScanned,
+    TResult Function(_ManualSubmitted value)? manualSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ResetRequested value)? resetRequested,
+    TResult Function(_ModeChanged value)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (barcodeScanned != null) {
+      return barcodeScanned(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _BarcodeScanned implements InventoryQueryEvent {
+  const factory _BarcodeScanned(final String raw) = _$BarcodeScannedImpl;
+
+  String get raw;
+  @JsonKey(ignore: true)
+  _$$BarcodeScannedImplCopyWith<_$BarcodeScannedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ManualSubmittedImplCopyWith<$Res> {
+  factory _$$ManualSubmittedImplCopyWith(
+    _$ManualSubmittedImpl value,
+    $Res Function(_$ManualSubmittedImpl) then,
+  ) = __$$ManualSubmittedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String input});
+}
+
+/// @nodoc
+class __$$ManualSubmittedImplCopyWithImpl<$Res>
+    extends _$InventoryQueryEventCopyWithImpl<$Res, _$ManualSubmittedImpl>
+    implements _$$ManualSubmittedImplCopyWith<$Res> {
+  __$$ManualSubmittedImplCopyWithImpl(
+    _$ManualSubmittedImpl _value,
+    $Res Function(_$ManualSubmittedImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? input = null}) {
+    return _then(
+      _$ManualSubmittedImpl(
+        input: null == input
+            ? _value.input
+            : input // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ManualSubmittedImpl implements _ManualSubmitted {
+  const _$ManualSubmittedImpl({required this.input});
+
+  @override
+  final String input;
+
+  @override
+  String toString() {
+    return 'InventoryQueryEvent.manualSubmitted(input: $input)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ManualSubmittedImpl &&
+            (identical(other.input, input) || other.input == input));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, input);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ManualSubmittedImplCopyWith<_$ManualSubmittedImpl> get copyWith =>
+      __$$ManualSubmittedImplCopyWithImpl<_$ManualSubmittedImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String raw) barcodeScanned,
+    required TResult Function(String input) manualSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() resetRequested,
+    required TResult Function(InventoryQueryMode mode) modeChanged,
+  }) {
+    return manualSubmitted(input);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String raw)? barcodeScanned,
+    TResult? Function(String input)? manualSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? resetRequested,
+    TResult? Function(InventoryQueryMode mode)? modeChanged,
+  }) {
+    return manualSubmitted?.call(input);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String raw)? barcodeScanned,
+    TResult Function(String input)? manualSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? resetRequested,
+    TResult Function(InventoryQueryMode mode)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (manualSubmitted != null) {
+      return manualSubmitted(input);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_BarcodeScanned value) barcodeScanned,
+    required TResult Function(_ManualSubmitted value) manualSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ResetRequested value) resetRequested,
+    required TResult Function(_ModeChanged value) modeChanged,
+  }) {
+    return manualSubmitted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_BarcodeScanned value)? barcodeScanned,
+    TResult? Function(_ManualSubmitted value)? manualSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ResetRequested value)? resetRequested,
+    TResult? Function(_ModeChanged value)? modeChanged,
+  }) {
+    return manualSubmitted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_BarcodeScanned value)? barcodeScanned,
+    TResult Function(_ManualSubmitted value)? manualSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ResetRequested value)? resetRequested,
+    TResult Function(_ModeChanged value)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (manualSubmitted != null) {
+      return manualSubmitted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ManualSubmitted implements InventoryQueryEvent {
+  const factory _ManualSubmitted({required final String input}) =
+      _$ManualSubmittedImpl;
+
+  String get input;
+  @JsonKey(ignore: true)
+  _$$ManualSubmittedImplCopyWith<_$ManualSubmittedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PageChangedImplCopyWith<$Res> {
+  factory _$$PageChangedImplCopyWith(
+    _$PageChangedImpl value,
+    $Res Function(_$PageChangedImpl) then,
+  ) = __$$PageChangedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({int pageIndex});
+}
+
+/// @nodoc
+class __$$PageChangedImplCopyWithImpl<$Res>
+    extends _$InventoryQueryEventCopyWithImpl<$Res, _$PageChangedImpl>
+    implements _$$PageChangedImplCopyWith<$Res> {
+  __$$PageChangedImplCopyWithImpl(
+    _$PageChangedImpl _value,
+    $Res Function(_$PageChangedImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? pageIndex = null}) {
+    return _then(
+      _$PageChangedImpl(
+        null == pageIndex
+            ? _value.pageIndex
+            : pageIndex // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$PageChangedImpl implements _PageChanged {
+  const _$PageChangedImpl(this.pageIndex);
+
+  @override
+  final int pageIndex;
+
+  @override
+  String toString() {
+    return 'InventoryQueryEvent.pageChanged(pageIndex: $pageIndex)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PageChangedImpl &&
+            (identical(other.pageIndex, pageIndex) ||
+                other.pageIndex == pageIndex));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, pageIndex);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      __$$PageChangedImplCopyWithImpl<_$PageChangedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String raw) barcodeScanned,
+    required TResult Function(String input) manualSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() resetRequested,
+    required TResult Function(InventoryQueryMode mode) modeChanged,
+  }) {
+    return pageChanged(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String raw)? barcodeScanned,
+    TResult? Function(String input)? manualSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? resetRequested,
+    TResult? Function(InventoryQueryMode mode)? modeChanged,
+  }) {
+    return pageChanged?.call(pageIndex);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String raw)? barcodeScanned,
+    TResult Function(String input)? manualSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? resetRequested,
+    TResult Function(InventoryQueryMode mode)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(pageIndex);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_BarcodeScanned value) barcodeScanned,
+    required TResult Function(_ManualSubmitted value) manualSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ResetRequested value) resetRequested,
+    required TResult Function(_ModeChanged value) modeChanged,
+  }) {
+    return pageChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_BarcodeScanned value)? barcodeScanned,
+    TResult? Function(_ManualSubmitted value)? manualSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ResetRequested value)? resetRequested,
+    TResult? Function(_ModeChanged value)? modeChanged,
+  }) {
+    return pageChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_BarcodeScanned value)? barcodeScanned,
+    TResult Function(_ManualSubmitted value)? manualSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ResetRequested value)? resetRequested,
+    TResult Function(_ModeChanged value)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (pageChanged != null) {
+      return pageChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _PageChanged implements InventoryQueryEvent {
+  const factory _PageChanged(final int pageIndex) = _$PageChangedImpl;
+
+  int get pageIndex;
+  @JsonKey(ignore: true)
+  _$$PageChangedImplCopyWith<_$PageChangedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ResetRequestedImplCopyWith<$Res> {
+  factory _$$ResetRequestedImplCopyWith(
+    _$ResetRequestedImpl value,
+    $Res Function(_$ResetRequestedImpl) then,
+  ) = __$$ResetRequestedImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$ResetRequestedImplCopyWithImpl<$Res>
+    extends _$InventoryQueryEventCopyWithImpl<$Res, _$ResetRequestedImpl>
+    implements _$$ResetRequestedImplCopyWith<$Res> {
+  __$$ResetRequestedImplCopyWithImpl(
+    _$ResetRequestedImpl _value,
+    $Res Function(_$ResetRequestedImpl) _then,
+  ) : super(_value, _then);
+}
+
+/// @nodoc
+
+class _$ResetRequestedImpl implements _ResetRequested {
+  const _$ResetRequestedImpl();
+
+  @override
+  String toString() {
+    return 'InventoryQueryEvent.resetRequested()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$ResetRequestedImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String raw) barcodeScanned,
+    required TResult Function(String input) manualSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() resetRequested,
+    required TResult Function(InventoryQueryMode mode) modeChanged,
+  }) {
+    return resetRequested();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String raw)? barcodeScanned,
+    TResult? Function(String input)? manualSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? resetRequested,
+    TResult? Function(InventoryQueryMode mode)? modeChanged,
+  }) {
+    return resetRequested?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String raw)? barcodeScanned,
+    TResult Function(String input)? manualSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? resetRequested,
+    TResult Function(InventoryQueryMode mode)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (resetRequested != null) {
+      return resetRequested();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_BarcodeScanned value) barcodeScanned,
+    required TResult Function(_ManualSubmitted value) manualSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ResetRequested value) resetRequested,
+    required TResult Function(_ModeChanged value) modeChanged,
+  }) {
+    return resetRequested(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_BarcodeScanned value)? barcodeScanned,
+    TResult? Function(_ManualSubmitted value)? manualSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ResetRequested value)? resetRequested,
+    TResult? Function(_ModeChanged value)? modeChanged,
+  }) {
+    return resetRequested?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_BarcodeScanned value)? barcodeScanned,
+    TResult Function(_ManualSubmitted value)? manualSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ResetRequested value)? resetRequested,
+    TResult Function(_ModeChanged value)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (resetRequested != null) {
+      return resetRequested(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ResetRequested implements InventoryQueryEvent {
+  const factory _ResetRequested() = _$ResetRequestedImpl;
+}
+
+/// @nodoc
+abstract class _$$ModeChangedImplCopyWith<$Res> {
+  factory _$$ModeChangedImplCopyWith(
+    _$ModeChangedImpl value,
+    $Res Function(_$ModeChangedImpl) then,
+  ) = __$$ModeChangedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({InventoryQueryMode mode});
+}
+
+/// @nodoc
+class __$$ModeChangedImplCopyWithImpl<$Res>
+    extends _$InventoryQueryEventCopyWithImpl<$Res, _$ModeChangedImpl>
+    implements _$$ModeChangedImplCopyWith<$Res> {
+  __$$ModeChangedImplCopyWithImpl(
+    _$ModeChangedImpl _value,
+    $Res Function(_$ModeChangedImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? mode = null}) {
+    return _then(
+      _$ModeChangedImpl(
+        null == mode
+            ? _value.mode
+            : mode // ignore: cast_nullable_to_non_nullable
+                  as InventoryQueryMode,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$ModeChangedImpl implements _ModeChanged {
+  const _$ModeChangedImpl(this.mode);
+
+  @override
+  final InventoryQueryMode mode;
+
+  @override
+  String toString() {
+    return 'InventoryQueryEvent.modeChanged(mode: $mode)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ModeChangedImpl &&
+            (identical(other.mode, mode) || other.mode == mode));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, mode);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ModeChangedImplCopyWith<_$ModeChangedImpl> get copyWith =>
+      __$$ModeChangedImplCopyWithImpl<_$ModeChangedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+    required TResult Function(String raw) barcodeScanned,
+    required TResult Function(String input) manualSubmitted,
+    required TResult Function(int pageIndex) pageChanged,
+    required TResult Function() resetRequested,
+    required TResult Function(InventoryQueryMode mode) modeChanged,
+  }) {
+    return modeChanged(mode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? initialized,
+    TResult? Function(String raw)? barcodeScanned,
+    TResult? Function(String input)? manualSubmitted,
+    TResult? Function(int pageIndex)? pageChanged,
+    TResult? Function()? resetRequested,
+    TResult? Function(InventoryQueryMode mode)? modeChanged,
+  }) {
+    return modeChanged?.call(mode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    TResult Function(String raw)? barcodeScanned,
+    TResult Function(String input)? manualSubmitted,
+    TResult Function(int pageIndex)? pageChanged,
+    TResult Function()? resetRequested,
+    TResult Function(InventoryQueryMode mode)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (modeChanged != null) {
+      return modeChanged(mode);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_BarcodeScanned value) barcodeScanned,
+    required TResult Function(_ManualSubmitted value) manualSubmitted,
+    required TResult Function(_PageChanged value) pageChanged,
+    required TResult Function(_ResetRequested value) resetRequested,
+    required TResult Function(_ModeChanged value) modeChanged,
+  }) {
+    return modeChanged(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initialized value)? initialized,
+    TResult? Function(_BarcodeScanned value)? barcodeScanned,
+    TResult? Function(_ManualSubmitted value)? manualSubmitted,
+    TResult? Function(_PageChanged value)? pageChanged,
+    TResult? Function(_ResetRequested value)? resetRequested,
+    TResult? Function(_ModeChanged value)? modeChanged,
+  }) {
+    return modeChanged?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_BarcodeScanned value)? barcodeScanned,
+    TResult Function(_ManualSubmitted value)? manualSubmitted,
+    TResult Function(_PageChanged value)? pageChanged,
+    TResult Function(_ResetRequested value)? resetRequested,
+    TResult Function(_ModeChanged value)? modeChanged,
+    required TResult orElse(),
+  }) {
+    if (modeChanged != null) {
+      return modeChanged(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ModeChanged implements InventoryQueryEvent {
+  const factory _ModeChanged(final InventoryQueryMode mode) = _$ModeChangedImpl;
+
+  InventoryQueryMode get mode;
+  @JsonKey(ignore: true)
+  _$$ModeChangedImplCopyWith<_$ModeChangedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_query/bloc/inventory_query_state.dart
+++ b/lib/modules/inventory_query/bloc/inventory_query_state.dart
@@ -1,0 +1,40 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../models/inventory_barcode_material.dart';
+import '../models/inventory_query_request.dart';
+import '../models/inventory_record.dart';
+import '../models/inventory_summary.dart';
+
+part 'inventory_query_state.freezed.dart';
+part 'inventory_query_state.g.dart';
+
+enum PageStatus { initial, loading, success, failure }
+
+@freezed
+class InventoryQueryState with _$InventoryQueryState {
+  const factory InventoryQueryState({
+    @Default(PageStatus.initial) PageStatus status,
+    InventoryBarcodeMaterial? barcodeMaterial,
+    @Default(InventorySummary()) InventorySummary summary,
+    @Default(<InventoryRecord>[]) List<InventoryRecord> records,
+    @Default(InventoryQueryMode.material) InventoryQueryMode selectedMode,
+    String? queryValue,
+    @Default(1) int currentPage,
+    @Default(10000) int pageSize,
+    @Default(0) int total,
+    String? errorMessage,
+    @Default(0) int focusTick,
+  }) = _InventoryQueryState;
+
+  const InventoryQueryState._();
+
+  factory InventoryQueryState.fromJson(Map<String, dynamic> json) =>
+      _$InventoryQueryStateFromJson(json);
+
+  int get totalPages {
+    if (total <= 0 || pageSize <= 0) return 1;
+    final pages = total ~/ pageSize;
+    final remainder = total % pageSize;
+    return remainder == 0 ? (pages == 0 ? 1 : pages) : pages + 1;
+  }
+}

--- a/lib/modules/inventory_query/bloc/inventory_query_state.freezed.dart
+++ b/lib/modules/inventory_query/bloc/inventory_query_state.freezed.dart
@@ -1,0 +1,436 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_query_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+InventoryQueryState _$InventoryQueryStateFromJson(Map<String, dynamic> json) {
+  return _InventoryQueryState.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryQueryState {
+  PageStatus get status => throw _privateConstructorUsedError;
+  InventoryBarcodeMaterial? get barcodeMaterial =>
+      throw _privateConstructorUsedError;
+  InventorySummary get summary => throw _privateConstructorUsedError;
+  List<InventoryRecord> get records => throw _privateConstructorUsedError;
+  InventoryQueryMode get selectedMode => throw _privateConstructorUsedError;
+  String? get queryValue => throw _privateConstructorUsedError;
+  int get currentPage => throw _privateConstructorUsedError;
+  int get pageSize => throw _privateConstructorUsedError;
+  int get total => throw _privateConstructorUsedError;
+  String? get errorMessage => throw _privateConstructorUsedError;
+  int get focusTick => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryQueryStateCopyWith<InventoryQueryState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryQueryStateCopyWith<$Res> {
+  factory $InventoryQueryStateCopyWith(
+    InventoryQueryState value,
+    $Res Function(InventoryQueryState) then,
+  ) = _$InventoryQueryStateCopyWithImpl<$Res, InventoryQueryState>;
+  @useResult
+  $Res call({
+    PageStatus status,
+    InventoryBarcodeMaterial? barcodeMaterial,
+    InventorySummary summary,
+    List<InventoryRecord> records,
+    InventoryQueryMode selectedMode,
+    String? queryValue,
+    int currentPage,
+    int pageSize,
+    int total,
+    String? errorMessage,
+    int focusTick,
+  });
+
+  $InventoryBarcodeMaterialCopyWith<$Res>? get barcodeMaterial;
+  $InventorySummaryCopyWith<$Res> get summary;
+}
+
+/// @nodoc
+class _$InventoryQueryStateCopyWithImpl<$Res, $Val extends InventoryQueryState>
+    implements $InventoryQueryStateCopyWith<$Res> {
+  _$InventoryQueryStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? barcodeMaterial = freezed,
+    Object? summary = null,
+    Object? records = null,
+    Object? selectedMode = null,
+    Object? queryValue = freezed,
+    Object? currentPage = null,
+    Object? pageSize = null,
+    Object? total = null,
+    Object? errorMessage = freezed,
+    Object? focusTick = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            status: null == status
+                ? _value.status
+                : status // ignore: cast_nullable_to_non_nullable
+                      as PageStatus,
+            barcodeMaterial: freezed == barcodeMaterial
+                ? _value.barcodeMaterial
+                : barcodeMaterial // ignore: cast_nullable_to_non_nullable
+                      as InventoryBarcodeMaterial?,
+            summary: null == summary
+                ? _value.summary
+                : summary // ignore: cast_nullable_to_non_nullable
+                      as InventorySummary,
+            records: null == records
+                ? _value.records
+                : records // ignore: cast_nullable_to_non_nullable
+                      as List<InventoryRecord>,
+            selectedMode: null == selectedMode
+                ? _value.selectedMode
+                : selectedMode // ignore: cast_nullable_to_non_nullable
+                      as InventoryQueryMode,
+            queryValue: freezed == queryValue
+                ? _value.queryValue
+                : queryValue // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            currentPage: null == currentPage
+                ? _value.currentPage
+                : currentPage // ignore: cast_nullable_to_non_nullable
+                      as int,
+            pageSize: null == pageSize
+                ? _value.pageSize
+                : pageSize // ignore: cast_nullable_to_non_nullable
+                      as int,
+            total: null == total
+                ? _value.total
+                : total // ignore: cast_nullable_to_non_nullable
+                      as int,
+            errorMessage: freezed == errorMessage
+                ? _value.errorMessage
+                : errorMessage // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            focusTick: null == focusTick
+                ? _value.focusTick
+                : focusTick // ignore: cast_nullable_to_non_nullable
+                      as int,
+          )
+          as $Val,
+    );
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventoryBarcodeMaterialCopyWith<$Res>? get barcodeMaterial {
+    if (_value.barcodeMaterial == null) {
+      return null;
+    }
+
+    return $InventoryBarcodeMaterialCopyWith<$Res>(_value.barcodeMaterial!, (
+      value,
+    ) {
+      return _then(_value.copyWith(barcodeMaterial: value) as $Val);
+    });
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $InventorySummaryCopyWith<$Res> get summary {
+    return $InventorySummaryCopyWith<$Res>(_value.summary, (value) {
+      return _then(_value.copyWith(summary: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryQueryStateImplCopyWith<$Res>
+    implements $InventoryQueryStateCopyWith<$Res> {
+  factory _$$InventoryQueryStateImplCopyWith(
+    _$InventoryQueryStateImpl value,
+    $Res Function(_$InventoryQueryStateImpl) then,
+  ) = __$$InventoryQueryStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    PageStatus status,
+    InventoryBarcodeMaterial? barcodeMaterial,
+    InventorySummary summary,
+    List<InventoryRecord> records,
+    InventoryQueryMode selectedMode,
+    String? queryValue,
+    int currentPage,
+    int pageSize,
+    int total,
+    String? errorMessage,
+    int focusTick,
+  });
+
+  @override
+  $InventoryBarcodeMaterialCopyWith<$Res>? get barcodeMaterial;
+  @override
+  $InventorySummaryCopyWith<$Res> get summary;
+}
+
+/// @nodoc
+class __$$InventoryQueryStateImplCopyWithImpl<$Res>
+    extends _$InventoryQueryStateCopyWithImpl<$Res, _$InventoryQueryStateImpl>
+    implements _$$InventoryQueryStateImplCopyWith<$Res> {
+  __$$InventoryQueryStateImplCopyWithImpl(
+    _$InventoryQueryStateImpl _value,
+    $Res Function(_$InventoryQueryStateImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? barcodeMaterial = freezed,
+    Object? summary = null,
+    Object? records = null,
+    Object? selectedMode = null,
+    Object? queryValue = freezed,
+    Object? currentPage = null,
+    Object? pageSize = null,
+    Object? total = null,
+    Object? errorMessage = freezed,
+    Object? focusTick = null,
+  }) {
+    return _then(
+      _$InventoryQueryStateImpl(
+        status: null == status
+            ? _value.status
+            : status // ignore: cast_nullable_to_non_nullable
+                  as PageStatus,
+        barcodeMaterial: freezed == barcodeMaterial
+            ? _value.barcodeMaterial
+            : barcodeMaterial // ignore: cast_nullable_to_non_nullable
+                  as InventoryBarcodeMaterial?,
+        summary: null == summary
+            ? _value.summary
+            : summary // ignore: cast_nullable_to_non_nullable
+                  as InventorySummary,
+        records: null == records
+            ? _value._records
+            : records // ignore: cast_nullable_to_non_nullable
+                  as List<InventoryRecord>,
+        selectedMode: null == selectedMode
+            ? _value.selectedMode
+            : selectedMode // ignore: cast_nullable_to_non_nullable
+                  as InventoryQueryMode,
+        queryValue: freezed == queryValue
+            ? _value.queryValue
+            : queryValue // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        currentPage: null == currentPage
+            ? _value.currentPage
+            : currentPage // ignore: cast_nullable_to_non_nullable
+                  as int,
+        pageSize: null == pageSize
+            ? _value.pageSize
+            : pageSize // ignore: cast_nullable_to_non_nullable
+                  as int,
+        total: null == total
+            ? _value.total
+            : total // ignore: cast_nullable_to_non_nullable
+                  as int,
+        errorMessage: freezed == errorMessage
+            ? _value.errorMessage
+            : errorMessage // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        focusTick: null == focusTick
+            ? _value.focusTick
+            : focusTick // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryQueryStateImpl extends _InventoryQueryState {
+  const _$InventoryQueryStateImpl({
+    this.status = PageStatus.initial,
+    this.barcodeMaterial,
+    this.summary = const InventorySummary(),
+    final List<InventoryRecord> records = const <InventoryRecord>[],
+    this.selectedMode = InventoryQueryMode.material,
+    this.queryValue,
+    this.currentPage = 1,
+    this.pageSize = 10000,
+    this.total = 0,
+    this.errorMessage,
+    this.focusTick = 0,
+  }) : _records = records,
+       super._();
+
+  factory _$InventoryQueryStateImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryQueryStateImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final PageStatus status;
+  @override
+  final InventoryBarcodeMaterial? barcodeMaterial;
+  @override
+  @JsonKey()
+  final InventorySummary summary;
+  final List<InventoryRecord> _records;
+  @override
+  @JsonKey()
+  List<InventoryRecord> get records {
+    if (_records is EqualUnmodifiableListView) return _records;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_records);
+  }
+
+  @override
+  @JsonKey()
+  final InventoryQueryMode selectedMode;
+  @override
+  final String? queryValue;
+  @override
+  @JsonKey()
+  final int currentPage;
+  @override
+  @JsonKey()
+  final int pageSize;
+  @override
+  @JsonKey()
+  final int total;
+  @override
+  final String? errorMessage;
+  @override
+  @JsonKey()
+  final int focusTick;
+
+  @override
+  String toString() {
+    return 'InventoryQueryState(status: $status, barcodeMaterial: $barcodeMaterial, summary: $summary, records: $records, selectedMode: $selectedMode, queryValue: $queryValue, currentPage: $currentPage, pageSize: $pageSize, total: $total, errorMessage: $errorMessage, focusTick: $focusTick)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryQueryStateImpl &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.barcodeMaterial, barcodeMaterial) ||
+                other.barcodeMaterial == barcodeMaterial) &&
+            (identical(other.summary, summary) || other.summary == summary) &&
+            const DeepCollectionEquality().equals(other._records, _records) &&
+            (identical(other.selectedMode, selectedMode) ||
+                other.selectedMode == selectedMode) &&
+            (identical(other.queryValue, queryValue) ||
+                other.queryValue == queryValue) &&
+            (identical(other.currentPage, currentPage) ||
+                other.currentPage == currentPage) &&
+            (identical(other.pageSize, pageSize) ||
+                other.pageSize == pageSize) &&
+            (identical(other.total, total) || other.total == total) &&
+            (identical(other.errorMessage, errorMessage) ||
+                other.errorMessage == errorMessage) &&
+            (identical(other.focusTick, focusTick) ||
+                other.focusTick == focusTick));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    status,
+    barcodeMaterial,
+    summary,
+    const DeepCollectionEquality().hash(_records),
+    selectedMode,
+    queryValue,
+    currentPage,
+    pageSize,
+    total,
+    errorMessage,
+    focusTick,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryQueryStateImplCopyWith<_$InventoryQueryStateImpl> get copyWith =>
+      __$$InventoryQueryStateImplCopyWithImpl<_$InventoryQueryStateImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryQueryStateImplToJson(this);
+  }
+}
+
+abstract class _InventoryQueryState extends InventoryQueryState {
+  const factory _InventoryQueryState({
+    final PageStatus status,
+    final InventoryBarcodeMaterial? barcodeMaterial,
+    final InventorySummary summary,
+    final List<InventoryRecord> records,
+    final InventoryQueryMode selectedMode,
+    final String? queryValue,
+    final int currentPage,
+    final int pageSize,
+    final int total,
+    final String? errorMessage,
+    final int focusTick,
+  }) = _$InventoryQueryStateImpl;
+  const _InventoryQueryState._() : super._();
+
+  factory _InventoryQueryState.fromJson(Map<String, dynamic> json) =
+      _$InventoryQueryStateImpl.fromJson;
+
+  @override
+  PageStatus get status;
+  @override
+  InventoryBarcodeMaterial? get barcodeMaterial;
+  @override
+  InventorySummary get summary;
+  @override
+  List<InventoryRecord> get records;
+  @override
+  InventoryQueryMode get selectedMode;
+  @override
+  String? get queryValue;
+  @override
+  int get currentPage;
+  @override
+  int get pageSize;
+  @override
+  int get total;
+  @override
+  String? get errorMessage;
+  @override
+  int get focusTick;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryQueryStateImplCopyWith<_$InventoryQueryStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_query/bloc/inventory_query_state.g.dart
+++ b/lib/modules/inventory_query/bloc/inventory_query_state.g.dart
@@ -1,0 +1,66 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_query_state.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryQueryStateImpl _$$InventoryQueryStateImplFromJson(
+  Map<String, dynamic> json,
+) => _$InventoryQueryStateImpl(
+  status:
+      $enumDecodeNullable(_$PageStatusEnumMap, json['status']) ??
+      PageStatus.initial,
+  barcodeMaterial: json['barcodeMaterial'] == null
+      ? null
+      : InventoryBarcodeMaterial.fromJson(
+          json['barcodeMaterial'] as Map<String, dynamic>,
+        ),
+  summary: json['summary'] == null
+      ? const InventorySummary()
+      : InventorySummary.fromJson(json['summary'] as Map<String, dynamic>),
+  records:
+      (json['records'] as List<dynamic>?)
+          ?.map((e) => InventoryRecord.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <InventoryRecord>[],
+  selectedMode:
+      $enumDecodeNullable(_$InventoryQueryModeEnumMap, json['selectedMode']) ??
+      InventoryQueryMode.material,
+  queryValue: json['queryValue'] as String?,
+  currentPage: (json['currentPage'] as num?)?.toInt() ?? 1,
+  pageSize: (json['pageSize'] as num?)?.toInt() ?? 10000,
+  total: (json['total'] as num?)?.toInt() ?? 0,
+  errorMessage: json['errorMessage'] as String?,
+  focusTick: (json['focusTick'] as num?)?.toInt() ?? 0,
+);
+
+Map<String, dynamic> _$$InventoryQueryStateImplToJson(
+  _$InventoryQueryStateImpl instance,
+) => <String, dynamic>{
+  'status': _$PageStatusEnumMap[instance.status]!,
+  'barcodeMaterial': instance.barcodeMaterial,
+  'summary': instance.summary,
+  'records': instance.records,
+  'selectedMode': _$InventoryQueryModeEnumMap[instance.selectedMode]!,
+  'queryValue': instance.queryValue,
+  'currentPage': instance.currentPage,
+  'pageSize': instance.pageSize,
+  'total': instance.total,
+  'errorMessage': instance.errorMessage,
+  'focusTick': instance.focusTick,
+};
+
+const _$PageStatusEnumMap = {
+  PageStatus.initial: 'initial',
+  PageStatus.loading: 'loading',
+  PageStatus.success: 'success',
+  PageStatus.failure: 'failure',
+};
+
+const _$InventoryQueryModeEnumMap = {
+  InventoryQueryMode.material: 'material',
+  InventoryQueryMode.storeSite: 'storeSite',
+  InventoryQueryMode.tray: 'tray',
+};

--- a/lib/modules/inventory_query/inventory_query_module.dart
+++ b/lib/modules/inventory_query/inventory_query_module.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../app_module.dart';
+import '../../services/dio_client.dart';
+import 'bloc/inventory_query_bloc.dart';
+import 'pages/inventory_query_page.dart';
+import 'services/inventory_query_service.dart';
+
+class InventoryQueryModule extends Module {
+  @override
+  List<Module> get imports => [AppModule()];
+
+  @override
+  void binds(Injector i) {
+    i.addSingleton<InventoryQueryService>(
+      () => InventoryQueryService(i.get<DioClient>().dio),
+    );
+
+    i.add<InventoryQueryBloc>(
+      () => InventoryQueryBloc(service: i.get<InventoryQueryService>()),
+    );
+  }
+
+  @override
+  void routes(RouteManager r) {
+    r.child(
+      '/',
+      child: (_) => BlocProvider(
+        create: (_) => Modular.get<InventoryQueryBloc>(),
+        child: const InventoryQueryPage(),
+      ),
+    );
+  }
+}

--- a/lib/modules/inventory_query/inventory_query_routes.dart
+++ b/lib/modules/inventory_query/inventory_query_routes.dart
@@ -1,0 +1,4 @@
+class InventoryQueryRoutes {
+  static const module = '/inventory-query';
+  static const entry = '$module/';
+}

--- a/lib/modules/inventory_query/models/inventory_barcode_material.dart
+++ b/lib/modules/inventory_query/models/inventory_barcode_material.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_barcode_material.freezed.dart';
+part 'inventory_barcode_material.g.dart';
+
+/// 解析条码后的物料信息。
+@freezed
+class InventoryBarcodeMaterial with _$InventoryBarcodeMaterial {
+  const factory InventoryBarcodeMaterial({
+    @Default('') String matcode,
+    @Default('') String matname,
+    @Default('') String qty,
+    @Default('') String batchno,
+    @Default('') String sn,
+    @Default('') String pdate,
+    @Default('') String vdays,
+    @Default('') String seqctrl,
+    @JsonKey(name: 'id_old') @Default('') String idOld,
+  }) = _InventoryBarcodeMaterial;
+
+  factory InventoryBarcodeMaterial.fromJson(Map<String, dynamic> json) =>
+      _$InventoryBarcodeMaterialFromJson(json);
+}

--- a/lib/modules/inventory_query/models/inventory_barcode_material.freezed.dart
+++ b/lib/modules/inventory_query/models/inventory_barcode_material.freezed.dart
@@ -1,0 +1,360 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_barcode_material.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+InventoryBarcodeMaterial _$InventoryBarcodeMaterialFromJson(
+  Map<String, dynamic> json,
+) {
+  return _InventoryBarcodeMaterial.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryBarcodeMaterial {
+  String get matcode => throw _privateConstructorUsedError;
+  String get matname => throw _privateConstructorUsedError;
+  String get qty => throw _privateConstructorUsedError;
+  String get batchno => throw _privateConstructorUsedError;
+  String get sn => throw _privateConstructorUsedError;
+  String get pdate => throw _privateConstructorUsedError;
+  String get vdays => throw _privateConstructorUsedError;
+  String get seqctrl => throw _privateConstructorUsedError;
+  @JsonKey(name: 'id_old')
+  String get idOld => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryBarcodeMaterialCopyWith<InventoryBarcodeMaterial> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryBarcodeMaterialCopyWith<$Res> {
+  factory $InventoryBarcodeMaterialCopyWith(
+    InventoryBarcodeMaterial value,
+    $Res Function(InventoryBarcodeMaterial) then,
+  ) = _$InventoryBarcodeMaterialCopyWithImpl<$Res, InventoryBarcodeMaterial>;
+  @useResult
+  $Res call({
+    String matcode,
+    String matname,
+    String qty,
+    String batchno,
+    String sn,
+    String pdate,
+    String vdays,
+    String seqctrl,
+    @JsonKey(name: 'id_old') String idOld,
+  });
+}
+
+/// @nodoc
+class _$InventoryBarcodeMaterialCopyWithImpl<
+  $Res,
+  $Val extends InventoryBarcodeMaterial
+>
+    implements $InventoryBarcodeMaterialCopyWith<$Res> {
+  _$InventoryBarcodeMaterialCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? matcode = null,
+    Object? matname = null,
+    Object? qty = null,
+    Object? batchno = null,
+    Object? sn = null,
+    Object? pdate = null,
+    Object? vdays = null,
+    Object? seqctrl = null,
+    Object? idOld = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            matcode: null == matcode
+                ? _value.matcode
+                : matcode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            matname: null == matname
+                ? _value.matname
+                : matname // ignore: cast_nullable_to_non_nullable
+                      as String,
+            qty: null == qty
+                ? _value.qty
+                : qty // ignore: cast_nullable_to_non_nullable
+                      as String,
+            batchno: null == batchno
+                ? _value.batchno
+                : batchno // ignore: cast_nullable_to_non_nullable
+                      as String,
+            sn: null == sn
+                ? _value.sn
+                : sn // ignore: cast_nullable_to_non_nullable
+                      as String,
+            pdate: null == pdate
+                ? _value.pdate
+                : pdate // ignore: cast_nullable_to_non_nullable
+                      as String,
+            vdays: null == vdays
+                ? _value.vdays
+                : vdays // ignore: cast_nullable_to_non_nullable
+                      as String,
+            seqctrl: null == seqctrl
+                ? _value.seqctrl
+                : seqctrl // ignore: cast_nullable_to_non_nullable
+                      as String,
+            idOld: null == idOld
+                ? _value.idOld
+                : idOld // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryBarcodeMaterialImplCopyWith<$Res>
+    implements $InventoryBarcodeMaterialCopyWith<$Res> {
+  factory _$$InventoryBarcodeMaterialImplCopyWith(
+    _$InventoryBarcodeMaterialImpl value,
+    $Res Function(_$InventoryBarcodeMaterialImpl) then,
+  ) = __$$InventoryBarcodeMaterialImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String matcode,
+    String matname,
+    String qty,
+    String batchno,
+    String sn,
+    String pdate,
+    String vdays,
+    String seqctrl,
+    @JsonKey(name: 'id_old') String idOld,
+  });
+}
+
+/// @nodoc
+class __$$InventoryBarcodeMaterialImplCopyWithImpl<$Res>
+    extends
+        _$InventoryBarcodeMaterialCopyWithImpl<
+          $Res,
+          _$InventoryBarcodeMaterialImpl
+        >
+    implements _$$InventoryBarcodeMaterialImplCopyWith<$Res> {
+  __$$InventoryBarcodeMaterialImplCopyWithImpl(
+    _$InventoryBarcodeMaterialImpl _value,
+    $Res Function(_$InventoryBarcodeMaterialImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? matcode = null,
+    Object? matname = null,
+    Object? qty = null,
+    Object? batchno = null,
+    Object? sn = null,
+    Object? pdate = null,
+    Object? vdays = null,
+    Object? seqctrl = null,
+    Object? idOld = null,
+  }) {
+    return _then(
+      _$InventoryBarcodeMaterialImpl(
+        matcode: null == matcode
+            ? _value.matcode
+            : matcode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        matname: null == matname
+            ? _value.matname
+            : matname // ignore: cast_nullable_to_non_nullable
+                  as String,
+        qty: null == qty
+            ? _value.qty
+            : qty // ignore: cast_nullable_to_non_nullable
+                  as String,
+        batchno: null == batchno
+            ? _value.batchno
+            : batchno // ignore: cast_nullable_to_non_nullable
+                  as String,
+        sn: null == sn
+            ? _value.sn
+            : sn // ignore: cast_nullable_to_non_nullable
+                  as String,
+        pdate: null == pdate
+            ? _value.pdate
+            : pdate // ignore: cast_nullable_to_non_nullable
+                  as String,
+        vdays: null == vdays
+            ? _value.vdays
+            : vdays // ignore: cast_nullable_to_non_nullable
+                  as String,
+        seqctrl: null == seqctrl
+            ? _value.seqctrl
+            : seqctrl // ignore: cast_nullable_to_non_nullable
+                  as String,
+        idOld: null == idOld
+            ? _value.idOld
+            : idOld // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryBarcodeMaterialImpl implements _InventoryBarcodeMaterial {
+  const _$InventoryBarcodeMaterialImpl({
+    this.matcode = '',
+    this.matname = '',
+    this.qty = '',
+    this.batchno = '',
+    this.sn = '',
+    this.pdate = '',
+    this.vdays = '',
+    this.seqctrl = '',
+    @JsonKey(name: 'id_old') this.idOld = '',
+  });
+
+  factory _$InventoryBarcodeMaterialImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryBarcodeMaterialImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final String matcode;
+  @override
+  @JsonKey()
+  final String matname;
+  @override
+  @JsonKey()
+  final String qty;
+  @override
+  @JsonKey()
+  final String batchno;
+  @override
+  @JsonKey()
+  final String sn;
+  @override
+  @JsonKey()
+  final String pdate;
+  @override
+  @JsonKey()
+  final String vdays;
+  @override
+  @JsonKey()
+  final String seqctrl;
+  @override
+  @JsonKey(name: 'id_old')
+  final String idOld;
+
+  @override
+  String toString() {
+    return 'InventoryBarcodeMaterial(matcode: $matcode, matname: $matname, qty: $qty, batchno: $batchno, sn: $sn, pdate: $pdate, vdays: $vdays, seqctrl: $seqctrl, idOld: $idOld)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryBarcodeMaterialImpl &&
+            (identical(other.matcode, matcode) || other.matcode == matcode) &&
+            (identical(other.matname, matname) || other.matname == matname) &&
+            (identical(other.qty, qty) || other.qty == qty) &&
+            (identical(other.batchno, batchno) || other.batchno == batchno) &&
+            (identical(other.sn, sn) || other.sn == sn) &&
+            (identical(other.pdate, pdate) || other.pdate == pdate) &&
+            (identical(other.vdays, vdays) || other.vdays == vdays) &&
+            (identical(other.seqctrl, seqctrl) || other.seqctrl == seqctrl) &&
+            (identical(other.idOld, idOld) || other.idOld == idOld));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    matcode,
+    matname,
+    qty,
+    batchno,
+    sn,
+    pdate,
+    vdays,
+    seqctrl,
+    idOld,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryBarcodeMaterialImplCopyWith<_$InventoryBarcodeMaterialImpl>
+  get copyWith =>
+      __$$InventoryBarcodeMaterialImplCopyWithImpl<
+        _$InventoryBarcodeMaterialImpl
+      >(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryBarcodeMaterialImplToJson(this);
+  }
+}
+
+abstract class _InventoryBarcodeMaterial implements InventoryBarcodeMaterial {
+  const factory _InventoryBarcodeMaterial({
+    final String matcode,
+    final String matname,
+    final String qty,
+    final String batchno,
+    final String sn,
+    final String pdate,
+    final String vdays,
+    final String seqctrl,
+    @JsonKey(name: 'id_old') final String idOld,
+  }) = _$InventoryBarcodeMaterialImpl;
+
+  factory _InventoryBarcodeMaterial.fromJson(Map<String, dynamic> json) =
+      _$InventoryBarcodeMaterialImpl.fromJson;
+
+  @override
+  String get matcode;
+  @override
+  String get matname;
+  @override
+  String get qty;
+  @override
+  String get batchno;
+  @override
+  String get sn;
+  @override
+  String get pdate;
+  @override
+  String get vdays;
+  @override
+  String get seqctrl;
+  @override
+  @JsonKey(name: 'id_old')
+  String get idOld;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryBarcodeMaterialImplCopyWith<_$InventoryBarcodeMaterialImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_query/models/inventory_barcode_material.g.dart
+++ b/lib/modules/inventory_query/models/inventory_barcode_material.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_barcode_material.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryBarcodeMaterialImpl _$$InventoryBarcodeMaterialImplFromJson(
+  Map<String, dynamic> json,
+) => _$InventoryBarcodeMaterialImpl(
+  matcode: json['matcode'] as String? ?? '',
+  matname: json['matname'] as String? ?? '',
+  qty: json['qty'] as String? ?? '',
+  batchno: json['batchno'] as String? ?? '',
+  sn: json['sn'] as String? ?? '',
+  pdate: json['pdate'] as String? ?? '',
+  vdays: json['vdays'] as String? ?? '',
+  seqctrl: json['seqctrl'] as String? ?? '',
+  idOld: json['id_old'] as String? ?? '',
+);
+
+Map<String, dynamic> _$$InventoryBarcodeMaterialImplToJson(
+  _$InventoryBarcodeMaterialImpl instance,
+) => <String, dynamic>{
+  'matcode': instance.matcode,
+  'matname': instance.matname,
+  'qty': instance.qty,
+  'batchno': instance.batchno,
+  'sn': instance.sn,
+  'pdate': instance.pdate,
+  'vdays': instance.vdays,
+  'seqctrl': instance.seqctrl,
+  'id_old': instance.idOld,
+};

--- a/lib/modules/inventory_query/models/inventory_query_request.dart
+++ b/lib/modules/inventory_query/models/inventory_query_request.dart
@@ -1,0 +1,54 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_query_request.freezed.dart';
+part 'inventory_query_request.g.dart';
+
+/// 请求库存查询的参数模型。
+@freezed
+class InventoryQueryRequest with _$InventoryQueryRequest {
+  const factory InventoryQueryRequest({
+    /// 查询条件，物料/库位/托盘均通过 barcode 字段传递。
+    @JsonKey(name: 'barcode') required String barcode,
+
+    /// 查询类型，M=物料，S=库位，P=托盘。
+    @JsonKey(name: 'currStep') required String queryType,
+
+    /// 页码（后端接口使用大写字段名）。
+    @JsonKey(name: 'PageIndex') @Default(1) int pageIndex,
+
+    /// 页大小（后端接口使用大写字段名）。
+    @JsonKey(name: 'PageSize') @Default(10000) int pageSize,
+  }) = _InventoryQueryRequest;
+
+  const InventoryQueryRequest._();
+
+  factory InventoryQueryRequest.fromJson(Map<String, dynamic> json) =>
+      _$InventoryQueryRequestFromJson(json);
+}
+
+/// 查询类型的枚举，便于在 BLoC 与 UI 层之间传递。
+enum InventoryQueryMode { material, storeSite, tray }
+
+extension InventoryQueryModeX on InventoryQueryMode {
+  String get apiCode {
+    switch (this) {
+      case InventoryQueryMode.material:
+        return 'M';
+      case InventoryQueryMode.storeSite:
+        return 'S';
+      case InventoryQueryMode.tray:
+        return 'P';
+    }
+  }
+
+  String get displayName {
+    switch (this) {
+      case InventoryQueryMode.material:
+        return '物料';
+      case InventoryQueryMode.storeSite:
+        return '库位';
+      case InventoryQueryMode.tray:
+        return '托盘';
+    }
+  }
+}

--- a/lib/modules/inventory_query/models/inventory_query_request.freezed.dart
+++ b/lib/modules/inventory_query/models/inventory_query_request.freezed.dart
@@ -1,0 +1,271 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_query_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+InventoryQueryRequest _$InventoryQueryRequestFromJson(
+  Map<String, dynamic> json,
+) {
+  return _InventoryQueryRequest.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryQueryRequest {
+  /// 查询条件，物料/库位/托盘均通过 barcode 字段传递。
+  @JsonKey(name: 'barcode')
+  String get barcode => throw _privateConstructorUsedError;
+
+  /// 查询类型，M=物料，S=库位，P=托盘。
+  @JsonKey(name: 'currStep')
+  String get queryType => throw _privateConstructorUsedError;
+
+  /// 页码（后端接口使用大写字段名）。
+  @JsonKey(name: 'PageIndex')
+  int get pageIndex => throw _privateConstructorUsedError;
+
+  /// 页大小（后端接口使用大写字段名）。
+  @JsonKey(name: 'PageSize')
+  int get pageSize => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryQueryRequestCopyWith<InventoryQueryRequest> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryQueryRequestCopyWith<$Res> {
+  factory $InventoryQueryRequestCopyWith(
+    InventoryQueryRequest value,
+    $Res Function(InventoryQueryRequest) then,
+  ) = _$InventoryQueryRequestCopyWithImpl<$Res, InventoryQueryRequest>;
+  @useResult
+  $Res call({
+    @JsonKey(name: 'barcode') String barcode,
+    @JsonKey(name: 'currStep') String queryType,
+    @JsonKey(name: 'PageIndex') int pageIndex,
+    @JsonKey(name: 'PageSize') int pageSize,
+  });
+}
+
+/// @nodoc
+class _$InventoryQueryRequestCopyWithImpl<
+  $Res,
+  $Val extends InventoryQueryRequest
+>
+    implements $InventoryQueryRequestCopyWith<$Res> {
+  _$InventoryQueryRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? barcode = null,
+    Object? queryType = null,
+    Object? pageIndex = null,
+    Object? pageSize = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            barcode: null == barcode
+                ? _value.barcode
+                : barcode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            queryType: null == queryType
+                ? _value.queryType
+                : queryType // ignore: cast_nullable_to_non_nullable
+                      as String,
+            pageIndex: null == pageIndex
+                ? _value.pageIndex
+                : pageIndex // ignore: cast_nullable_to_non_nullable
+                      as int,
+            pageSize: null == pageSize
+                ? _value.pageSize
+                : pageSize // ignore: cast_nullable_to_non_nullable
+                      as int,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryQueryRequestImplCopyWith<$Res>
+    implements $InventoryQueryRequestCopyWith<$Res> {
+  factory _$$InventoryQueryRequestImplCopyWith(
+    _$InventoryQueryRequestImpl value,
+    $Res Function(_$InventoryQueryRequestImpl) then,
+  ) = __$$InventoryQueryRequestImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    @JsonKey(name: 'barcode') String barcode,
+    @JsonKey(name: 'currStep') String queryType,
+    @JsonKey(name: 'PageIndex') int pageIndex,
+    @JsonKey(name: 'PageSize') int pageSize,
+  });
+}
+
+/// @nodoc
+class __$$InventoryQueryRequestImplCopyWithImpl<$Res>
+    extends
+        _$InventoryQueryRequestCopyWithImpl<$Res, _$InventoryQueryRequestImpl>
+    implements _$$InventoryQueryRequestImplCopyWith<$Res> {
+  __$$InventoryQueryRequestImplCopyWithImpl(
+    _$InventoryQueryRequestImpl _value,
+    $Res Function(_$InventoryQueryRequestImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? barcode = null,
+    Object? queryType = null,
+    Object? pageIndex = null,
+    Object? pageSize = null,
+  }) {
+    return _then(
+      _$InventoryQueryRequestImpl(
+        barcode: null == barcode
+            ? _value.barcode
+            : barcode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        queryType: null == queryType
+            ? _value.queryType
+            : queryType // ignore: cast_nullable_to_non_nullable
+                  as String,
+        pageIndex: null == pageIndex
+            ? _value.pageIndex
+            : pageIndex // ignore: cast_nullable_to_non_nullable
+                  as int,
+        pageSize: null == pageSize
+            ? _value.pageSize
+            : pageSize // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryQueryRequestImpl extends _InventoryQueryRequest {
+  const _$InventoryQueryRequestImpl({
+    @JsonKey(name: 'barcode') required this.barcode,
+    @JsonKey(name: 'currStep') required this.queryType,
+    @JsonKey(name: 'PageIndex') this.pageIndex = 1,
+    @JsonKey(name: 'PageSize') this.pageSize = 10000,
+  }) : super._();
+
+  factory _$InventoryQueryRequestImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryQueryRequestImplFromJson(json);
+
+  /// 查询条件，物料/库位/托盘均通过 barcode 字段传递。
+  @override
+  @JsonKey(name: 'barcode')
+  final String barcode;
+
+  /// 查询类型，M=物料，S=库位，P=托盘。
+  @override
+  @JsonKey(name: 'currStep')
+  final String queryType;
+
+  /// 页码（后端接口使用大写字段名）。
+  @override
+  @JsonKey(name: 'PageIndex')
+  final int pageIndex;
+
+  /// 页大小（后端接口使用大写字段名）。
+  @override
+  @JsonKey(name: 'PageSize')
+  final int pageSize;
+
+  @override
+  String toString() {
+    return 'InventoryQueryRequest(barcode: $barcode, queryType: $queryType, pageIndex: $pageIndex, pageSize: $pageSize)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryQueryRequestImpl &&
+            (identical(other.barcode, barcode) || other.barcode == barcode) &&
+            (identical(other.queryType, queryType) ||
+                other.queryType == queryType) &&
+            (identical(other.pageIndex, pageIndex) ||
+                other.pageIndex == pageIndex) &&
+            (identical(other.pageSize, pageSize) ||
+                other.pageSize == pageSize));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, barcode, queryType, pageIndex, pageSize);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryQueryRequestImplCopyWith<_$InventoryQueryRequestImpl>
+  get copyWith =>
+      __$$InventoryQueryRequestImplCopyWithImpl<_$InventoryQueryRequestImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryQueryRequestImplToJson(this);
+  }
+}
+
+abstract class _InventoryQueryRequest extends InventoryQueryRequest {
+  const factory _InventoryQueryRequest({
+    @JsonKey(name: 'barcode') required final String barcode,
+    @JsonKey(name: 'currStep') required final String queryType,
+    @JsonKey(name: 'PageIndex') final int pageIndex,
+    @JsonKey(name: 'PageSize') final int pageSize,
+  }) = _$InventoryQueryRequestImpl;
+  const _InventoryQueryRequest._() : super._();
+
+  factory _InventoryQueryRequest.fromJson(Map<String, dynamic> json) =
+      _$InventoryQueryRequestImpl.fromJson;
+
+  @override
+  /// 查询条件，物料/库位/托盘均通过 barcode 字段传递。
+  @JsonKey(name: 'barcode')
+  String get barcode;
+  @override
+  /// 查询类型，M=物料，S=库位，P=托盘。
+  @JsonKey(name: 'currStep')
+  String get queryType;
+  @override
+  /// 页码（后端接口使用大写字段名）。
+  @JsonKey(name: 'PageIndex')
+  int get pageIndex;
+  @override
+  /// 页大小（后端接口使用大写字段名）。
+  @JsonKey(name: 'PageSize')
+  int get pageSize;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryQueryRequestImplCopyWith<_$InventoryQueryRequestImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_query/models/inventory_query_request.g.dart
+++ b/lib/modules/inventory_query/models/inventory_query_request.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_query_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryQueryRequestImpl _$$InventoryQueryRequestImplFromJson(
+  Map<String, dynamic> json,
+) => _$InventoryQueryRequestImpl(
+  barcode: json['barcode'] as String,
+  queryType: json['currStep'] as String,
+  pageIndex: (json['PageIndex'] as num?)?.toInt() ?? 1,
+  pageSize: (json['PageSize'] as num?)?.toInt() ?? 10000,
+);
+
+Map<String, dynamic> _$$InventoryQueryRequestImplToJson(
+  _$InventoryQueryRequestImpl instance,
+) => <String, dynamic>{
+  'barcode': instance.barcode,
+  'currStep': instance.queryType,
+  'PageIndex': instance.pageIndex,
+  'PageSize': instance.pageSize,
+};

--- a/lib/modules/inventory_query/models/inventory_record.dart
+++ b/lib/modules/inventory_query/models/inventory_record.dart
@@ -1,0 +1,35 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_record.freezed.dart';
+part 'inventory_record.g.dart';
+
+/// 单条库存记录。
+@freezed
+class InventoryRecord with _$InventoryRecord {
+  const factory InventoryRecord({
+    @Default('') String matcode,
+    @Default('') String matname,
+    @Default('') String batchno,
+    @Default('') String sn,
+    @Default('') String storesiteno,
+    @JsonKey(name: 'erpStoreroom') @Default('') String erpStoreroom,
+    @Default('') String storeroomno,
+    @Default('') String storeroomname,
+    @Default(0.0) double repqty,
+  }) = _InventoryRecord;
+
+  factory InventoryRecord.fromJson(Map<String, dynamic> json) =>
+      _$InventoryRecordFromJson(json);
+}
+
+/// 分页响应体。
+@freezed
+class InventoryRecordPage with _$InventoryRecordPage {
+  const factory InventoryRecordPage({
+    @Default(<InventoryRecord>[]) List<InventoryRecord> rows,
+    @Default(0) int total,
+  }) = _InventoryRecordPage;
+
+  factory InventoryRecordPage.fromJson(Map<String, dynamic> json) =>
+      _$InventoryRecordPageFromJson(json);
+}

--- a/lib/modules/inventory_query/models/inventory_record.freezed.dart
+++ b/lib/modules/inventory_query/models/inventory_record.freezed.dart
@@ -1,0 +1,528 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_record.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+InventoryRecord _$InventoryRecordFromJson(Map<String, dynamic> json) {
+  return _InventoryRecord.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryRecord {
+  String get matcode => throw _privateConstructorUsedError;
+  String get matname => throw _privateConstructorUsedError;
+  String get batchno => throw _privateConstructorUsedError;
+  String get sn => throw _privateConstructorUsedError;
+  String get storesiteno => throw _privateConstructorUsedError;
+  @JsonKey(name: 'erpStoreroom')
+  String get erpStoreroom => throw _privateConstructorUsedError;
+  String get storeroomno => throw _privateConstructorUsedError;
+  String get storeroomname => throw _privateConstructorUsedError;
+  double get repqty => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryRecordCopyWith<InventoryRecord> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryRecordCopyWith<$Res> {
+  factory $InventoryRecordCopyWith(
+    InventoryRecord value,
+    $Res Function(InventoryRecord) then,
+  ) = _$InventoryRecordCopyWithImpl<$Res, InventoryRecord>;
+  @useResult
+  $Res call({
+    String matcode,
+    String matname,
+    String batchno,
+    String sn,
+    String storesiteno,
+    @JsonKey(name: 'erpStoreroom') String erpStoreroom,
+    String storeroomno,
+    String storeroomname,
+    double repqty,
+  });
+}
+
+/// @nodoc
+class _$InventoryRecordCopyWithImpl<$Res, $Val extends InventoryRecord>
+    implements $InventoryRecordCopyWith<$Res> {
+  _$InventoryRecordCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? matcode = null,
+    Object? matname = null,
+    Object? batchno = null,
+    Object? sn = null,
+    Object? storesiteno = null,
+    Object? erpStoreroom = null,
+    Object? storeroomno = null,
+    Object? storeroomname = null,
+    Object? repqty = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            matcode: null == matcode
+                ? _value.matcode
+                : matcode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            matname: null == matname
+                ? _value.matname
+                : matname // ignore: cast_nullable_to_non_nullable
+                      as String,
+            batchno: null == batchno
+                ? _value.batchno
+                : batchno // ignore: cast_nullable_to_non_nullable
+                      as String,
+            sn: null == sn
+                ? _value.sn
+                : sn // ignore: cast_nullable_to_non_nullable
+                      as String,
+            storesiteno: null == storesiteno
+                ? _value.storesiteno
+                : storesiteno // ignore: cast_nullable_to_non_nullable
+                      as String,
+            erpStoreroom: null == erpStoreroom
+                ? _value.erpStoreroom
+                : erpStoreroom // ignore: cast_nullable_to_non_nullable
+                      as String,
+            storeroomno: null == storeroomno
+                ? _value.storeroomno
+                : storeroomno // ignore: cast_nullable_to_non_nullable
+                      as String,
+            storeroomname: null == storeroomname
+                ? _value.storeroomname
+                : storeroomname // ignore: cast_nullable_to_non_nullable
+                      as String,
+            repqty: null == repqty
+                ? _value.repqty
+                : repqty // ignore: cast_nullable_to_non_nullable
+                      as double,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryRecordImplCopyWith<$Res>
+    implements $InventoryRecordCopyWith<$Res> {
+  factory _$$InventoryRecordImplCopyWith(
+    _$InventoryRecordImpl value,
+    $Res Function(_$InventoryRecordImpl) then,
+  ) = __$$InventoryRecordImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String matcode,
+    String matname,
+    String batchno,
+    String sn,
+    String storesiteno,
+    @JsonKey(name: 'erpStoreroom') String erpStoreroom,
+    String storeroomno,
+    String storeroomname,
+    double repqty,
+  });
+}
+
+/// @nodoc
+class __$$InventoryRecordImplCopyWithImpl<$Res>
+    extends _$InventoryRecordCopyWithImpl<$Res, _$InventoryRecordImpl>
+    implements _$$InventoryRecordImplCopyWith<$Res> {
+  __$$InventoryRecordImplCopyWithImpl(
+    _$InventoryRecordImpl _value,
+    $Res Function(_$InventoryRecordImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? matcode = null,
+    Object? matname = null,
+    Object? batchno = null,
+    Object? sn = null,
+    Object? storesiteno = null,
+    Object? erpStoreroom = null,
+    Object? storeroomno = null,
+    Object? storeroomname = null,
+    Object? repqty = null,
+  }) {
+    return _then(
+      _$InventoryRecordImpl(
+        matcode: null == matcode
+            ? _value.matcode
+            : matcode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        matname: null == matname
+            ? _value.matname
+            : matname // ignore: cast_nullable_to_non_nullable
+                  as String,
+        batchno: null == batchno
+            ? _value.batchno
+            : batchno // ignore: cast_nullable_to_non_nullable
+                  as String,
+        sn: null == sn
+            ? _value.sn
+            : sn // ignore: cast_nullable_to_non_nullable
+                  as String,
+        storesiteno: null == storesiteno
+            ? _value.storesiteno
+            : storesiteno // ignore: cast_nullable_to_non_nullable
+                  as String,
+        erpStoreroom: null == erpStoreroom
+            ? _value.erpStoreroom
+            : erpStoreroom // ignore: cast_nullable_to_non_nullable
+                  as String,
+        storeroomno: null == storeroomno
+            ? _value.storeroomno
+            : storeroomno // ignore: cast_nullable_to_non_nullable
+                  as String,
+        storeroomname: null == storeroomname
+            ? _value.storeroomname
+            : storeroomname // ignore: cast_nullable_to_non_nullable
+                  as String,
+        repqty: null == repqty
+            ? _value.repqty
+            : repqty // ignore: cast_nullable_to_non_nullable
+                  as double,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryRecordImpl implements _InventoryRecord {
+  const _$InventoryRecordImpl({
+    this.matcode = '',
+    this.matname = '',
+    this.batchno = '',
+    this.sn = '',
+    this.storesiteno = '',
+    @JsonKey(name: 'erpStoreroom') this.erpStoreroom = '',
+    this.storeroomno = '',
+    this.storeroomname = '',
+    this.repqty = 0.0,
+  });
+
+  factory _$InventoryRecordImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryRecordImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final String matcode;
+  @override
+  @JsonKey()
+  final String matname;
+  @override
+  @JsonKey()
+  final String batchno;
+  @override
+  @JsonKey()
+  final String sn;
+  @override
+  @JsonKey()
+  final String storesiteno;
+  @override
+  @JsonKey(name: 'erpStoreroom')
+  final String erpStoreroom;
+  @override
+  @JsonKey()
+  final String storeroomno;
+  @override
+  @JsonKey()
+  final String storeroomname;
+  @override
+  @JsonKey()
+  final double repqty;
+
+  @override
+  String toString() {
+    return 'InventoryRecord(matcode: $matcode, matname: $matname, batchno: $batchno, sn: $sn, storesiteno: $storesiteno, erpStoreroom: $erpStoreroom, storeroomno: $storeroomno, storeroomname: $storeroomname, repqty: $repqty)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryRecordImpl &&
+            (identical(other.matcode, matcode) || other.matcode == matcode) &&
+            (identical(other.matname, matname) || other.matname == matname) &&
+            (identical(other.batchno, batchno) || other.batchno == batchno) &&
+            (identical(other.sn, sn) || other.sn == sn) &&
+            (identical(other.storesiteno, storesiteno) ||
+                other.storesiteno == storesiteno) &&
+            (identical(other.erpStoreroom, erpStoreroom) ||
+                other.erpStoreroom == erpStoreroom) &&
+            (identical(other.storeroomno, storeroomno) ||
+                other.storeroomno == storeroomno) &&
+            (identical(other.storeroomname, storeroomname) ||
+                other.storeroomname == storeroomname) &&
+            (identical(other.repqty, repqty) || other.repqty == repqty));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    matcode,
+    matname,
+    batchno,
+    sn,
+    storesiteno,
+    erpStoreroom,
+    storeroomno,
+    storeroomname,
+    repqty,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryRecordImplCopyWith<_$InventoryRecordImpl> get copyWith =>
+      __$$InventoryRecordImplCopyWithImpl<_$InventoryRecordImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryRecordImplToJson(this);
+  }
+}
+
+abstract class _InventoryRecord implements InventoryRecord {
+  const factory _InventoryRecord({
+    final String matcode,
+    final String matname,
+    final String batchno,
+    final String sn,
+    final String storesiteno,
+    @JsonKey(name: 'erpStoreroom') final String erpStoreroom,
+    final String storeroomno,
+    final String storeroomname,
+    final double repqty,
+  }) = _$InventoryRecordImpl;
+
+  factory _InventoryRecord.fromJson(Map<String, dynamic> json) =
+      _$InventoryRecordImpl.fromJson;
+
+  @override
+  String get matcode;
+  @override
+  String get matname;
+  @override
+  String get batchno;
+  @override
+  String get sn;
+  @override
+  String get storesiteno;
+  @override
+  @JsonKey(name: 'erpStoreroom')
+  String get erpStoreroom;
+  @override
+  String get storeroomno;
+  @override
+  String get storeroomname;
+  @override
+  double get repqty;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryRecordImplCopyWith<_$InventoryRecordImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+InventoryRecordPage _$InventoryRecordPageFromJson(Map<String, dynamic> json) {
+  return _InventoryRecordPage.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventoryRecordPage {
+  List<InventoryRecord> get rows => throw _privateConstructorUsedError;
+  int get total => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventoryRecordPageCopyWith<InventoryRecordPage> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventoryRecordPageCopyWith<$Res> {
+  factory $InventoryRecordPageCopyWith(
+    InventoryRecordPage value,
+    $Res Function(InventoryRecordPage) then,
+  ) = _$InventoryRecordPageCopyWithImpl<$Res, InventoryRecordPage>;
+  @useResult
+  $Res call({List<InventoryRecord> rows, int total});
+}
+
+/// @nodoc
+class _$InventoryRecordPageCopyWithImpl<$Res, $Val extends InventoryRecordPage>
+    implements $InventoryRecordPageCopyWith<$Res> {
+  _$InventoryRecordPageCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? rows = null, Object? total = null}) {
+    return _then(
+      _value.copyWith(
+            rows: null == rows
+                ? _value.rows
+                : rows // ignore: cast_nullable_to_non_nullable
+                      as List<InventoryRecord>,
+            total: null == total
+                ? _value.total
+                : total // ignore: cast_nullable_to_non_nullable
+                      as int,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$InventoryRecordPageImplCopyWith<$Res>
+    implements $InventoryRecordPageCopyWith<$Res> {
+  factory _$$InventoryRecordPageImplCopyWith(
+    _$InventoryRecordPageImpl value,
+    $Res Function(_$InventoryRecordPageImpl) then,
+  ) = __$$InventoryRecordPageImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({List<InventoryRecord> rows, int total});
+}
+
+/// @nodoc
+class __$$InventoryRecordPageImplCopyWithImpl<$Res>
+    extends _$InventoryRecordPageCopyWithImpl<$Res, _$InventoryRecordPageImpl>
+    implements _$$InventoryRecordPageImplCopyWith<$Res> {
+  __$$InventoryRecordPageImplCopyWithImpl(
+    _$InventoryRecordPageImpl _value,
+    $Res Function(_$InventoryRecordPageImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? rows = null, Object? total = null}) {
+    return _then(
+      _$InventoryRecordPageImpl(
+        rows: null == rows
+            ? _value._rows
+            : rows // ignore: cast_nullable_to_non_nullable
+                  as List<InventoryRecord>,
+        total: null == total
+            ? _value.total
+            : total // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventoryRecordPageImpl implements _InventoryRecordPage {
+  const _$InventoryRecordPageImpl({
+    final List<InventoryRecord> rows = const <InventoryRecord>[],
+    this.total = 0,
+  }) : _rows = rows;
+
+  factory _$InventoryRecordPageImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventoryRecordPageImplFromJson(json);
+
+  final List<InventoryRecord> _rows;
+  @override
+  @JsonKey()
+  List<InventoryRecord> get rows {
+    if (_rows is EqualUnmodifiableListView) return _rows;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_rows);
+  }
+
+  @override
+  @JsonKey()
+  final int total;
+
+  @override
+  String toString() {
+    return 'InventoryRecordPage(rows: $rows, total: $total)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventoryRecordPageImpl &&
+            const DeepCollectionEquality().equals(other._rows, _rows) &&
+            (identical(other.total, total) || other.total == total));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    const DeepCollectionEquality().hash(_rows),
+    total,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventoryRecordPageImplCopyWith<_$InventoryRecordPageImpl> get copyWith =>
+      __$$InventoryRecordPageImplCopyWithImpl<_$InventoryRecordPageImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventoryRecordPageImplToJson(this);
+  }
+}
+
+abstract class _InventoryRecordPage implements InventoryRecordPage {
+  const factory _InventoryRecordPage({
+    final List<InventoryRecord> rows,
+    final int total,
+  }) = _$InventoryRecordPageImpl;
+
+  factory _InventoryRecordPage.fromJson(Map<String, dynamic> json) =
+      _$InventoryRecordPageImpl.fromJson;
+
+  @override
+  List<InventoryRecord> get rows;
+  @override
+  int get total;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventoryRecordPageImplCopyWith<_$InventoryRecordPageImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_query/models/inventory_record.g.dart
+++ b/lib/modules/inventory_query/models/inventory_record.g.dart
@@ -1,0 +1,50 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_record.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventoryRecordImpl _$$InventoryRecordImplFromJson(
+  Map<String, dynamic> json,
+) => _$InventoryRecordImpl(
+  matcode: json['matcode'] as String? ?? '',
+  matname: json['matname'] as String? ?? '',
+  batchno: json['batchno'] as String? ?? '',
+  sn: json['sn'] as String? ?? '',
+  storesiteno: json['storesiteno'] as String? ?? '',
+  erpStoreroom: json['erpStoreroom'] as String? ?? '',
+  storeroomno: json['storeroomno'] as String? ?? '',
+  storeroomname: json['storeroomname'] as String? ?? '',
+  repqty: (json['repqty'] as num?)?.toDouble() ?? 0.0,
+);
+
+Map<String, dynamic> _$$InventoryRecordImplToJson(
+  _$InventoryRecordImpl instance,
+) => <String, dynamic>{
+  'matcode': instance.matcode,
+  'matname': instance.matname,
+  'batchno': instance.batchno,
+  'sn': instance.sn,
+  'storesiteno': instance.storesiteno,
+  'erpStoreroom': instance.erpStoreroom,
+  'storeroomno': instance.storeroomno,
+  'storeroomname': instance.storeroomname,
+  'repqty': instance.repqty,
+};
+
+_$InventoryRecordPageImpl _$$InventoryRecordPageImplFromJson(
+  Map<String, dynamic> json,
+) => _$InventoryRecordPageImpl(
+  rows:
+      (json['rows'] as List<dynamic>?)
+          ?.map((e) => InventoryRecord.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const <InventoryRecord>[],
+  total: (json['total'] as num?)?.toInt() ?? 0,
+);
+
+Map<String, dynamic> _$$InventoryRecordPageImplToJson(
+  _$InventoryRecordPageImpl instance,
+) => <String, dynamic>{'rows': instance.rows, 'total': instance.total};

--- a/lib/modules/inventory_query/models/inventory_summary.dart
+++ b/lib/modules/inventory_query/models/inventory_summary.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'inventory_summary.freezed.dart';
+part 'inventory_summary.g.dart';
+
+/// 页面顶部汇总信息。
+@freezed
+class InventorySummary with _$InventorySummary {
+  const factory InventorySummary({
+    @Default('') String materialCode,
+    @Default('') String materialName,
+    @Default('') String storeSite,
+    @Default('') String trayNo,
+    @Default(0.0) double totalQuantity,
+  }) = _InventorySummary;
+
+  factory InventorySummary.fromJson(Map<String, dynamic> json) =>
+      _$InventorySummaryFromJson(json);
+}

--- a/lib/modules/inventory_query/models/inventory_summary.freezed.dart
+++ b/lib/modules/inventory_query/models/inventory_summary.freezed.dart
@@ -1,0 +1,265 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'inventory_summary.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+InventorySummary _$InventorySummaryFromJson(Map<String, dynamic> json) {
+  return _InventorySummary.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InventorySummary {
+  String get materialCode => throw _privateConstructorUsedError;
+  String get materialName => throw _privateConstructorUsedError;
+  String get storeSite => throw _privateConstructorUsedError;
+  String get trayNo => throw _privateConstructorUsedError;
+  double get totalQuantity => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $InventorySummaryCopyWith<InventorySummary> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InventorySummaryCopyWith<$Res> {
+  factory $InventorySummaryCopyWith(
+    InventorySummary value,
+    $Res Function(InventorySummary) then,
+  ) = _$InventorySummaryCopyWithImpl<$Res, InventorySummary>;
+  @useResult
+  $Res call({
+    String materialCode,
+    String materialName,
+    String storeSite,
+    String trayNo,
+    double totalQuantity,
+  });
+}
+
+/// @nodoc
+class _$InventorySummaryCopyWithImpl<$Res, $Val extends InventorySummary>
+    implements $InventorySummaryCopyWith<$Res> {
+  _$InventorySummaryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = null,
+    Object? materialName = null,
+    Object? storeSite = null,
+    Object? trayNo = null,
+    Object? totalQuantity = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            materialCode: null == materialCode
+                ? _value.materialCode
+                : materialCode // ignore: cast_nullable_to_non_nullable
+                      as String,
+            materialName: null == materialName
+                ? _value.materialName
+                : materialName // ignore: cast_nullable_to_non_nullable
+                      as String,
+            storeSite: null == storeSite
+                ? _value.storeSite
+                : storeSite // ignore: cast_nullable_to_non_nullable
+                      as String,
+            trayNo: null == trayNo
+                ? _value.trayNo
+                : trayNo // ignore: cast_nullable_to_non_nullable
+                      as String,
+            totalQuantity: null == totalQuantity
+                ? _value.totalQuantity
+                : totalQuantity // ignore: cast_nullable_to_non_nullable
+                      as double,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$InventorySummaryImplCopyWith<$Res>
+    implements $InventorySummaryCopyWith<$Res> {
+  factory _$$InventorySummaryImplCopyWith(
+    _$InventorySummaryImpl value,
+    $Res Function(_$InventorySummaryImpl) then,
+  ) = __$$InventorySummaryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String materialCode,
+    String materialName,
+    String storeSite,
+    String trayNo,
+    double totalQuantity,
+  });
+}
+
+/// @nodoc
+class __$$InventorySummaryImplCopyWithImpl<$Res>
+    extends _$InventorySummaryCopyWithImpl<$Res, _$InventorySummaryImpl>
+    implements _$$InventorySummaryImplCopyWith<$Res> {
+  __$$InventorySummaryImplCopyWithImpl(
+    _$InventorySummaryImpl _value,
+    $Res Function(_$InventorySummaryImpl) _then,
+  ) : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? materialCode = null,
+    Object? materialName = null,
+    Object? storeSite = null,
+    Object? trayNo = null,
+    Object? totalQuantity = null,
+  }) {
+    return _then(
+      _$InventorySummaryImpl(
+        materialCode: null == materialCode
+            ? _value.materialCode
+            : materialCode // ignore: cast_nullable_to_non_nullable
+                  as String,
+        materialName: null == materialName
+            ? _value.materialName
+            : materialName // ignore: cast_nullable_to_non_nullable
+                  as String,
+        storeSite: null == storeSite
+            ? _value.storeSite
+            : storeSite // ignore: cast_nullable_to_non_nullable
+                  as String,
+        trayNo: null == trayNo
+            ? _value.trayNo
+            : trayNo // ignore: cast_nullable_to_non_nullable
+                  as String,
+        totalQuantity: null == totalQuantity
+            ? _value.totalQuantity
+            : totalQuantity // ignore: cast_nullable_to_non_nullable
+                  as double,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InventorySummaryImpl implements _InventorySummary {
+  const _$InventorySummaryImpl({
+    this.materialCode = '',
+    this.materialName = '',
+    this.storeSite = '',
+    this.trayNo = '',
+    this.totalQuantity = 0.0,
+  });
+
+  factory _$InventorySummaryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InventorySummaryImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final String materialCode;
+  @override
+  @JsonKey()
+  final String materialName;
+  @override
+  @JsonKey()
+  final String storeSite;
+  @override
+  @JsonKey()
+  final String trayNo;
+  @override
+  @JsonKey()
+  final double totalQuantity;
+
+  @override
+  String toString() {
+    return 'InventorySummary(materialCode: $materialCode, materialName: $materialName, storeSite: $storeSite, trayNo: $trayNo, totalQuantity: $totalQuantity)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InventorySummaryImpl &&
+            (identical(other.materialCode, materialCode) ||
+                other.materialCode == materialCode) &&
+            (identical(other.materialName, materialName) ||
+                other.materialName == materialName) &&
+            (identical(other.storeSite, storeSite) ||
+                other.storeSite == storeSite) &&
+            (identical(other.trayNo, trayNo) || other.trayNo == trayNo) &&
+            (identical(other.totalQuantity, totalQuantity) ||
+                other.totalQuantity == totalQuantity));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    materialCode,
+    materialName,
+    storeSite,
+    trayNo,
+    totalQuantity,
+  );
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InventorySummaryImplCopyWith<_$InventorySummaryImpl> get copyWith =>
+      __$$InventorySummaryImplCopyWithImpl<_$InventorySummaryImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InventorySummaryImplToJson(this);
+  }
+}
+
+abstract class _InventorySummary implements InventorySummary {
+  const factory _InventorySummary({
+    final String materialCode,
+    final String materialName,
+    final String storeSite,
+    final String trayNo,
+    final double totalQuantity,
+  }) = _$InventorySummaryImpl;
+
+  factory _InventorySummary.fromJson(Map<String, dynamic> json) =
+      _$InventorySummaryImpl.fromJson;
+
+  @override
+  String get materialCode;
+  @override
+  String get materialName;
+  @override
+  String get storeSite;
+  @override
+  String get trayNo;
+  @override
+  double get totalQuantity;
+  @override
+  @JsonKey(ignore: true)
+  _$$InventorySummaryImplCopyWith<_$InventorySummaryImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/modules/inventory_query/models/inventory_summary.g.dart
+++ b/lib/modules/inventory_query/models/inventory_summary.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'inventory_summary.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InventorySummaryImpl _$$InventorySummaryImplFromJson(
+  Map<String, dynamic> json,
+) => _$InventorySummaryImpl(
+  materialCode: json['materialCode'] as String? ?? '',
+  materialName: json['materialName'] as String? ?? '',
+  storeSite: json['storeSite'] as String? ?? '',
+  trayNo: json['trayNo'] as String? ?? '',
+  totalQuantity: (json['totalQuantity'] as num?)?.toDouble() ?? 0.0,
+);
+
+Map<String, dynamic> _$$InventorySummaryImplToJson(
+  _$InventorySummaryImpl instance,
+) => <String, dynamic>{
+  'materialCode': instance.materialCode,
+  'materialName': instance.materialName,
+  'storeSite': instance.storeSite,
+  'trayNo': instance.trayNo,
+  'totalQuantity': instance.totalQuantity,
+};

--- a/lib/modules/inventory_query/pages/inventory_query_page.dart
+++ b/lib/modules/inventory_query/pages/inventory_query_page.dart
@@ -1,0 +1,369 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+import '../../../common_widgets/common_grid/common_data_grid.dart';
+import '../../../common_widgets/custom_app_bar.dart';
+import '../../../common_widgets/scanner_widget/scanner_config.dart';
+import '../../../common_widgets/scanner_widget/scanner_widget.dart';
+import '../bloc/inventory_query_bloc.dart';
+import '../bloc/inventory_query_event.dart';
+import '../bloc/inventory_query_state.dart';
+import '../models/inventory_barcode_material.dart';
+import '../models/inventory_query_request.dart';
+import '../models/inventory_record.dart';
+import '../models/inventory_summary.dart';
+
+class InventoryQueryPage extends StatefulWidget {
+  const InventoryQueryPage({super.key});
+
+  @override
+  State<InventoryQueryPage> createState() => _InventoryQueryPageState();
+}
+
+class _InventoryQueryPageState extends State<InventoryQueryPage> {
+  final ScannerController _scannerController = ScannerController();
+  int _lastFocusTick = 0;
+
+  static final List<GridColumnConfig<InventoryRecord>> _columns = [
+    GridColumnConfig<InventoryRecord>(
+      name: 'matcode',
+      headerText: '物料编码',
+      valueGetter: (row) => row.matcode,
+      enableSelectableText: true,
+    ),
+    GridColumnConfig<InventoryRecord>(
+      name: 'matname',
+      headerText: '物料名称',
+      valueGetter: (row) => row.matname,
+      enableSelectableText: true,
+      width: 200,
+    ),
+    GridColumnConfig<InventoryRecord>(
+      name: 'repqty',
+      headerText: '库存数量',
+      valueGetter: (row) => row.repqty,
+      textAlign: TextAlign.right,
+      formatter: (value, row) => _formatQuantity(row.repqty),
+    ),
+    GridColumnConfig<InventoryRecord>(
+      name: 'batchno',
+      headerText: '批次号',
+      valueGetter: (row) => row.batchno,
+      enableSelectableText: true,
+      width: 160,
+    ),
+    GridColumnConfig<InventoryRecord>(
+      name: 'sn',
+      headerText: '序列号',
+      valueGetter: (row) => row.sn,
+      enableSelectableText: true,
+      width: 160,
+    ),
+    GridColumnConfig<InventoryRecord>(
+      name: 'storesiteno',
+      headerText: '库位',
+      valueGetter: (row) => row.storesiteno,
+      enableSelectableText: true,
+    ),
+    GridColumnConfig<InventoryRecord>(
+      name: 'erpStoreroom',
+      headerText: 'ERP子库',
+      valueGetter: (row) => row.erpStoreroom,
+    ),
+    GridColumnConfig<InventoryRecord>(
+      name: 'storeroomno',
+      headerText: '库房编码',
+      valueGetter: (row) => row.storeroomno,
+    ),
+    GridColumnConfig<InventoryRecord>(
+      name: 'storeroomname',
+      headerText: '库房名称',
+      valueGetter: (row) => row.storeroomname,
+      enableSelectableText: true,
+    ),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<InventoryQueryBloc>().add(
+        const InventoryQueryEvent.initialized(),
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _scannerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(
+        title: '库存查询',
+        onBackPressed: () => Modular.to.pop(),
+      ).appBar,
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          if (_scannerController.isAttached) {
+            _scannerController.requestFocus();
+          }
+        },
+        child: const Icon(Icons.qr_code_scanner),
+      ),
+      body: BlocConsumer<InventoryQueryBloc, InventoryQueryState>(
+        listener: (context, state) {
+          if (_lastFocusTick != state.focusTick) {
+            _lastFocusTick = state.focusTick;
+            if (_scannerController.isAttached) {
+              _scannerController.requestFocus();
+            }
+          }
+
+          if (state.status == PageStatus.failure &&
+              state.errorMessage != null) {
+            ScaffoldMessenger.of(context)
+              ..hideCurrentSnackBar()
+              ..showSnackBar(SnackBar(content: Text(state.errorMessage!)));
+          }
+        },
+        builder: (context, state) {
+          return Stack(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildModeSelector(state),
+                    const SizedBox(height: 12),
+                    _buildScanner(context, state),
+                    const SizedBox(height: 16),
+                    InventorySummaryCard(
+                      summary: state.summary,
+                      material: state.barcodeMaterial,
+                      onReset: () => context.read<InventoryQueryBloc>().add(
+                        const InventoryQueryEvent.resetRequested(),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Expanded(child: _buildDataSection(state)),
+                  ],
+                ),
+              ),
+              if (state.status == PageStatus.loading)
+                Positioned.fill(
+                  child: Container(
+                    color: Colors.black.withOpacity(0.1),
+                    child: const Center(child: CircularProgressIndicator()),
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildModeSelector(InventoryQueryState state) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: InventoryQueryMode.values
+          .map(
+            (mode) => ChoiceChip(
+              label: Text(mode.displayName),
+              selected: state.selectedMode == mode,
+              onSelected: (_) => context.read<InventoryQueryBloc>().add(
+                InventoryQueryEvent.modeChanged(mode),
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  Widget _buildScanner(BuildContext context, InventoryQueryState state) {
+    return ScannerWidget(
+      controller: _scannerController,
+      config: const ScannerConfig(placeholder: '请扫描或输入条码', autoFocus: true),
+      onScanResult: (code) {
+        context.read<InventoryQueryBloc>().add(
+          InventoryQueryEvent.barcodeScanned(code),
+        );
+      },
+      onError: (message) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(SnackBar(content: Text(message)));
+      },
+      suffix: Padding(
+        padding: const EdgeInsets.only(left: 8),
+        child: ElevatedButton.icon(
+          onPressed: () {
+            final input = _scannerController.text.trim();
+            context.read<InventoryQueryBloc>().add(
+              InventoryQueryEvent.manualSubmitted(input: input),
+            );
+          },
+          icon: const Icon(Icons.search),
+          label: const Text('查询'),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDataSection(InventoryQueryState state) {
+    if (state.status == PageStatus.initial) {
+      return const Center(child: Text('请扫描物料、库位或托盘条码开始查询'));
+    }
+
+    if (state.status == PageStatus.failure && state.records.isEmpty) {
+      return const Center(child: Text('暂无数据'));
+    }
+
+    if (state.records.isEmpty) {
+      return const Center(child: Text('未查询到相关库存'));
+    }
+
+    return CommonDataGrid<InventoryRecord>(
+      columns: _columns,
+      datas: state.records,
+      currentPage: state.currentPage,
+      totalPages: state.totalPages,
+      onLoadData: (pageIndex) async {
+        context.read<InventoryQueryBloc>().add(
+          InventoryQueryEvent.pageChanged(pageIndex),
+        );
+      },
+      allowPager: true,
+    );
+  }
+
+  static String _formatQuantity(double value) {
+    if (value == value.roundToDouble()) {
+      return value.toStringAsFixed(0);
+    }
+    return value.toStringAsFixed(3);
+  }
+}
+
+class InventorySummaryCard extends StatelessWidget {
+  const InventorySummaryCard({
+    super.key,
+    required this.summary,
+    this.material,
+    this.onReset,
+  });
+
+  final InventorySummary summary;
+  final InventoryBarcodeMaterial? material;
+  final VoidCallback? onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 1,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: _SummaryTile(
+                    label: '库存数量',
+                    value: _InventoryQueryPageState._formatQuantity(
+                      summary.totalQuantity,
+                    ),
+                    valueStyle: theme.textTheme.headlineSmall?.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                if (onReset != null)
+                  IconButton(
+                    onPressed: onReset,
+                    icon: const Icon(Icons.refresh),
+                    tooltip: '重置',
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 16,
+              runSpacing: 8,
+              children: [
+                _SummaryTile(
+                  label: '物料编码',
+                  value: _resolveText(summary.materialCode, material?.matcode),
+                ),
+                _SummaryTile(
+                  label: '物料名称',
+                  value: _resolveText(summary.materialName, material?.matname),
+                  maxLines: 2,
+                ),
+                _SummaryTile(label: '库位', value: summary.storeSite),
+                _SummaryTile(label: '托盘号', value: summary.trayNo),
+                _SummaryTile(label: '批次号', value: material?.batchno ?? ''),
+                _SummaryTile(label: '序列号', value: material?.sn ?? ''),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String _resolveText(String primary, String? fallback) {
+    if (primary.isNotEmpty) return primary;
+    if (fallback == null || fallback.isEmpty) return '-';
+    return fallback;
+  }
+}
+
+class _SummaryTile extends StatelessWidget {
+  const _SummaryTile({
+    required this.label,
+    required this.value,
+    this.maxLines = 1,
+    this.valueStyle,
+  });
+
+  final String label;
+  final String value;
+  final int maxLines;
+  final TextStyle? valueStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: 160,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey[600]),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value.isEmpty ? '-' : value,
+            maxLines: maxLines,
+            overflow: TextOverflow.ellipsis,
+            style: valueStyle ?? theme.textTheme.titleMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/modules/inventory_query/services/inventory_query_service.dart
+++ b/lib/modules/inventory_query/services/inventory_query_service.dart
@@ -1,0 +1,57 @@
+import 'package:dio/dio.dart';
+
+import '../../../services/api_response_handler.dart';
+import '../models/inventory_barcode_material.dart';
+import '../models/inventory_query_request.dart';
+import '../models/inventory_record.dart';
+
+class InventoryQueryService {
+  InventoryQueryService(this._dio);
+
+  final Dio _dio;
+
+  Future<InventoryBarcodeMaterial> getMaterialInfoByQr(String barcode) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/materialInfo',
+      queryParameters: {'QRstring': barcode},
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) => InventoryBarcodeMaterial.fromJson(
+        Map<String, dynamic>.from(data as Map),
+      ),
+    );
+  }
+
+  Future<InventoryRecordPage> getInventoryByBarcode(
+    InventoryQueryRequest request,
+  ) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getRepertoryByBarCode',
+      queryParameters: request.toJson(),
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) =>
+          InventoryRecordPage.fromJson(Map<String, dynamic>.from(data as Map)),
+    );
+  }
+
+  Future<InventoryRecordPage> getInventoryByMode({
+    required InventoryQueryMode mode,
+    required String value,
+    int pageIndex = 1,
+    int pageSize = 10000,
+  }) {
+    return getInventoryByBarcode(
+      InventoryQueryRequest(
+        barcode: value,
+        queryType: mode.apiCode,
+        pageIndex: pageIndex,
+        pageSize: pageSize,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
+  bloc_test:
+    dependency: "direct dev"
+    description:
+      name: bloc_test
+      sha256: "165a6ec950d9252ebe36dc5335f2e6eb13055f33d56db0eeb7642768849b43d2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.7"
   boolean_selector:
     dependency: transitive
     description:
@@ -153,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -185,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -217,6 +241,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
+  diff_match_patch:
+    dependency: transitive
+    description:
+      name: diff_match_patch
+      sha256: "2efc9e6e8f449d0abe15be240e2c2a3bcd977c8d126cfd70598aee60af35c0a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.1"
   dio:
     dependency: "direct main"
     description:
@@ -596,10 +628,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -608,6 +640,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   modular_core:
     dependency: transitive
     description:
@@ -624,6 +664,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -832,6 +880,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -861,6 +925,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.5"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -933,14 +1013,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.11"
   timing:
     dependency: transitive
     description:
@@ -1045,6 +1141,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,6 +69,8 @@ dev_dependencies:
   freezed: ^2.4.7
   json_serializable: ^6.7.1
   hive_generator: ^2.0.1
+  bloc_test: ^9.1.7
+  mocktail: ^1.0.3
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/modules/inventory_query/bloc/inventory_query_bloc_test.dart
+++ b/test/modules/inventory_query/bloc/inventory_query_bloc_test.dart
@@ -1,0 +1,88 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:wms_app/modules/inventory_query/bloc/inventory_query_bloc.dart';
+import 'package:wms_app/modules/inventory_query/bloc/inventory_query_event.dart';
+import 'package:wms_app/modules/inventory_query/bloc/inventory_query_state.dart';
+import 'package:wms_app/modules/inventory_query/models/inventory_barcode_material.dart';
+import 'package:wms_app/modules/inventory_query/models/inventory_query_request.dart';
+import 'package:wms_app/modules/inventory_query/models/inventory_record.dart';
+import 'package:wms_app/modules/inventory_query/services/inventory_query_service.dart';
+
+class _MockInventoryQueryService extends Mock
+    implements InventoryQueryService {}
+
+void main() {
+  late InventoryQueryService service;
+
+  setUpAll(() {
+    registerFallbackValue(
+      const InventoryQueryRequest(barcode: '', queryType: 'M'),
+    );
+  });
+
+  setUp(() {
+    service = _MockInventoryQueryService();
+  });
+
+  InventoryQueryBloc buildBloc() => InventoryQueryBloc(service: service);
+
+  blocTest<InventoryQueryBloc, InventoryQueryState>(
+    'initialized event triggers focus request',
+    build: buildBloc,
+    act: (bloc) => bloc.add(const InventoryQueryEvent.initialized()),
+    expect: () => [const InventoryQueryState(focusTick: 1)],
+  );
+
+  blocTest<InventoryQueryBloc, InventoryQueryState>(
+    'barcode scan success emits loading and success states',
+    build: () {
+      final material = const InventoryBarcodeMaterial(
+        matcode: 'MAT001',
+        matname: '叶轮',
+      );
+      final page = InventoryRecordPage(
+        rows: const [InventoryRecord(matcode: 'MAT001', repqty: 5)],
+        total: 1,
+      );
+
+      when(
+        () => service.getMaterialInfoByQr(any()),
+      ).thenAnswer((_) async => material);
+      when(
+        () => service.getInventoryByBarcode(any()),
+      ).thenAnswer((_) async => page);
+      return buildBloc();
+    },
+    act: (bloc) =>
+        bloc.add(const InventoryQueryEvent.barcodeScanned('MC123456')),
+    expect: () => [
+      isA<InventoryQueryState>().having(
+        (s) => s.status,
+        'status',
+        PageStatus.loading,
+      ),
+      isA<InventoryQueryState>()
+          .having((s) => s.status, 'status', PageStatus.success)
+          .having((s) => s.records.length, 'records', 1)
+          .having((s) => s.summary.totalQuantity, 'totalQuantity', 5)
+          .having((s) => s.summary.materialCode, 'materialCode', 'MAT001'),
+    ],
+    verify: (bloc) {
+      verify(() => service.getMaterialInfoByQr(any())).called(1);
+      verify(() => service.getInventoryByBarcode(any())).called(1);
+    },
+  );
+
+  blocTest<InventoryQueryBloc, InventoryQueryState>(
+    'manual submit empty input emits failure state',
+    build: buildBloc,
+    act: (bloc) =>
+        bloc.add(const InventoryQueryEvent.manualSubmitted(input: ' ')),
+    expect: () => [
+      isA<InventoryQueryState>()
+          .having((s) => s.status, 'status', PageStatus.failure)
+          .having((s) => s.errorMessage, 'error', isNotNull),
+    ],
+  );
+}

--- a/test/modules/inventory_query/services/inventory_query_service_test.dart
+++ b/test/modules/inventory_query/services/inventory_query_service_test.dart
@@ -1,0 +1,71 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:wms_app/modules/inventory_query/models/inventory_barcode_material.dart';
+import 'package:wms_app/modules/inventory_query/models/inventory_query_request.dart';
+import 'package:wms_app/modules/inventory_query/models/inventory_record.dart';
+import 'package:wms_app/modules/inventory_query/services/inventory_query_service.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+void main() {
+  late Dio dio;
+  late InventoryQueryService service;
+
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  setUp(() {
+    dio = _MockDio();
+    service = InventoryQueryService(dio);
+  });
+
+  Response<Map<String, dynamic>> _buildResponse(Map<String, dynamic> data) {
+    return Response<Map<String, dynamic>>(
+      requestOptions: RequestOptions(path: ''),
+      data: {'code': 200, 'msg': 'ok', 'data': data},
+    );
+  }
+
+  test('getMaterialInfoByQr parses barcode material', () async {
+    final payload = InventoryBarcodeMaterial(
+      matcode: 'MAT001',
+      matname: '物料A',
+    ).toJson();
+
+    when(
+      () => dio.get<Map<String, dynamic>>(
+        any(),
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer((_) async => _buildResponse(payload));
+
+    final result = await service.getMaterialInfoByQr('barcode');
+
+    expect(result.matcode, 'MAT001');
+    expect(result.matname, '物料A');
+  });
+
+  test('getInventoryByBarcode returns inventory page', () async {
+    final rows = [
+      InventoryRecord(matcode: 'MAT001', repqty: 5).toJson(),
+      InventoryRecord(matcode: 'MAT002', repqty: 3).toJson(),
+    ];
+
+    when(
+      () => dio.get<Map<String, dynamic>>(
+        any(),
+        queryParameters: any(named: 'queryParameters'),
+      ),
+    ).thenAnswer((_) async => _buildResponse({'rows': rows, 'total': 2}));
+
+    final page = await service.getInventoryByBarcode(
+      InventoryQueryRequest(barcode: 'MAT001', queryType: 'M'),
+    );
+
+    expect(page.total, 2);
+    expect(page.rows.length, 2);
+    expect(page.rows.first.matcode, 'MAT001');
+  });
+}


### PR DESCRIPTION
## Summary
- implement the new `inventory_query` module with Freezed models, service, bloc workflow, and UI that mirrors the UniApp库存查询 experience
- wire the module into `AppModule` and the home shortcut grid, extend the shared scanner widget, and document outstanding optional follow-ups in the refactor TODO guide
- add bloc and service unit tests plus dev dependencies (`bloc_test`, `mocktail`), updating the refactor checklist with recorded QA command outcomes

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter analyze --no-pub lib test` *(fails: 604 pre-existing warnings)*
- `flutter test` *(fails: StubGoodsUpTaskService signature drift)*

------
https://chatgpt.com/codex/tasks/task_e_68f215a8b3dc8330916dcde98354e26f