### PR TITLE
Align cache snapshot models with new inventory fields

### DIFF
--- a/lib/modules/aswh_down/collection_task/REFACTOR_TODO.md
+++ b/lib/modules/aswh_down/collection_task/REFACTOR_TODO.md
@@ -11,3 +11,7 @@
 - [x] 实现托盘/指令相关操作：提交采集、托盘获取、空盘出入库、回库、WCS 指令查询等流程，调用服务层 `commitASWHDownShelves`、`commitDownWmsToWcs`、`commitEmptyTrayWmsToWcs`、`commitResetWmsToWcs` 等接口，并适配现有 WCS Bloc 页面。
 - [x] 搭建 `AswhDownCollectionResultPage`，复刻 NVUE 采集结果列表（含多选删除、统计提示），并与主页面通过 `Navigator` 传递、回收删除记录。
 - [x] 设计采集缓存持久化：替换 NVUE 中的 `uni.setStorageSync` 方案，使用 Hive 存储 `OnlinePickCollectionCacheSnapshot`，支持离线恢复与退出提醒。
+
+- [x] 补齐扫码物料校验流程：串联管控标识、库位与 ERP 子库库存校验，防止无效条码进入数量录入。
+- [x] 优化数量采集：按任务剩余量与库存上限分摊采集数量，并同步多行任务的计划/采集映射。
+- [x] 恢复库存核对模式：记录结余数据至库存核对列表，随提交一起上传并在界面单独展示。

--- a/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart
+++ b/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart
@@ -14,6 +14,7 @@ class OnlinePickCollectionState {
   final OnlinePickCollectionStep step;
   final String placeholder;
   final String currentTrayCode;
+  final String currentStoreSite;
   final int currentTab;
   final List<int> selectedItemIds;
   final bool focus;
@@ -26,6 +27,13 @@ class OnlinePickCollectionState {
   final Map<String, List<double>> dicMtlQty;
   final Map<String, double> dicInvMtlQty;
   final List<String> issuedTrayNos;
+  final List<OnlinePickInventoryCheckRecord> inventoryCheckRecords;
+  final String roomMatControl;
+  final String matControlFlag;
+  final String matSendControl;
+  final String erpRoom;
+  final String erpStoreInv;
+  final double availableInventory;
 
   const OnlinePickCollectionState({
     this.status = const CollectionStatus(CollectionStatusType.normal),
@@ -38,6 +46,7 @@ class OnlinePickCollectionState {
     this.step = OnlinePickCollectionStep.location,
     this.placeholder = '请扫描库位',
     this.currentTrayCode = '',
+    this.currentStoreSite = '',
     this.currentTab = 0,
     this.selectedItemIds = const [],
     this.focus = false,
@@ -66,6 +75,13 @@ class OnlinePickCollectionState {
     this.dicMtlQty = const {},
     this.dicInvMtlQty = const {},
     this.issuedTrayNos = const [],
+    this.inventoryCheckRecords = const [],
+    this.roomMatControl = '0',
+    this.matControlFlag = '',
+    this.matSendControl = '0',
+    this.erpRoom = '',
+    this.erpStoreInv = '',
+    this.availableInventory = 0,
   });
 
   OnlinePickCollectionState copyWith({
@@ -79,6 +95,7 @@ class OnlinePickCollectionState {
     OnlinePickCollectionStep? step,
     String? placeholder,
     String? currentTrayCode,
+    String? currentStoreSite,
     int? currentTab,
     List<int>? selectedItemIds,
     bool? focus,
@@ -92,6 +109,13 @@ class OnlinePickCollectionState {
     Map<String, List<double>>? dicMtlQty,
     Map<String, double>? dicInvMtlQty,
     List<String>? issuedTrayNos,
+    List<OnlinePickInventoryCheckRecord>? inventoryCheckRecords,
+    String? roomMatControl,
+    String? matControlFlag,
+    String? matSendControl,
+    String? erpRoom,
+    String? erpStoreInv,
+    double? availableInventory,
   }) {
     return OnlinePickCollectionState(
       status: status ?? this.status,
@@ -106,6 +130,7 @@ class OnlinePickCollectionState {
       step: step ?? this.step,
       placeholder: placeholder ?? this.placeholder,
       currentTrayCode: currentTrayCode ?? this.currentTrayCode,
+      currentStoreSite: currentStoreSite ?? this.currentStoreSite,
       currentTab: currentTab ?? this.currentTab,
       selectedItemIds: selectedItemIds ?? this.selectedItemIds,
       focus: focus ?? this.focus,
@@ -118,6 +143,14 @@ class OnlinePickCollectionState {
       dicMtlQty: dicMtlQty ?? this.dicMtlQty,
       dicInvMtlQty: dicInvMtlQty ?? this.dicInvMtlQty,
       issuedTrayNos: issuedTrayNos ?? this.issuedTrayNos,
+      inventoryCheckRecords:
+          inventoryCheckRecords ?? this.inventoryCheckRecords,
+      roomMatControl: roomMatControl ?? this.roomMatControl,
+      matControlFlag: matControlFlag ?? this.matControlFlag,
+      matSendControl: matSendControl ?? this.matSendControl,
+      erpRoom: erpRoom ?? this.erpRoom,
+      erpStoreInv: erpStoreInv ?? this.erpStoreInv,
+      availableInventory: availableInventory ?? this.availableInventory,
     );
   }
 }

--- a/lib/modules/aswh_down/collection_task/pages/online_pick_collection_page.dart
+++ b/lib/modules/aswh_down/collection_task/pages/online_pick_collection_page.dart
@@ -90,7 +90,7 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
                     children: [
                       _buildTaskGrid(state, state.taskItems),
                       _buildTaskGrid(state, state.currentTrayItems),
-                      _buildTaskGrid(state, state.pendingCheckItems),
+                      _buildInventoryCheckList(state),
                     ],
                   ),
                 ),
@@ -236,7 +236,7 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
         tabs: const [
           Tab(text: '任务列表'),
           Tab(text: '当前托盘'),
-          Tab(text: '待校验'),
+          Tab(text: '库存核对'),
         ],
         onTap: (index) {
           _bloc.add(ChangeCollectionTabEvent(index));
@@ -269,6 +269,76 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
     );
   }
 
+  Widget _buildInventoryCheckList(OnlinePickCollectionState state) {
+    final records = state.inventoryCheckRecords;
+    if (records.isEmpty) {
+      return _buildEmptyPlaceholder('暂无库存核对记录');
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.all(16),
+      itemCount: records.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final record = records[index];
+        return Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: const [
+              BoxShadow(
+                color: Color(0x14000000),
+                offset: Offset(0, 2),
+                blurRadius: 6,
+              ),
+            ],
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '物料：${record.materialCode}',
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 16,
+                runSpacing: 8,
+                children: [
+                  _buildInfoChip(
+                    '托盘',
+                    record.trayNo.isEmpty ? '-' : record.trayNo,
+                  ),
+                  _buildInfoChip(
+                    '库位',
+                    record.storeSite.isEmpty ? '-' : record.storeSite,
+                  ),
+                  _buildInfoChip(
+                    '结余数量',
+                    record.quantity.toString(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyPlaceholder(String message) {
+    return Center(
+      child: Text(
+        message,
+        style: const TextStyle(color: Colors.grey),
+      ),
+    );
+  }
+
   Widget _buildBottomBar(OnlinePickCollectionState state) {
     return SafeArea(
       child: Container(
@@ -295,7 +365,8 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
             Expanded(
               child: ElevatedButton(
                 style: _primaryActionStyle(),
-                onPressed: state.collectedStocks.isEmpty
+                onPressed: state.collectedStocks.isEmpty ||
+                        state.inventoryCheckRecords.isEmpty
                     ? null
                     : () => _confirmSubmit(state),
                 child: const Text('提交采集'),

--- a/lib/modules/aswh_down/models/online_pick_collection_models.dart
+++ b/lib/modules/aswh_down/models/online_pick_collection_models.dart
@@ -70,6 +70,76 @@ class OnlinePickCollectionStock with _$OnlinePickCollectionStock {
       _$OnlinePickCollectionStockFromJson(json);
 }
 
+/// 库存核对记录。
+@HiveType(typeId: 43)
+class OnlinePickInventoryCheckRecord {
+  const OnlinePickInventoryCheckRecord({
+    @HiveField(0) this.recordId = '',
+    @HiveField(1) @JsonKey(name: 'matCode') required this.materialCode,
+    @HiveField(2) @JsonKey(name: 'trayNo') required this.trayNo,
+    @HiveField(3) @JsonKey(name: 'storeSite') required this.storeSite,
+    @HiveField(4) @JsonKey(name: 'collectQty') this.quantity = 0,
+  });
+
+  factory OnlinePickInventoryCheckRecord.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return OnlinePickInventoryCheckRecord(
+      recordId: json['stockid']?.toString() ?? '',
+      materialCode: json['matCode']?.toString() ?? '',
+      trayNo: json['trayNo']?.toString() ?? '',
+      storeSite: json['storeSite']?.toString() ?? '',
+      quantity: json['collectQty'] is num
+          ? json['collectQty'] as num
+          : num.tryParse(json['collectQty']?.toString() ?? '0') ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'stockid': recordId,
+        'matCode': materialCode,
+        'trayNo': trayNo,
+        'storeSite': storeSite,
+        'collectQty': quantity,
+      };
+
+  OnlinePickInventoryCheckRecord copyWith({
+    String? recordId,
+    String? materialCode,
+    String? trayNo,
+    String? storeSite,
+    num? quantity,
+  }) {
+    return OnlinePickInventoryCheckRecord(
+      recordId: recordId ?? this.recordId,
+      materialCode: materialCode ?? this.materialCode,
+      trayNo: trayNo ?? this.trayNo,
+      storeSite: storeSite ?? this.storeSite,
+      quantity: quantity ?? this.quantity,
+    );
+  }
+
+  @HiveField(0)
+  @JsonKey(name: 'stockid')
+  final String recordId;
+
+  @HiveField(1)
+  @JsonKey(name: 'matCode')
+  final String materialCode;
+
+  @HiveField(2)
+  @JsonKey(name: 'trayNo')
+  final String trayNo;
+
+  @HiveField(3)
+  @JsonKey(name: 'storeSite')
+  final String storeSite;
+
+  @HiveField(4)
+  @JsonKey(name: 'collectQty')
+  final num quantity;
+}
+
 /// 自动化仓库拣选模式。
 @freezed
 class OnlinePickCollectionMode with _$OnlinePickCollectionMode {
@@ -154,6 +224,16 @@ class OnlinePickCollectionCacheSnapshot
     @HiveField(8) num? pendingQuantity,
     @HiveField(9) @Default('outbound') String mode,
     @HiveField(10) @Default('') String expectedErpStore,
+    @HiveField(11)
+    @Default(<OnlinePickInventoryCheckRecord>[])
+    List<OnlinePickInventoryCheckRecord> inventoryChecks,
+    @HiveField(12) @Default('0') String roomMatControl,
+    @HiveField(13) @Default('') String currentStoreSite,
+    @HiveField(14) @Default('') String matControlFlag,
+    @HiveField(15) @Default('') String matSendControl,
+    @HiveField(16) @Default('') String erpRoom,
+    @HiveField(17) @Default('') String erpStoreInv,
+    @HiveField(18) @Default(0) double availableInventory,
   }) = _OnlinePickCollectionCacheSnapshot;
 
   factory OnlinePickCollectionCacheSnapshot.fromJson(

--- a/lib/modules/aswh_down/models/online_pick_collection_models.freezed.dart
+++ b/lib/modules/aswh_down/models/online_pick_collection_models.freezed.dart
@@ -1847,6 +1847,23 @@ mixin _$OnlinePickCollectionCacheSnapshot {
   String get mode => throw _privateConstructorUsedError;
   @HiveField(10)
   String get expectedErpStore => throw _privateConstructorUsedError;
+  @HiveField(11)
+  List<OnlinePickInventoryCheckRecord> get inventoryChecks =>
+      throw _privateConstructorUsedError;
+  @HiveField(12)
+  String get roomMatControl => throw _privateConstructorUsedError;
+  @HiveField(13)
+  String get currentStoreSite => throw _privateConstructorUsedError;
+  @HiveField(14)
+  String get matControlFlag => throw _privateConstructorUsedError;
+  @HiveField(15)
+  String get matSendControl => throw _privateConstructorUsedError;
+  @HiveField(16)
+  String get erpRoom => throw _privateConstructorUsedError;
+  @HiveField(17)
+  String get erpStoreInv => throw _privateConstructorUsedError;
+  @HiveField(18)
+  double get availableInventory => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -1873,7 +1890,15 @@ abstract class $OnlinePickCollectionCacheSnapshotCopyWith<$Res> {
       @HiveField(7) int userId,
       @HiveField(8) num? pendingQuantity,
       @HiveField(9) String mode,
-      @HiveField(10) String expectedErpStore});
+      @HiveField(10) String expectedErpStore,
+      @HiveField(11) List<OnlinePickInventoryCheckRecord> inventoryChecks,
+      @HiveField(12) String roomMatControl,
+      @HiveField(13) String currentStoreSite,
+      @HiveField(14) String matControlFlag,
+      @HiveField(15) String matSendControl,
+      @HiveField(16) String erpRoom,
+      @HiveField(17) String erpStoreInv,
+      @HiveField(18) double availableInventory});
 
   $OnlinePickBarcodeContentCopyWith<$Res>? get lastBarcode;
 }
@@ -1903,6 +1928,14 @@ class _$OnlinePickCollectionCacheSnapshotCopyWithImpl<$Res,
     Object? pendingQuantity = freezed,
     Object? mode = null,
     Object? expectedErpStore = null,
+    Object? inventoryChecks = null,
+    Object? roomMatControl = null,
+    Object? currentStoreSite = null,
+    Object? matControlFlag = null,
+    Object? matSendControl = null,
+    Object? erpRoom = null,
+    Object? erpStoreInv = null,
+    Object? availableInventory = null,
   }) {
     return _then(_value.copyWith(
       stocks: null == stocks
@@ -1949,6 +1982,38 @@ class _$OnlinePickCollectionCacheSnapshotCopyWithImpl<$Res,
           ? _value.expectedErpStore
           : expectedErpStore // ignore: cast_nullable_to_non_nullable
               as String,
+      inventoryChecks: null == inventoryChecks
+          ? _value._inventoryChecks
+          : inventoryChecks // ignore: cast_nullable_to_non_nullable
+              as List<OnlinePickInventoryCheckRecord>,
+      roomMatControl: null == roomMatControl
+          ? _value.roomMatControl
+          : roomMatControl // ignore: cast_nullable_to_non_nullable
+              as String,
+      currentStoreSite: null == currentStoreSite
+          ? _value.currentStoreSite
+          : currentStoreSite // ignore: cast_nullable_to_non_nullable
+              as String,
+      matControlFlag: null == matControlFlag
+          ? _value.matControlFlag
+          : matControlFlag // ignore: cast_nullable_to_non_nullable
+              as String,
+      matSendControl: null == matSendControl
+          ? _value.matSendControl
+          : matSendControl // ignore: cast_nullable_to_non_nullable
+              as String,
+      erpRoom: null == erpRoom
+          ? _value.erpRoom
+          : erpRoom // ignore: cast_nullable_to_non_nullable
+              as String,
+      erpStoreInv: null == erpStoreInv
+          ? _value.erpStoreInv
+          : erpStoreInv // ignore: cast_nullable_to_non_nullable
+              as String,
+      availableInventory: null == availableInventory
+          ? _value.availableInventory
+          : availableInventory // ignore: cast_nullable_to_non_nullable
+              as double,
     ) as $Val);
   }
 
@@ -1986,7 +2051,15 @@ abstract class _$$OnlinePickCollectionCacheSnapshotImplCopyWith<$Res>
       @HiveField(7) int userId,
       @HiveField(8) num? pendingQuantity,
       @HiveField(9) String mode,
-      @HiveField(10) String expectedErpStore});
+      @HiveField(10) String expectedErpStore,
+      @HiveField(11) List<OnlinePickInventoryCheckRecord> inventoryChecks,
+      @HiveField(12) String roomMatControl,
+      @HiveField(13) String currentStoreSite,
+      @HiveField(14) String matControlFlag,
+      @HiveField(15) String matSendControl,
+      @HiveField(16) String erpRoom,
+      @HiveField(17) String erpStoreInv,
+      @HiveField(18) double availableInventory});
 
   @override
   $OnlinePickBarcodeContentCopyWith<$Res>? get lastBarcode;
@@ -2016,6 +2089,14 @@ class __$$OnlinePickCollectionCacheSnapshotImplCopyWithImpl<$Res>
     Object? pendingQuantity = freezed,
     Object? mode = null,
     Object? expectedErpStore = null,
+    Object? inventoryChecks = null,
+    Object? roomMatControl = null,
+    Object? currentStoreSite = null,
+    Object? matControlFlag = null,
+    Object? matSendControl = null,
+    Object? erpRoom = null,
+    Object? erpStoreInv = null,
+    Object? availableInventory = null,
   }) {
     return _then(_$OnlinePickCollectionCacheSnapshotImpl(
       stocks: null == stocks
@@ -2062,6 +2143,38 @@ class __$$OnlinePickCollectionCacheSnapshotImplCopyWithImpl<$Res>
           ? _value.expectedErpStore
           : expectedErpStore // ignore: cast_nullable_to_non_nullable
               as String,
+      inventoryChecks: null == inventoryChecks
+          ? _value.inventoryChecks
+          : inventoryChecks // ignore: cast_nullable_to_non_nullable
+              as List<OnlinePickInventoryCheckRecord>,
+      roomMatControl: null == roomMatControl
+          ? _value.roomMatControl
+          : roomMatControl // ignore: cast_nullable_to_non_nullable
+              as String,
+      currentStoreSite: null == currentStoreSite
+          ? _value.currentStoreSite
+          : currentStoreSite // ignore: cast_nullable_to_non_nullable
+              as String,
+      matControlFlag: null == matControlFlag
+          ? _value.matControlFlag
+          : matControlFlag // ignore: cast_nullable_to_non_nullable
+              as String,
+      matSendControl: null == matSendControl
+          ? _value.matSendControl
+          : matSendControl // ignore: cast_nullable_to_non_nullable
+              as String,
+      erpRoom: null == erpRoom
+          ? _value.erpRoom
+          : erpRoom // ignore: cast_nullable_to_non_nullable
+              as String,
+      erpStoreInv: null == erpStoreInv
+          ? _value.erpStoreInv
+          : erpStoreInv // ignore: cast_nullable_to_non_nullable
+              as String,
+      availableInventory: null == availableInventory
+          ? _value.availableInventory
+          : availableInventory // ignore: cast_nullable_to_non_nullable
+              as double,
     ));
   }
 }
@@ -2084,11 +2197,22 @@ class _$OnlinePickCollectionCacheSnapshotImpl
       @HiveField(7) this.userId = 0,
       @HiveField(8) this.pendingQuantity,
       @HiveField(9) this.mode = 'outbound',
-      @HiveField(10) this.expectedErpStore = ''})
+      @HiveField(10) this.expectedErpStore = '',
+      @HiveField(11)
+      final List<OnlinePickInventoryCheckRecord> inventoryChecks =
+          const <OnlinePickInventoryCheckRecord>[],
+      @HiveField(12) this.roomMatControl = '0',
+      @HiveField(13) this.currentStoreSite = '',
+      @HiveField(14) this.matControlFlag = '',
+      @HiveField(15) this.matSendControl = '',
+      @HiveField(16) this.erpRoom = '',
+      @HiveField(17) this.erpStoreInv = '',
+      @HiveField(18) this.availableInventory = 0})
       : _stocks = stocks,
         _dicSeq = dicSeq,
         _dicMtlQty = dicMtlQty,
-        _dicInvMtlQty = dicInvMtlQty;
+        _dicInvMtlQty = dicInvMtlQty,
+        _inventoryChecks = inventoryChecks;
 
   factory _$OnlinePickCollectionCacheSnapshotImpl.fromJson(
           Map<String, dynamic> json) =>
@@ -2134,6 +2258,16 @@ class _$OnlinePickCollectionCacheSnapshotImpl
     return EqualUnmodifiableMapView(_dicInvMtlQty);
   }
 
+  final List<OnlinePickInventoryCheckRecord> _inventoryChecks;
+  @override
+  @JsonKey()
+  @HiveField(11)
+  List<OnlinePickInventoryCheckRecord> get inventoryChecks {
+    if (_inventoryChecks is EqualUnmodifiableListView) return _inventoryChecks;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_inventoryChecks);
+  }
+
   @override
   @HiveField(4)
   final OnlinePickBarcodeContent? lastBarcode;
@@ -2160,10 +2294,38 @@ class _$OnlinePickCollectionCacheSnapshotImpl
   @JsonKey()
   @HiveField(10)
   final String expectedErpStore;
+  @override
+  @JsonKey()
+  @HiveField(12)
+  final String roomMatControl;
+  @override
+  @JsonKey()
+  @HiveField(13)
+  final String currentStoreSite;
+  @override
+  @JsonKey()
+  @HiveField(14)
+  final String matControlFlag;
+  @override
+  @JsonKey()
+  @HiveField(15)
+  final String matSendControl;
+  @override
+  @JsonKey()
+  @HiveField(16)
+  final String erpRoom;
+  @override
+  @JsonKey()
+  @HiveField(17)
+  final String erpStoreInv;
+  @override
+  @JsonKey()
+  @HiveField(18)
+  final double availableInventory;
 
   @override
   String toString() {
-    return 'OnlinePickCollectionCacheSnapshot(stocks: $stocks, dicSeq: $dicSeq, dicMtlQty: $dicMtlQty, dicInvMtlQty: $dicInvMtlQty, lastBarcode: $lastBarcode, location: $location, trayNo: $trayNo, userId: $userId, pendingQuantity: $pendingQuantity, mode: $mode, expectedErpStore: $expectedErpStore)';
+    return 'OnlinePickCollectionCacheSnapshot(stocks: $stocks, dicSeq: $dicSeq, dicMtlQty: $dicMtlQty, dicInvMtlQty: $dicInvMtlQty, lastBarcode: $lastBarcode, location: $location, trayNo: $trayNo, userId: $userId, pendingQuantity: $pendingQuantity, mode: $mode, expectedErpStore: $expectedErpStore, inventoryChecks: $inventoryChecks, roomMatControl: $roomMatControl, currentStoreSite: $currentStoreSite, matControlFlag: $matControlFlag, matSendControl: $matSendControl, erpRoom: $erpRoom, erpStoreInv: $erpStoreInv, availableInventory: $availableInventory)';
   }
 
   @override
@@ -2177,6 +2339,8 @@ class _$OnlinePickCollectionCacheSnapshotImpl
                 .equals(other._dicMtlQty, _dicMtlQty) &&
             const DeepCollectionEquality()
                 .equals(other._dicInvMtlQty, _dicInvMtlQty) &&
+            const DeepCollectionEquality()
+                .equals(other._inventoryChecks, _inventoryChecks) &&
             (identical(other.lastBarcode, lastBarcode) ||
                 other.lastBarcode == lastBarcode) &&
             (identical(other.location, location) ||
@@ -2187,7 +2351,20 @@ class _$OnlinePickCollectionCacheSnapshotImpl
                 other.pendingQuantity == pendingQuantity) &&
             (identical(other.mode, mode) || other.mode == mode) &&
             (identical(other.expectedErpStore, expectedErpStore) ||
-                other.expectedErpStore == expectedErpStore));
+                other.expectedErpStore == expectedErpStore) &&
+            (identical(other.roomMatControl, roomMatControl) ||
+                other.roomMatControl == roomMatControl) &&
+            (identical(other.currentStoreSite, currentStoreSite) ||
+                other.currentStoreSite == currentStoreSite) &&
+            (identical(other.matControlFlag, matControlFlag) ||
+                other.matControlFlag == matControlFlag) &&
+            (identical(other.matSendControl, matSendControl) ||
+                other.matSendControl == matSendControl) &&
+            (identical(other.erpRoom, erpRoom) || other.erpRoom == erpRoom) &&
+            (identical(other.erpStoreInv, erpStoreInv) ||
+                other.erpStoreInv == erpStoreInv) &&
+            (identical(other.availableInventory, availableInventory) ||
+                other.availableInventory == availableInventory));
   }
 
   @JsonKey(ignore: true)
@@ -2198,13 +2375,21 @@ class _$OnlinePickCollectionCacheSnapshotImpl
       const DeepCollectionEquality().hash(_dicSeq),
       const DeepCollectionEquality().hash(_dicMtlQty),
       const DeepCollectionEquality().hash(_dicInvMtlQty),
+      const DeepCollectionEquality().hash(_inventoryChecks),
       lastBarcode,
       location,
       trayNo,
       userId,
       pendingQuantity,
       mode,
-      expectedErpStore);
+      expectedErpStore,
+      roomMatControl,
+      currentStoreSite,
+      matControlFlag,
+      matSendControl,
+      erpRoom,
+      erpStoreInv,
+      availableInventory);
 
   @JsonKey(ignore: true)
   @override
@@ -2235,7 +2420,16 @@ abstract class _OnlinePickCollectionCacheSnapshot
           @HiveField(7) final int userId,
           @HiveField(8) final num? pendingQuantity,
           @HiveField(9) final String mode,
-          @HiveField(10) final String expectedErpStore}) =
+          @HiveField(10) final String expectedErpStore,
+          @HiveField(11)
+          final List<OnlinePickInventoryCheckRecord> inventoryChecks,
+          @HiveField(12) final String roomMatControl,
+          @HiveField(13) final String currentStoreSite,
+          @HiveField(14) final String matControlFlag,
+          @HiveField(15) final String matSendControl,
+          @HiveField(16) final String erpRoom,
+          @HiveField(17) final String erpStoreInv,
+          @HiveField(18) final double availableInventory}) =
       _$OnlinePickCollectionCacheSnapshotImpl;
 
   factory _OnlinePickCollectionCacheSnapshot.fromJson(

--- a/lib/modules/aswh_down/models/online_pick_collection_models.g.dart
+++ b/lib/modules/aswh_down/models/online_pick_collection_models.g.dart
@@ -127,6 +127,53 @@ class OnlinePickCollectionStockAdapter
           typeId == other.typeId;
 }
 
+class OnlinePickInventoryCheckRecordAdapter
+    extends TypeAdapter<OnlinePickInventoryCheckRecord> {
+  @override
+  final int typeId = 43;
+
+  @override
+  OnlinePickInventoryCheckRecord read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return OnlinePickInventoryCheckRecord(
+      recordId: fields[0] as String? ?? '',
+      materialCode: fields[1] as String,
+      trayNo: fields[2] as String,
+      storeSite: fields[3] as String,
+      quantity: fields[4] as num,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, OnlinePickInventoryCheckRecord obj) {
+    writer
+      ..writeByte(5)
+      ..writeByte(0)
+      ..write(obj.recordId)
+      ..writeByte(1)
+      ..write(obj.materialCode)
+      ..writeByte(2)
+      ..write(obj.trayNo)
+      ..writeByte(3)
+      ..write(obj.storeSite)
+      ..writeByte(4)
+      ..write(obj.quantity);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OnlinePickInventoryCheckRecordAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
 class OnlinePickCollectionCacheSnapshotAdapter
     extends TypeAdapter<OnlinePickCollectionCacheSnapshot> {
   @override
@@ -151,13 +198,23 @@ class OnlinePickCollectionCacheSnapshotAdapter
       pendingQuantity: fields[8] as num?,
       mode: fields[9] as String,
       expectedErpStore: fields[10] as String,
+      inventoryChecks:
+          (fields[11] as List?)?.cast<OnlinePickInventoryCheckRecord>() ??
+              const [],
+      roomMatControl: fields[12] as String,
+      currentStoreSite: fields[13] as String,
+      matControlFlag: fields[14] as String,
+      matSendControl: fields[15] as String,
+      erpRoom: fields[16] as String,
+      erpStoreInv: fields[17] as String,
+      availableInventory: (fields[18] as num?)?.toDouble() ?? 0,
     );
   }
 
   @override
   void write(BinaryWriter writer, OnlinePickCollectionCacheSnapshot obj) {
     writer
-      ..writeByte(11)
+      ..writeByte(19)
       ..writeByte(0)
       ..write(obj.stocks)
       ..writeByte(1)
@@ -179,7 +236,23 @@ class OnlinePickCollectionCacheSnapshotAdapter
       ..writeByte(9)
       ..write(obj.mode)
       ..writeByte(10)
-      ..write(obj.expectedErpStore);
+      ..write(obj.expectedErpStore)
+      ..writeByte(11)
+      ..write(obj.inventoryChecks)
+      ..writeByte(12)
+      ..write(obj.roomMatControl)
+      ..writeByte(13)
+      ..write(obj.currentStoreSite)
+      ..writeByte(14)
+      ..write(obj.matControlFlag)
+      ..writeByte(15)
+      ..write(obj.matSendControl)
+      ..writeByte(16)
+      ..write(obj.erpRoom)
+      ..writeByte(17)
+      ..write(obj.erpStoreInv)
+      ..writeByte(18)
+      ..write(obj.availableInventory);
   }
 
   @override
@@ -362,6 +435,19 @@ _$OnlinePickCollectionCacheSnapshotImpl
           pendingQuantity: json['pendingQuantity'] as num?,
           mode: json['mode'] as String? ?? 'outbound',
           expectedErpStore: json['expectedErpStore'] as String? ?? '',
+          inventoryChecks: (json['inventoryChecks'] as List<dynamic>?)
+                  ?.map((e) => OnlinePickInventoryCheckRecord.fromJson(
+                      e as Map<String, dynamic>))
+                  .toList() ??
+              const <OnlinePickInventoryCheckRecord>[],
+          roomMatControl: json['roomMatControl'] as String? ?? '0',
+          currentStoreSite: json['currentStoreSite'] as String? ?? '',
+          matControlFlag: json['matControlFlag'] as String? ?? '',
+          matSendControl: json['matSendControl'] as String? ?? '',
+          erpRoom: json['erpRoom'] as String? ?? '',
+          erpStoreInv: json['erpStoreInv'] as String? ?? '',
+          availableInventory:
+              (json['availableInventory'] as num?)?.toDouble() ?? 0,
         );
 
 Map<String, dynamic> _$$OnlinePickCollectionCacheSnapshotImplToJson(
@@ -378,4 +464,13 @@ Map<String, dynamic> _$$OnlinePickCollectionCacheSnapshotImplToJson(
       'pendingQuantity': instance.pendingQuantity,
       'mode': instance.mode,
       'expectedErpStore': instance.expectedErpStore,
+      'inventoryChecks':
+          instance.inventoryChecks.map((e) => e.toJson()).toList(),
+      'roomMatControl': instance.roomMatControl,
+      'currentStoreSite': instance.currentStoreSite,
+      'matControlFlag': instance.matControlFlag,
+      'matSendControl': instance.matSendControl,
+      'erpRoom': instance.erpRoom,
+      'erpStoreInv': instance.erpStoreInv,
+      'availableInventory': instance.availableInventory,
     };

--- a/lib/modules/aswh_down/services/aswh_down_collection_service.dart
+++ b/lib/modules/aswh_down/services/aswh_down_collection_service.dart
@@ -79,10 +79,11 @@ class AswhDownCollectionService {
       queryParameters: {'storesiteno': storeSiteNo, 'matcode': materialCode},
     );
 
-    return ApiResponseHandler.handleResponse(
-      response: response,
-      dataExtractor: (data) => data as Map<String, dynamic>,
-    );
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      return Map<String, dynamic>.from(data);
+    }
+    throw Exception('获取库存信息失败：响应格式错误');
   }
 
   /// 根据库位查询库存（对应 `getMtlRepertoryByStoresiteNoSn`）。
@@ -104,10 +105,11 @@ class AswhDownCollectionService {
       },
     );
 
-    return ApiResponseHandler.handleResponse(
-      response: response,
-      dataExtractor: (data) => data as Map<String, dynamic>,
-    );
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      return Map<String, dynamic>.from(data);
+    }
+    throw Exception('获取序列号库存失败：响应格式错误');
   }
 
   /// 根据库位查询库存（ERP 子库校验，`getRepertoryByStoresiteNoErp`）。
@@ -120,10 +122,11 @@ class AswhDownCollectionService {
       queryParameters: {'storesiteno': storeSiteNo, 'matcode': materialCode},
     );
 
-    return ApiResponseHandler.handleResponse(
-      response: response,
-      dataExtractor: (data) => data as Map<String, dynamic>,
-    );
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      return Map<String, dynamic>.from(data);
+    }
+    throw Exception('获取ERP子库信息失败：响应格式错误');
   }
 
   /// 提交自动化仓库下架（对应 `CommitASWHDownShelves`）。


### PR DESCRIPTION
## Summary
- sync the generated Freezed mixins and cache snapshot constructor with the new inventory control fields
- extend Hive adapters and JSON serialization to persist inventory check records and related flags
- keep collection state/BLoC/UI updates compatible with the expanded snapshot schema

## Testing
- not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ff8d5afa848330830753e5575a175a