### PR TITLE
Fix online pick scanning and inventory validation flows

### DIFF
--- a/lib/modules/aswh_down/collection_task/pages/online_pick_collection_page.dart
+++ b/lib/modules/aswh_down/collection_task/pages/online_pick_collection_page.dart
@@ -161,9 +161,16 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
   }
 
   Widget _buildScanInput(OnlinePickCollectionState state) {
+    final isNumericStep =
+        state.requireInventoryCheck ||
+        state.step == OnlinePickCollectionStep.quantity;
+    final keyboardType = isNumericStep
+        ? const TextInputType.numberWithOptions(decimal: true)
+        : TextInputType.text;
+
     final config = ScannerConfig(
       placeholder: state.placeholder,
-      keyboardType: TextInputType.number,
+      keyboardType: keyboardType,
     );
 
     return Container(


### PR DESCRIPTION
## Summary
- treat $KW$/$TP$ barcodes as location and tray scans, clearing the current barcode and quantities when context changes
- tighten material validation with matSendControl/roomMatControl, per-mode serial duplication guards, richer inventory checks, and automatic collected quantity tracking
- require outstanding tray tasks to be finished before submit, deduplicate bulk tray dispatches, restore cached UI state more accurately, and switch the scanner input to numeric only on quantity steps

## Testing
- Not run (flutter tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_690061e06e388330a5035345de0f08bc