### PR TITLE
Align ASWH collection tables with common grid

### DIFF
--- a/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart
+++ b/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:wms_app/models/page_status.dart';
 import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
 import 'package:wms_app/modules/aswh_down/models/online_pick_task_models.dart';
 import 'package:wms_app/modules/aswh_down/utils/online_pick_scanner_parser.dart';
 
@@ -25,6 +26,14 @@ class OnlinePickCollectionState extends Equatable {
     this.inventoryQtyMap = const {},
     this.expectedErpStore = '',
     this.currentMode = OnlinePickCollectionModeType.outbound,
+    this.taskItems = const [],
+    this.collectedQtyByItemId = const {},
+    this.inventoryRecords = const [],
+    this.roomMatControl = '0',
+    this.forceSiteCheck = false,
+    this.forceBatchCheck = false,
+    this.materialControls = const {},
+    this.currentMaterialControl,
   });
 
   final CollectionStatus status;
@@ -44,6 +53,14 @@ class OnlinePickCollectionState extends Equatable {
   final Map<String, double> inventoryQtyMap;
   final String expectedErpStore;
   final OnlinePickCollectionModeType currentMode;
+  final List<OnlinePickTaskItem> taskItems;
+  final Map<String, double> collectedQtyByItemId;
+  final List<OnlinePickInventoryRecord> inventoryRecords;
+  final String roomMatControl;
+  final bool forceSiteCheck;
+  final bool forceBatchCheck;
+  final Map<String, OnlinePickMaterialControl> materialControls;
+  final OnlinePickMaterialControl? currentMaterialControl;
 
   OnlinePickCollectionState copyWith({
     CollectionStatus? status,
@@ -63,6 +80,14 @@ class OnlinePickCollectionState extends Equatable {
     Map<String, double>? inventoryQtyMap,
     String? expectedErpStore,
     OnlinePickCollectionModeType? currentMode,
+    List<OnlinePickTaskItem>? taskItems,
+    Map<String, double>? collectedQtyByItemId,
+    List<OnlinePickInventoryRecord>? inventoryRecords,
+    String? roomMatControl,
+    bool? forceSiteCheck,
+    bool? forceBatchCheck,
+    Map<String, OnlinePickMaterialControl>? materialControls,
+    Object? currentMaterialControl = _unset,
   }) {
     return OnlinePickCollectionState(
       status: status ?? this.status,
@@ -91,6 +116,17 @@ class OnlinePickCollectionState extends Equatable {
       inventoryQtyMap: inventoryQtyMap ?? this.inventoryQtyMap,
       expectedErpStore: expectedErpStore ?? this.expectedErpStore,
       currentMode: currentMode ?? this.currentMode,
+      taskItems: taskItems ?? this.taskItems,
+      collectedQtyByItemId:
+          collectedQtyByItemId ?? this.collectedQtyByItemId,
+      inventoryRecords: inventoryRecords ?? this.inventoryRecords,
+      roomMatControl: roomMatControl ?? this.roomMatControl,
+      forceSiteCheck: forceSiteCheck ?? this.forceSiteCheck,
+      forceBatchCheck: forceBatchCheck ?? this.forceBatchCheck,
+      materialControls: materialControls ?? this.materialControls,
+      currentMaterialControl: currentMaterialControl == _unset
+          ? this.currentMaterialControl
+          : currentMaterialControl as OnlinePickMaterialControl?,
     );
   }
 
@@ -113,5 +149,13 @@ class OnlinePickCollectionState extends Equatable {
         inventoryQtyMap,
         expectedErpStore,
         currentMode,
+        taskItems,
+        collectedQtyByItemId,
+        inventoryRecords,
+        roomMatControl,
+        forceSiteCheck,
+        forceBatchCheck,
+        materialControls,
+        currentMaterialControl,
       ];
 }

--- a/lib/modules/aswh_down/collection_task/pages/online_pick_collection_page.dart
+++ b/lib/modules/aswh_down/collection_task/pages/online_pick_collection_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
 import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
 import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
 import 'package:wms_app/modules/aswh_down/utils/online_pick_scanner_parser.dart';
@@ -50,72 +51,54 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('在线拣选采集'),
-        actions: [
-          PopupMenuButton<OnlinePickCollectionModeType>(
-            tooltip: '切换模式',
-            icon: const Icon(Icons.tune),
-            onSelected: (mode) =>
-                _bloc.add(OnlinePickCollectionModeChanged(mode)),
-            itemBuilder: (context) => OnlinePickCollectionModeType.values
-                .map(
-                  (mode) => PopupMenuItem(
-                    value: mode,
-                    child: Text(_modeLabel(mode)),
-                  ),
-                )
-                .toList(),
+    return PopScope(
+      canPop: _bloc.state.collectedStocks.isEmpty,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        _handleBackPress(context);
+      },
+      child: Scaffold(
+        backgroundColor: const Color(0xFFF6F6F6),
+        appBar: AppBar(
+          backgroundColor: const Color(0xFF1976D2),
+          centerTitle: true,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: () => _handleBackPress(context),
           ),
-          IconButton(
-            tooltip: '清空缓存',
-            onPressed: () => _bloc.add(const OnlinePickCollectionCacheCleared()),
-            icon: const Icon(Icons.delete_outline),
+          title: const Text(
+            '在线拣选采集',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
           ),
-          IconButton(
-            tooltip: '重置采集步骤',
-            onPressed: () => _bloc.add(const OnlinePickCollectionStepResetRequested()),
-            icon: const Icon(Icons.refresh),
-          ),
-          IconButton(
-            tooltip: '提交采集结果',
-            onPressed: () => _bloc.add(const OnlinePickCollectionSubmitPressed()),
-            icon: const Icon(Icons.save),
-          ),
-        ],
-      ),
-      body: BlocConsumer<OnlinePickCollectionBloc, OnlinePickCollectionState>(
+          actions: [
+            TextButton(
+              onPressed: _showMoreOptions,
+              child: const Text(
+                '更多',
+                style: TextStyle(color: Colors.white, fontSize: 16),
+              ),
+            ),
+          ],
+        ),
+        body: BlocConsumer<OnlinePickCollectionBloc, OnlinePickCollectionState>(
         listener: (context, state) {
           _handleFocus(state);
           _handleStatusFeedback(context, state);
         },
         builder: (context, state) {
           return Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               if (state.status.isLoading)
                 const LinearProgressIndicator(minHeight: 2),
-              Padding(
-                padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                child: _buildScanInput(state),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  state.currentStepLabel,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
+              _buildScanInput(state),
               const SizedBox(height: 8),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: _buildInfoCards(state),
-              ),
-              const SizedBox(height: 12),
+              _buildInfoCard(state),
+              const SizedBox(height: 8),
               Expanded(child: _buildTabs(state)),
               _buildBottomActions(state),
             ],
@@ -130,6 +113,10 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
       placeholder: state.scannerPlaceholder,
       clearOnSubmit: true,
       autoFocus: false,
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      height: 48,
+      borderRadius: const BorderRadius.vertical(bottom: Radius.circular(8)),
+      backgroundColor: Colors.white,
     );
 
     Widget? suffix;
@@ -169,136 +156,123 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
       );
     }
 
-    return ScannerWidget(
-      controller: _scannerController,
-      config: config,
-      onScanResult: (value) {
-        if (value.trim().isEmpty) return;
-        _bloc.add(OnlinePickCollectionScanSubmitted(value));
-      },
-      onError: (message) {
-        _showSnackBar(
-          context,
-          message,
-          Colors.red.shade600,
-        );
-      },
-      suffix: suffix,
+    return Container(
+      color: Colors.white,
+      child: ScannerWidget(
+        controller: _scannerController,
+        config: config,
+        onScanResult: (value) {
+          if (value.trim().isEmpty) return;
+          _bloc.add(OnlinePickCollectionScanSubmitted(value));
+        },
+        onError: (message) {
+          _showSnackBar(
+            context,
+            message,
+            Colors.red.shade600,
+          );
+        },
+        suffix: suffix,
+      ),
     );
   }
 
-  Widget _buildInfoCards(OnlinePickCollectionState state) {
-    final textTheme = Theme.of(context).textTheme;
-
-    Widget buildTile(String label, String value, {IconData? icon}) {
-      return Expanded(
-        child: Container(
-          margin: const EdgeInsets.only(right: 12, bottom: 12),
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            boxShadow: const [
-              BoxShadow(
-                color: Color(0x11000000),
-                blurRadius: 6,
-                offset: Offset(0, 2),
-              ),
-            ],
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  if (icon != null)
-                    Icon(icon, size: 18, color: const Color(0xFF1E88E5)),
-                  if (icon != null) const SizedBox(width: 4),
-                  Text(
-                    label,
-                    style: textTheme.bodySmall
-                        ?.copyWith(color: Colors.grey.shade600),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 6),
-              Text(
-                value.isEmpty ? '-' : value,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style: textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
+  Widget _buildInfoCard(OnlinePickCollectionState state) {
     final materialName =
         state.barcodeContent?.materialName ?? state.barcodeContent?.materialCode ?? '';
     final qrBatch = state.barcodeContent?.batchNo ?? state.barcodeContent?.serialNumber ?? '';
+    final quantity = state.pendingQuantity == null
+        ? ''
+        : _formatNumber(state.pendingQuantity!.toDouble());
 
-    return Column(
-      children: [
-        Row(
-          children: [
-            buildTile(
-              '模式',
-              _modeLabel(state.currentMode),
-              icon: Icons.tune,
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.vertical(bottom: Radius.circular(8)),
+      ),
+      child: Column(
+        children: [
+          _buildInfoRow('当前步骤：', state.currentStepLabel, '模式：', _modeLabel(state.currentMode)),
+          _buildDottedDivider(),
+          _buildInfoRow('库位：', state.currentLocation ?? '', '托盘：', state.currentTrayNo ?? ''),
+          _buildDottedDivider(),
+          _buildInfoRow('预计子库：', state.expectedErpStore, '采集数量：', quantity),
+          _buildDottedDivider(),
+          _buildInfoRow('物料：', materialName, '批次/序列：', qrBatch),
+          _buildDottedDivider(),
+          _buildInfoRow('下一步：', _nextStepDescription(state.nextExpectedScanType), '', ''),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(
+    String label1,
+    String value1,
+    String label2,
+    String value2,
+  ) {
+    const labelStyle = TextStyle(fontSize: 14, fontWeight: FontWeight.w400);
+    final textColor = Colors.grey.shade800;
+
+    Widget buildCell(String label, String value) {
+      return Row(
+        children: [
+          Container(
+            width: 4,
+            height: 10,
+            margin: const EdgeInsets.only(right: 4),
+            decoration: BoxDecoration(
+              color: const Color(0xFF1976D2),
+              borderRadius: BorderRadius.circular(2),
             ),
-            buildTile(
-              '库位',
-              state.currentLocation ?? '',
-              icon: Icons.location_on_outlined,
+          ),
+          Text(label, style: labelStyle.copyWith(color: textColor)),
+          Expanded(
+            child: Text(
+              value.isEmpty ? '-' : value,
+              style: labelStyle.copyWith(color: textColor),
+              overflow: TextOverflow.ellipsis,
             ),
-          ],
-        ),
-        Row(
-          children: [
-            buildTile(
-              '托盘',
-              state.currentTrayNo ?? '',
-              icon: Icons.inventory_2_outlined,
-            ),
-            buildTile(
-              '预计子库',
-              state.expectedErpStore,
-              icon: Icons.warehouse_outlined,
-            ),
-          ],
-        ),
-        Row(
-          children: [
-            buildTile(
-              '物料',
-              materialName,
-              icon: Icons.qr_code_scanner,
-            ),
-            buildTile(
-              '批次/序列',
-              qrBatch,
-              icon: Icons.tag,
-            ),
-          ],
-        ),
-        Row(
-          children: [
-            buildTile(
-              '采集数量',
-              state.pendingQuantity?.toString() ?? '',
-              icon: Icons.calculate_outlined,
-            ),
-            buildTile(
-              '下一步',
-              _nextStepDescription(state.nextExpectedScanType),
-              icon: Icons.directions_walk,
-            ),
-          ],
-        ),
-      ],
+          ),
+        ],
+      );
+    }
+
+    return SizedBox(
+      height: 32,
+      child: Row(
+        children: [
+          Expanded(child: buildCell(label1, value1)),
+          if (label2.isNotEmpty)
+            const SizedBox(width: 16),
+          if (label2.isNotEmpty) Expanded(child: buildCell(label2, value2)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDottedDivider() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.constrainWidth();
+        const dashWidth = 5.0;
+        const dashSpace = 3.0;
+        final dashCount = (width / (dashWidth + dashSpace)).floor();
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: List.generate(dashCount, (_) {
+            return const SizedBox(
+              width: dashWidth,
+              height: 1,
+              child: DecoratedBox(
+                decoration: BoxDecoration(color: Color(0xFF1976D2)),
+              ),
+            );
+          }),
+        );
+      },
     );
   }
 
@@ -316,24 +290,19 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
     return Column(
       children: [
         Container(
-          margin: const EdgeInsets.symmetric(horizontal: 16),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            borderRadius: BorderRadius.circular(8),
-            boxShadow: const [
-              BoxShadow(
-                color: Color(0x0F000000),
-                blurRadius: 6,
-                offset: Offset(0, 2),
-              ),
-            ],
-          ),
+          height: 44,
+          color: Colors.white,
           child: TabBar(
+            dividerHeight: 0,
             controller: _tabController,
-            labelColor: const Color(0xFF1E88E5),
-            unselectedLabelColor: Colors.grey.shade600,
-            indicatorColor: const Color(0xFF1E88E5),
+            labelColor: const Color(0xFF1976D2),
+            unselectedLabelColor: Colors.grey,
+            indicatorColor: const Color(0xFF1976D2),
             indicatorWeight: 3,
+            labelStyle: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
             tabs: const [
               Tab(text: '任务明细'),
               Tab(text: '采集中'),
@@ -341,14 +310,13 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
             ],
           ),
         ),
-        const SizedBox(height: 8),
         Expanded(
           child: TabBarView(
             controller: _tabController,
-            children: const [
-              _CollectionPlaceholder(title: 'TODO: 任务列表'),
-              _CollectionPlaceholder(title: 'TODO: 正在采集明细'),
-              _CollectionPlaceholder(title: 'TODO: 库存核对'),
+            children: [
+              _buildTaskItemsView(state),
+              _buildCollectedStocksView(state),
+              _buildInventoryRecordsView(state),
             ],
           ),
         ),
@@ -357,8 +325,10 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
   }
 
   Widget _buildBottomActions(OnlinePickCollectionState state) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+    return Container(
+      height: 52,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: const BoxDecoration(color: Colors.white),
       child: Row(
         children: [
           Expanded(
@@ -366,6 +336,16 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
               onPressed: () => _navigateToCollectionResult(state),
               icon: const Icon(Icons.list_alt_outlined),
               label: const Text('采集结果'),
+              style: _outlinedButtonStyle(),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: ElevatedButton.icon(
+              onPressed: () => _showCommandSheet(state),
+              icon: const Icon(Icons.precision_manufacturing_outlined),
+              label: const Text('下发指令'),
+              style: _primaryButtonStyle(),
             ),
           ),
           const SizedBox(width: 12),
@@ -374,10 +354,97 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
               onPressed: () => _navigateToWcs(state),
               icon: const Icon(Icons.send_outlined),
               label: const Text('指令查询'),
+              style: _primaryButtonStyle(),
             ),
           ),
         ],
       ),
+    );
+  }
+
+  ButtonStyle _outlinedButtonStyle() {
+    return OutlinedButton.styleFrom(
+      foregroundColor: const Color(0xFF1976D2),
+      side: const BorderSide(color: Color(0xFF1976D2)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      padding: const EdgeInsets.symmetric(vertical: 12),
+    );
+  }
+
+  ButtonStyle _primaryButtonStyle() {
+    return ElevatedButton.styleFrom(
+      backgroundColor: const Color(0xFF1976D2),
+      foregroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      padding: const EdgeInsets.symmetric(vertical: 12),
+    );
+  }
+
+  void _showMoreOptions() {
+    showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) {
+        final state = _bloc.state;
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '更多操作',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+              ...OnlinePickCollectionModeType.values.map(
+                (mode) => ListTile(
+                  leading: const Icon(Icons.tune, color: Color(0xFF1976D2)),
+                  title: Text(_modeLabel(mode)),
+                  trailing: mode == state.currentMode
+                      ? const Icon(Icons.check, color: Color(0xFF1976D2))
+                      : null,
+                  onTap: () {
+                    Navigator.of(sheetContext).pop();
+                    _bloc.add(OnlinePickCollectionModeChanged(mode));
+                  },
+                ),
+              ),
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.delete_outline, color: Color(0xFFEF5350)),
+                title: const Text('清空缓存'),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  _bloc.add(const OnlinePickCollectionCacheCleared());
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.refresh, color: Color(0xFF1976D2)),
+                title: const Text('重置采集步骤'),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  _bloc.add(const OnlinePickCollectionStepResetRequested());
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.save_alt, color: Color(0xFF1976D2)),
+                title: const Text('提交采集结果'),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  _bloc.add(const OnlinePickCollectionSubmitPressed());
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
     );
   }
 
@@ -522,6 +589,322 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
       );
   }
 
+  void _handleBackPress(BuildContext context) {
+    final state = _bloc.state;
+    if (state.collectedStocks.isNotEmpty) {
+      showDialog<void>(
+        context: context,
+        builder: (dialogContext) {
+          return AlertDialog(
+            title: const Text('提示'),
+            content: const Text('当前采集记录尚未提交，确定退出采集吗？'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(),
+                child: const Text('取消'),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.of(dialogContext).pop();
+                  Modular.to.pop();
+                },
+                child: const Text('确认'),
+              ),
+            ],
+          );
+        },
+      );
+    } else {
+      Modular.to.pop();
+    }
+  }
+
+  Widget _buildTaskItemsView(OnlinePickCollectionState state) {
+    final items = state.taskItems;
+    return _buildGridSection<OnlinePickTaskItem>(
+      data: items,
+      columns: _taskListColumns(),
+      emptyMessage: '暂无任务明细',
+    );
+  }
+
+  Widget _buildCollectedStocksView(OnlinePickCollectionState state) {
+    final stocks = state.collectedStocks;
+    return _buildGridSection<OnlinePickCollectionStock>(
+      data: stocks,
+      columns: _collectingColumns(),
+      emptyMessage: '暂无采集记录',
+    );
+  }
+
+  Widget _buildInventoryRecordsView(OnlinePickCollectionState state) {
+    final records = state.inventoryRecords;
+    return _buildGridSection<OnlinePickInventoryRecord>(
+      data: records,
+      columns: _inventoryColumns(),
+      emptyMessage: '暂无库存核对信息',
+    );
+  }
+
+  Widget _buildGridSection<T>({
+    required List<T> data,
+    required List<GridColumnConfig<T>> columns,
+    required String emptyMessage,
+  }) {
+    final content = data.isEmpty
+        ? _buildEmptyContent(emptyMessage)
+        : CommonDataGrid<T>(
+            columns: columns,
+            datas: data,
+            allowPager: false,
+            allowSelect: false,
+            onLoadData: (_) async {},
+          );
+
+    return _buildTableCard(content);
+  }
+
+  Widget _buildTableCard(Widget child) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey.shade200),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0C000000),
+            blurRadius: 8,
+            offset: Offset(0, 2),
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+
+  Widget _buildEmptyContent(String message) {
+    return SizedBox(
+      height: 240,
+      child: Center(
+        child: Text(
+          message,
+          style: Theme.of(context)
+              .textTheme
+              .bodyMedium
+              ?.copyWith(color: Colors.grey.shade600),
+        ),
+      ),
+    );
+  }
+
+  List<GridColumnConfig<OnlinePickTaskItem>> _taskListColumns() {
+    return [
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'storeSiteNo',
+        headerText: '库位',
+        width: 140,
+        valueGetter: (item) => item.storeSiteNo ?? '-',
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'palletNo',
+        headerText: '托盘',
+        width: 140,
+        valueGetter: (item) => item.palletNo ?? '-',
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'materialCode',
+        headerText: '物料编码',
+        width: 160,
+        enableSelectableText: true,
+        valueGetter: (item) => item.materialCode ?? '-',
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'materialName',
+        headerText: '物料名称',
+        width: 180,
+        valueGetter: (item) => item.materialName ?? '-',
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'taskQty',
+        headerText: '任务数量',
+        width: 110,
+        textAlign: TextAlign.right,
+        valueGetter: (item) => item.taskQty,
+        formatter: (value, _) => _formatNumber(value as num?),
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'collectedQty',
+        headerText: '已采集',
+        width: 110,
+        textAlign: TextAlign.right,
+        valueGetter: (item) => item.collectedQty,
+        formatter: (value, _) => _formatNumber(value as num?),
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'difference',
+        headerText: '差异',
+        width: 110,
+        textAlign: TextAlign.right,
+        textStyle: const TextStyle(color: Color(0xFFD32F2F)),
+        valueGetter: (item) => item.taskQty - item.collectedQty,
+        formatter: (value, _) => _formatNumber(value as num?),
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'subInventoryCode',
+        headerText: '子库',
+        width: 120,
+        valueGetter: (item) => item.subInventoryCode ?? '-',
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'batchOrSerial',
+        headerText: '批次/序列',
+        width: 160,
+        valueGetter: (item) =>
+            item.batchNo ?? item.serialNumber ?? item.hintBatchNo ?? '-',
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'taskComment',
+        headerText: '备注',
+        width: 160,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        valueGetter: (item) => item.taskComment ?? '-',
+      ),
+    ];
+  }
+
+  List<GridColumnConfig<OnlinePickCollectionStock>> _collectingColumns() {
+    return [
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'trayNo',
+        headerText: '托盘',
+        width: 140,
+        valueGetter: (stock) => stock.trayNo ?? '-',
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'storeSite',
+        headerText: '库位',
+        width: 140,
+        valueGetter: (stock) => stock.storeSite ?? '-',
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'materialCode',
+        headerText: '物料编码',
+        width: 160,
+        enableSelectableText: true,
+        valueGetter: (stock) => stock.materialCode,
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'batchOrSerial',
+        headerText: '批次/序列',
+        width: 160,
+        valueGetter: (stock) => stock.batchNo ?? stock.serialNumber ?? '-',
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'taskQty',
+        headerText: '任务数量',
+        width: 110,
+        textAlign: TextAlign.right,
+        valueGetter: (stock) => stock.taskQty,
+        formatter: (value, _) => _formatNumber(value as num?),
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'collectQty',
+        headerText: '采集数量',
+        width: 110,
+        textAlign: TextAlign.right,
+        valueGetter: (stock) => stock.collectQty,
+        formatter: (value, _) => _formatNumber(value as num?),
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'erpStore',
+        headerText: '子库',
+        width: 120,
+        valueGetter: (stock) => stock.erpStore ?? '-',
+      ),
+    ];
+  }
+
+  List<GridColumnConfig<OnlinePickInventoryRecord>> _inventoryColumns() {
+    return [
+      GridColumnConfig<OnlinePickInventoryRecord>(
+        name: 'storeSite',
+        headerText: '库位',
+        width: 140,
+        valueGetter: (record) => record.storeSite ?? '-',
+      ),
+      GridColumnConfig<OnlinePickInventoryRecord>(
+        name: 'materialCode',
+        headerText: '物料编码',
+        width: 160,
+        enableSelectableText: true,
+        valueGetter: (record) => record.materialCode,
+      ),
+      GridColumnConfig<OnlinePickInventoryRecord>(
+        name: 'materialName',
+        headerText: '物料名称',
+        width: 180,
+        valueGetter: (record) => record.materialName ?? '-',
+      ),
+      GridColumnConfig<OnlinePickInventoryRecord>(
+        name: 'taskQty',
+        headerText: '任务数量',
+        width: 110,
+        textAlign: TextAlign.right,
+        valueGetter: (record) => record.taskQty,
+        formatter: (value, _) => _formatNumber(value as num?),
+      ),
+      GridColumnConfig<OnlinePickInventoryRecord>(
+        name: 'collectedQty',
+        headerText: '已采集',
+        width: 110,
+        textAlign: TextAlign.right,
+        valueGetter: (record) => record.collectedQty,
+        formatter: (value, _) => _formatNumber(value as num?),
+      ),
+      GridColumnConfig<OnlinePickInventoryRecord>(
+        name: 'difference',
+        headerText: '差异',
+        width: 110,
+        textAlign: TextAlign.right,
+        textStyle: const TextStyle(color: Color(0xFFD32F2F)),
+        valueGetter: (record) => record.difference,
+        formatter: (value, _) => _formatNumber(value as num?),
+      ),
+      GridColumnConfig<OnlinePickInventoryRecord>(
+        name: 'erpStore',
+        headerText: '子库',
+        width: 120,
+        valueGetter: (record) => record.erpStore ?? '-',
+      ),
+      GridColumnConfig<OnlinePickInventoryRecord>(
+        name: 'trayNo',
+        headerText: '托盘',
+        width: 140,
+        valueGetter: (record) => record.trayNo ?? '-',
+      ),
+    ];
+  }
+
+  String _formatNumber(num? value) {
+    if (value == null) {
+      return '-';
+    }
+    final doubleValue = value.toDouble();
+    if ((doubleValue - doubleValue.round()).abs() < 1e-6) {
+      return doubleValue.toStringAsFixed(0);
+    }
+    var formatted = doubleValue.toStringAsFixed(3);
+    while (formatted.contains('.') && formatted.endsWith('0')) {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+    if (formatted.endsWith('.')) {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+    return formatted;
+  }
+
   String _nextStepDescription(OnlinePickScanType type) {
     switch (type) {
       case OnlinePickScanType.location:
@@ -534,30 +917,153 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
         return '等待录入数量';
     }
   }
-}
 
-class _CollectionPlaceholder extends StatelessWidget {
-  const _CollectionPlaceholder({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      alignment: Alignment.center,
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.grey.shade200),
+  Future<void> _showCommandSheet(OnlinePickCollectionState state) async {
+    final options = [
+      const _CommandOption(
+        label: '单个来料盘',
+        commandType: OnlinePickCommandType.downShelf,
+        singleFlag: 'Y',
       ),
-      child: Text(
-        title,
-        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Colors.grey.shade600,
+      const _CommandOption(
+        label: '全部托盘',
+        commandType: OnlinePickCommandType.downShelf,
+        singleFlag: 'N',
+      ),
+      const _CommandOption(
+        label: '盘点下架',
+        commandType: OnlinePickCommandType.inventoryDownShelf,
+      ),
+      const _CommandOption(
+        label: '空托盘下架',
+        commandType: OnlinePickCommandType.emptyTray,
+      ),
+      const _CommandOption(
+        label: '回库重置',
+        commandType: OnlinePickCommandType.reset,
+      ),
+      const _CommandOption(
+        label: '盘点回库',
+        commandType: OnlinePickCommandType.inventoryReset,
+      ),
+    ];
+
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const ListTile(
+                title: Text(
+                  '选择指令类型',
+                  style: TextStyle(fontWeight: FontWeight.w600),
+                ),
+              ),
+              for (final option in options)
+                ListTile(
+                  leading: const Icon(Icons.chevron_right),
+                  title: Text(option.label),
+                  onTap: () {
+                    Navigator.of(context).pop();
+                    _promptCommand(option, state);
+                  },
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _promptCommand(
+    _CommandOption option,
+    OnlinePickCollectionState state,
+  ) async {
+    final startController = TextEditingController();
+    final endController = TextEditingController();
+    final trayController =
+        TextEditingController(text: state.currentTrayNo ?? '');
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(option.label),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: startController,
+                decoration: const InputDecoration(labelText: '起始地址'),
+              ),
+              TextField(
+                controller: endController,
+                decoration: const InputDecoration(labelText: '目标地址'),
+              ),
+              TextField(
+                controller: trayController,
+                decoration: const InputDecoration(labelText: '托盘号'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
             ),
-        textAlign: TextAlign.center,
+            ElevatedButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('确定'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmed != true) {
+      startController.dispose();
+      endController.dispose();
+      trayController.dispose();
+      return;
+    }
+
+    final start = startController.text.trim();
+    final end = endController.text.trim();
+    final tray = trayController.text.trim().isEmpty
+        ? state.currentTrayNo
+        : trayController.text.trim();
+
+    startController.dispose();
+    endController.dispose();
+    trayController.dispose();
+
+    if (start.isEmpty || end.isEmpty) {
+      _showSnackBar(context, '请填写完整的起始地址和目标地址', Colors.orange.shade600);
+      return;
+    }
+
+    _bloc.add(
+      OnlinePickCollectionCommandSubmitted(
+        commandType: option.commandType,
+        startAddress: start,
+        endAddress: end,
+        trayNo: tray,
+        singleFlag: option.singleFlag,
       ),
     );
   }
+}
+
+class _CommandOption {
+  const _CommandOption({
+    required this.label,
+    required this.commandType,
+    this.singleFlag = 'N',
+  });
+
+  final String label;
+  final OnlinePickCommandType commandType;
+  final String singleFlag;
 }

--- a/lib/modules/aswh_down/models/online_pick_collection_models.dart
+++ b/lib/modules/aswh_down/models/online_pick_collection_models.dart
@@ -161,3 +161,86 @@ class OnlinePickCollectionCacheSnapshot
   ) =>
       _$OnlinePickCollectionCacheSnapshotFromJson(json);
 }
+
+/// 物料控制配置。
+class OnlinePickMaterialControl {
+  const OnlinePickMaterialControl({
+    required this.controlFlag,
+    this.sendControl = '0',
+  });
+
+  /// 物料控制模式：0-序列号、1/2-批次。
+  final int controlFlag;
+
+  /// 物料发送控制标记。
+  final String sendControl;
+
+  bool get isSerialControl => controlFlag == 0;
+
+  bool get isBatchControl => controlFlag == 1 || controlFlag == 2;
+
+  OnlinePickMaterialControl copyWith({
+    int? controlFlag,
+    String? sendControl,
+  }) {
+    return OnlinePickMaterialControl(
+      controlFlag: controlFlag ?? this.controlFlag,
+      sendControl: sendControl ?? this.sendControl,
+    );
+  }
+}
+
+/// 库存核对记录。
+class OnlinePickInventoryRecord {
+  const OnlinePickInventoryRecord({
+    required this.outTaskItemId,
+    required this.materialCode,
+    this.materialName,
+    this.storeSite,
+    this.trayNo,
+    this.batchNo,
+    this.serialNumber,
+    this.erpStore,
+    this.taskQty = 0,
+    this.collectedQty = 0,
+  });
+
+  final String outTaskItemId;
+  final String materialCode;
+  final String? materialName;
+  final String? storeSite;
+  final String? trayNo;
+  final String? batchNo;
+  final String? serialNumber;
+  final String? erpStore;
+  final num taskQty;
+  final num collectedQty;
+
+  num get difference => taskQty - collectedQty;
+
+  OnlinePickInventoryRecord copyWith({
+    String? outTaskItemId,
+    String? materialCode,
+    String? materialName,
+    String? storeSite,
+    String? trayNo,
+    String? batchNo,
+    String? serialNumber,
+    String? erpStore,
+    num? taskQty,
+    num? collectedQty,
+  }) {
+    return OnlinePickInventoryRecord(
+      outTaskItemId: outTaskItemId ?? this.outTaskItemId,
+      materialCode: materialCode ?? this.materialCode,
+      materialName: materialName ?? this.materialName,
+      storeSite: storeSite ?? this.storeSite,
+      trayNo: trayNo ?? this.trayNo,
+      batchNo: batchNo ?? this.batchNo,
+      serialNumber: serialNumber ?? this.serialNumber,
+      erpStore: erpStore ?? this.erpStore,
+      taskQty: taskQty ?? this.taskQty,
+      collectedQty: collectedQty ?? this.collectedQty,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- switch the ASWH collection tabs to the shared CommonDataGrid component
- add column configurations matching task, collecting, and inventory datasets
- reuse the outbound-style card wrapper so empty states and grids share the same styling

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ff18fbf9a8833091eb6243dd0a7a53