### PR TITLE
fix: skip xn-bl subinventory check and guard task submission

### DIFF
--- a/docs/aswh_up_collection_todo.md
+++ b/docs/aswh_up_collection_todo.md
@@ -28,6 +28,21 @@
 - [x] **Restore missing task grid columns**
   - 补齐任务/库存列表必要字段，保证布局与平库一致。
 
+- [x] **校验条码库房与任务库房保持一致**
+  - 在 `_handleQuantityInput` 中新增 ERP 库房与任务明细库房的比对，不一致时阻断采集并提示原文案。
+
+- [x] **拦截物权/拥有方冲突**
+  - 调用 `getMtlRepertoryByStoresiteNo` 校验库位现存库存的 `erpStoreroom` 与拥有方（`parno`），对齐 UniApp 的异常提示。
+
+- [x] **提交流程校验凭证号非空**
+  - 在 `_onSubmit` 开始阶段校验 `_task.taskComment`，为空时弹出“凭证号为空，请确认”。
+
+- [x] **XN-BL 库房跳过子库冲突校验**
+  - 识别 `storeRoomNo` 为 `XN-BL` 且启用供应商校验的任务，跳过 `erpStoreroom` 与子库编码的比对，仅保留拥有方校验。
+
+- [x] **提交前校验任务号非空**
+  - 在 `_onSubmit` 中追加 `_task.inTaskNo` 判空，提示“任务号为空，请确认”。
+
 - [ ] **Testing & validation**
   - 记录执行的自动化或手工测试步骤。
   - 当前容器缺少 Flutter SDK（`flutter` 命令不可用），待本地环境验证 `flutter test` 及关键手工场景。


### PR DESCRIPTION
## Summary
- skip the subinventory ownership conflict check whenever XN-BL tasks require supplier validation, matching the UniApp guard
- block submissions when the inbound task number is blank to mirror the legacy confirmation flow
- record the completed fixes in the collection TODO tracker

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f606ddcf5c8330992d64b4c0323eba