### PR TITLE
feat: add ASWH down exception handling flows

### DIFF
--- a/docs/aswh_down_collection_refactor_todo.md
+++ b/docs/aswh_down_collection_refactor_todo.md
@@ -1,0 +1,36 @@
+# ASWH 下架采集页面重构 TODO
+
+> 目标：基于 `GlodWind-Wms-App/pages/aswhdown/task_collect` 的 UniApp 页面，将自动化仓库下架采集流程完整迁移到 Flutter 模块 `lib/modules/aswh_down/collection_task/` 中，保持与现有出库/入库模块一致的交互体验与架构。
+
+## 架构与基础
+- [x] 新建 `collection_task/` 目录，按 BLoC / config / widgets / pages 拆分结构。
+- [x] 接入模块路由 `/aswh-down/collect`、`/aswh-down/collect/result`，支持任务参数传递与结果回写。
+- [x] 创建 `OnlinePickCollectionBloc`，实现初始化、扫码解析、缓存恢复、采集结果同步等核心状态管理。
+- [x] 引入 Hive 缓存快照 `OnlinePickCollectionCacheSnapshot`，落库库位/托盘/采集记录。
+- [x] 为提交成功后清理缓存、恢复任务等流程编写集成测试用例。（`test/modules/aswh_down/collection_task/online_pick_collection_bloc_submit_test.dart` 验证提交成功后清空缓存、重载任务明细与 WCS 指令。）
+
+## 页面实现
+- [x] 采集主页面 `OnlinePickCollectionPage`
+  - [x] 扫码输入框与焦点控制
+  - [x] 信息卡片展示任务、库位、托盘、物料、数量
+  - [x] `TabBar`+`CommonDataGrid` 显示任务列表/正在采集
+  - [x] 底部操作区（采集结果、提交采集、跳转 WCS 指令）
+- [x] 采集结果页 `OnlinePickCollectionResultPage`，支持选中批量删除并回传删除清单。
+- [x] 采集结果页返回后，联动主页面刷新 WCS 指令状态和任务待采集数量。（返回时触发 BLoC 刷新任务明细与 WCS 指令，并依据本地缓存重算采集数量）
+- [x] 补充托盘数量确认、模式切换等弹窗交互。
+
+## 业务逻辑
+- [x] 托盘/库位/物料/数量扫码解析，按步骤切换占位提示。
+- [x] 采集数量入栈后更新序列缓存、物料数量字典、库位库存映射。
+- [x] 提交采集调用 `commitASWHDownShelves`，构建下架/明细入参。
+- [x] 支持根据任务类型调用 `commitDownShelves`、`commitTrayDownShelves` 等分支接口。
+- [x] 对接库存校验接口（`getRepertoryByStoresiteNo*`）并在数量录入前校验子库、批次、库存余量。（`OnlinePickCollectionBloc` 库位校验调用库存接口并新增 `online_pick_collection_bloc_inventory_test.dart` 覆盖库存不足/成功场景。）
+- [x] 完成异常流程（异常补录、空盘出库、回库）事件与弹窗。
+
+## 质量与迭代
+- [ ] 编写 BLoC 单测：扫码流程、缓存恢复、提交失败场景。
+- [ ] 编写服务层集成测试（Mock Dio）验证参数映射。
+- [ ] 完善错误提示与日志记录，统一使用 `ErrorHandler`。
+- [ ] 与 WCS 页面交互的数据刷新、回调协议。
+
+> 更新说明：完成的条目已打勾；后续新增任务请在此文档追加并标记状态，方便跨端团队协作追踪。

--- a/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_bloc.dart
+++ b/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_bloc.dart
@@ -1,0 +1,1713 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hive/hive.dart';
+import 'package:uuid/uuid.dart';
+import 'package:wms_app/models/page_status.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_models.dart';
+import 'package:wms_app/modules/aswh_down/services/aswh_down_collection_service.dart';
+import 'package:wms_app/modules/aswh_down/services/aswh_down_task_service.dart';
+import 'package:wms_app/modules/aswh_down/utils/online_pick_scanner_parser.dart';
+import 'package:wms_app/services/user_manager.dart';
+import 'package:wms_app/utils/error_handler.dart';
+
+import 'online_pick_collection_event.dart';
+import 'online_pick_collection_state.dart';
+
+class OnlinePickCollectionBloc
+    extends Bloc<OnlinePickCollectionEvent, OnlinePickCollectionState> {
+  OnlinePickCollectionBloc({
+    required OnlinePickTask task,
+    required AswhDownTaskService taskService,
+    required AswhDownCollectionService collectionService,
+    required UserManager userManager,
+    HiveInterface? hive,
+    Uuid? uuid,
+    String? submissionHint,
+  })  : _taskService = taskService,
+        _collectionService = collectionService,
+        _userManager = userManager,
+        _hive = hive ?? Hive,
+        _uuid = uuid ?? const Uuid(),
+        super(
+          OnlinePickCollectionState.initial(
+            task,
+            submitChannel:
+                _resolveInitialSubmissionChannel(task, submissionHint),
+          ),
+        ) {
+    on<OnlinePickCollectionStarted>(_onStarted);
+    on<OnlinePickCollectionScanPerformed>(_onScanPerformed);
+    on<OnlinePickCollectionQuantitySubmitted>(_onQuantitySubmitted);
+    on<OnlinePickCollectionStocksSynced>(_onStocksSynced);
+    on<OnlinePickCollectionResetStatus>(_onResetStatus);
+    on<OnlinePickCollectionChangeTab>(_onChangeTab);
+    on<OnlinePickCollectionSelectionChanged>(_onSelectionChanged);
+    on<OnlinePickCollectionFocusRequested>(_onFocusRequested);
+    on<OnlinePickCollectionDeleteStocksRequested>(_onDeleteStocksRequested);
+    on<OnlinePickCollectionResultRemoved>(_onResultRemoved);
+    on<OnlinePickCollectionDetailsRefreshRequested>(
+        _onDetailsRefreshRequested);
+    on<OnlinePickCollectionSubmitRequested>(_onSubmitRequested);
+    on<OnlinePickCollectionCacheCleared>(_onCacheCleared);
+    on<OnlinePickCollectionModeChanged>(_onModeChanged);
+    on<OnlinePickCollectionLocationSelected>(_onLocationSelected);
+    on<OnlinePickCollectionPalletsCallRequested>(_onPalletsCallRequested);
+    on<OnlinePickCollectionExceptionSubmitted>(_onExceptionSubmitted);
+    on<OnlinePickCollectionEmptyTrayOutboundRequested>(
+        _onEmptyTrayOutboundRequested);
+    on<OnlinePickCollectionTrayReturnRequested>(_onTrayReturnRequested);
+  }
+
+  final AswhDownTaskService _taskService;
+  final AswhDownCollectionService _collectionService;
+  final UserManager _userManager;
+  final HiveInterface _hive;
+  final Uuid _uuid;
+
+  Box<OnlinePickCollectionCacheSnapshot>? _cacheBox;
+  OnlinePickCollectionQuery? _currentQuery;
+  List<OnlinePickTaskItem> _remoteDetails = const [];
+
+  Future<void> _onStarted(
+    OnlinePickCollectionStarted event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    await _openCacheBox();
+
+    emit(
+      state.copyWith(
+        status: CollectionStatus.loading(),
+        focus: true,
+        placeholder: _placeholderForStep(OnlinePickCollectionStep.location),
+      ),
+    );
+
+    try {
+      final user = _userManager.userInfo;
+      final query = OnlinePickCollectionQuery(
+        outTaskNo: state.task.outTaskNo,
+        storeRoomNo: state.task.storeRoomNo ?? '',
+        taskComment: state.task.taskComment ?? '',
+        forceSite: state.task.forceSite ?? '',
+        forceBatch: state.task.forceBatch ?? '',
+        workStation: state.task.workStation ?? '',
+        collector: user?.userId ?? 0,
+      );
+      _currentQuery = query;
+
+      final itemsFuture = _collectionService.fetchCollectionTaskItems(
+        query: query,
+      );
+      final wcsFuture = _collectionService.fetchWcsCommands(
+        taskComment: state.task.taskComment ?? '',
+        taskId: state.task.outTaskId.toString(),
+      );
+      final locationsFuture = _collectionService.fetchInOutLocations();
+
+      final items = await itemsFuture;
+      _remoteDetails = items;
+
+      var expectedErpStore = state.expectedErpStore;
+      if (items.isNotEmpty) {
+        expectedErpStore = items.first.subInventoryCode ?? expectedErpStore;
+      }
+
+      final detailList = _deriveDetailListFromRemote(state.collectedStocks);
+      final collectingList = _buildCollectingListFromDetail(detailList);
+      final wcsCommands = await wcsFuture;
+      final locations = await locationsFuture;
+      final selectedLocation = _resolveSelectedLocation(locations);
+
+      emit(
+        state.copyWith(
+          status: const CollectionStatus.success(),
+          detailList: detailList,
+          collectingList: collectingList,
+          expectedErpStore: expectedErpStore,
+          wcsCommands: wcsCommands,
+          focus: true,
+          locationOptions: locations,
+          selectedLocation: selectedLocation,
+        ),
+      );
+
+      if (event.restoreCache) {
+        await _restoreFromCache(emit);
+      }
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onScanPerformed(
+    OnlinePickCollectionScanPerformed event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    try {
+      final result = OnlinePickScannerParser.parse(event.rawValue);
+      switch (result.type) {
+        case OnlinePickScanType.location:
+          emit(
+            state.copyWith(
+              location: result.normalizedValue,
+              step: OnlinePickCollectionStep.tray,
+              placeholder: _placeholderForStep(OnlinePickCollectionStep.tray),
+              focus: true,
+              status: CollectionStatus.success('已识别库位 ${result.normalizedValue}'),
+              clearBarcode: true,
+              clearCurrentItem: true,
+              clearPendingQuantity: true,
+            ),
+          );
+          await _persistCache();
+          break;
+        case OnlinePickScanType.tray:
+          emit(
+            state.copyWith(
+              trayNo: result.normalizedValue,
+              step: OnlinePickCollectionStep.material,
+              placeholder:
+                  _placeholderForStep(OnlinePickCollectionStep.material),
+              focus: true,
+              status: CollectionStatus.success('托盘 ${result.normalizedValue} 就绪'),
+              clearPendingQuantity: true,
+            ),
+          );
+          await _persistCache();
+          break;
+        case OnlinePickScanType.material:
+          if (state.location.isEmpty) {
+            emit(
+              state.copyWith(
+                status: CollectionStatus.error('请先扫描库位条码'),
+                focus: true,
+              ),
+            );
+            return;
+          }
+          if (state.trayNo.isEmpty) {
+            emit(
+              state.copyWith(
+                status: CollectionStatus.error('请先扫描托盘条码'),
+                focus: true,
+              ),
+            );
+            return;
+          }
+
+          emit(state.copyWith(status: CollectionStatus.loading()));
+          final barcode = await _collectionService.getMaterialInfoByQr(
+            event.rawValue,
+          );
+
+          final matched = _matchTaskItem(barcode.materialCode ?? '');
+          if (matched == null) {
+            emit(
+              state.copyWith(
+                status: CollectionStatus.error('未匹配到待采集任务行'),
+                focus: true,
+                clearBarcode: true,
+                clearCurrentItem: true,
+              ),
+            );
+            return;
+          }
+
+          emit(
+            state.copyWith(
+              barcodeContent: barcode,
+              currentItem: matched,
+              step: OnlinePickCollectionStep.quantity,
+              placeholder: _placeholderForStep(OnlinePickCollectionStep.quantity),
+              status: CollectionStatus.success('物料 ${barcode.materialCode} 已匹配'),
+              focus: true,
+            ),
+          );
+          await _persistCache();
+          break;
+        case OnlinePickScanType.quantity:
+          add(OnlinePickCollectionQuantitySubmitted(result.quantity ?? 0));
+          break;
+      }
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onQuantitySubmitted(
+    OnlinePickCollectionQuantitySubmitted event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    final currentItem = state.currentItem;
+    if (currentItem == null) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请先扫描物料二维码'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+    if (state.location.isEmpty || state.trayNo.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请确认已扫描库位和托盘'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    if (event.quantity <= 0) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('采集数量必须大于 0'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(pendingQuantity: event.quantity));
+
+    _InventoryValidationResult? validationResult;
+    try {
+      validationResult = await _validateInventoryBeforeCollect(
+        quantity: event.quantity,
+        currentItem: currentItem,
+        barcode: state.barcodeContent,
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+          clearPendingQuantity: true,
+        ),
+      );
+      return;
+    }
+
+    final barcode = state.barcodeContent;
+    final resolvedErpStore = validationResult?.erpStore?.isNotEmpty == true
+        ? validationResult!.erpStore
+        : (state.expectedErpStore.isNotEmpty
+            ? state.expectedErpStore
+            : currentItem.subInventoryCode);
+    final stock = OnlinePickCollectionStock(
+      stockId: _uuid.v4(),
+      materialCode: barcode?.materialCode ?? currentItem.materialCode ?? '',
+      batchNo: barcode?.batchNo ?? currentItem.batchNo ?? currentItem.hintBatchNo,
+      serialNumber: barcode?.serialNumber ?? currentItem.serialNumber,
+      taskQty: currentItem.taskQty,
+      collectQty: event.quantity,
+      outTaskItemId: currentItem.outTaskItemId.toString(),
+      taskId: currentItem.outTaskId.toString(),
+      storeRoom: currentItem.storeRoomNo,
+      storeSite: state.location,
+      erpStore: resolvedErpStore,
+      trayNo: state.trayNo,
+    );
+
+    final updatedStocks = List<OnlinePickCollectionStock>.from(
+      state.collectedStocks,
+    )
+      ..add(stock);
+
+    final cache = _rebuildCachesFromStocks(updatedStocks);
+    final detailList = _deriveDetailListFromRemote(updatedStocks);
+    final collecting = _buildCollectingListFromDetail(detailList);
+
+    emit(
+      state.copyWith(
+        collectedStocks: updatedStocks,
+        detailList: detailList,
+        collectingList: collecting,
+        serialMap: cache.serialMap,
+        materialQtyMap: cache.materialQtyMap,
+        inventoryQtyMap: cache.inventoryQtyMap,
+        expectedErpStore:
+            cache.expectedErpStore.isNotEmpty ? cache.expectedErpStore : state.expectedErpStore,
+        status: CollectionStatus.success('已记录采集数量 ${event.quantity}'),
+        step: OnlinePickCollectionStep.location,
+        placeholder: _placeholderForStep(OnlinePickCollectionStep.location),
+        focus: true,
+        clearBarcode: true,
+        clearCurrentItem: true,
+        clearPendingQuantity: true,
+      ),
+    );
+    await _persistCache();
+  }
+
+  Future<_InventoryValidationResult?> _validateInventoryBeforeCollect({
+    required num quantity,
+    required OnlinePickTaskItem currentItem,
+    OnlinePickBarcodeContent? barcode,
+  }) async {
+    if (state.mode != OnlinePickCollectionModeType.outbound) {
+      return null;
+    }
+
+    final storeSite = state.location.trim();
+    if (storeSite.isEmpty) {
+      throw Exception('请先扫描库位条码');
+    }
+
+    final materialCode =
+        (barcode?.materialCode ?? currentItem.materialCode ?? '').trim();
+    if (materialCode.isEmpty) {
+      throw Exception('当前物料编码缺失，无法校验库存');
+    }
+
+    final requestedQty = quantity.toDouble();
+    if (requestedQty <= 0) {
+      throw Exception('采集数量必须大于 0');
+    }
+
+    final batchNo = _resolveBatchNo(barcode, currentItem);
+    final serialNumber = _resolveSerialNumber(barcode, currentItem);
+    final expectedErp = (state.expectedErpStore.isNotEmpty
+            ? state.expectedErpStore
+            : currentItem.subInventoryCode ?? '')
+        .trim();
+
+    final inventoryKey = _composeInventoryKey(
+      storeSite: storeSite,
+      materialCode: materialCode,
+      batchNo: batchNo,
+      serialNumber: serialNumber,
+    );
+    final collectedQty = state.inventoryQtyMap[inventoryKey] ?? 0;
+
+    final bool serialControlled = _isSerialControlled(barcode, currentItem);
+
+    final List<Map<String, dynamic>> records = serialControlled
+        ? await _collectionService.getRepertoryByStoreSiteSn(
+            storeSiteNo: storeSite,
+            materialCode: materialCode,
+            erpStoreroom: expectedErp.isNotEmpty ? expectedErp : null,
+            batchNo: batchNo.isNotEmpty ? batchNo : null,
+            serialNumber: serialNumber.isNotEmpty ? serialNumber : null,
+          )
+        : await _collectionService.getRepertoryByStoreSite(
+            storeSiteNo: storeSite,
+            materialCode: materialCode,
+            erpStoreroom: expectedErp.isNotEmpty ? expectedErp : null,
+            batchNo: batchNo.isNotEmpty ? batchNo : null,
+            serialNumber: serialNumber.isNotEmpty ? serialNumber : null,
+          );
+
+    if (records.isEmpty) {
+      final targetLabel = serialControlled && serialNumber.isNotEmpty
+          ? '序列号【$serialNumber】'
+          : (batchNo.isNotEmpty ? '批次【$batchNo】' : '库存');
+      throw Exception('库位【$storeSite】物料【$materialCode】$targetLabel不存在，请确认');
+    }
+
+    final filteredRecords = serialControlled
+        ? records.where((record) {
+            if (serialNumber.isEmpty) return true;
+            final sn = record['sn']?.toString().trim() ?? '';
+            return sn == serialNumber;
+          }).toList()
+        : records.where((record) {
+            if (batchNo.isEmpty) return true;
+            final batch = record['batchno']?.toString().trim() ?? '';
+            return batch == batchNo;
+          }).toList();
+
+    if (filteredRecords.isEmpty) {
+      if (serialControlled && serialNumber.isNotEmpty) {
+        throw Exception('库位【$storeSite】物料【$materialCode】序列号【$serialNumber】不存在，请确认');
+      }
+      if (!serialControlled && batchNo.isNotEmpty) {
+        throw Exception('库位【$storeSite】物料【$materialCode】批次【$batchNo】不存在，请确认');
+      }
+    }
+
+    final recordsToUse =
+        filteredRecords.isEmpty ? records : filteredRecords;
+    final availableQty = recordsToUse.fold<double>(0, (sum, record) {
+      return sum + _parseQty(record['repqty']);
+    });
+
+    if (availableQty <= 0) {
+      throw Exception('库位【$storeSite】物料【$materialCode】库存不足，请确认');
+    }
+
+    final remainingQty = availableQty - collectedQty.toDouble();
+    if (remainingQty + 1e-6 < requestedQty) {
+      throw Exception(
+        '库位【$storeSite】物料【$materialCode】剩余库存【${remainingQty.toStringAsFixed(3)}】不足，无法采集 ${requestedQty.toStringAsFixed(3)}',
+      );
+    }
+
+    String? erpStore;
+    for (final record in recordsToUse) {
+      final candidate = record['erpStoreroom']?.toString().trim();
+      if (candidate != null && candidate.isNotEmpty) {
+        erpStore = candidate;
+        break;
+      }
+    }
+
+    if ((erpStore == null || erpStore.isEmpty)) {
+      final erpRecords = await _collectionService.getRepertoryByStoreSiteErp(
+        storeSiteNo: storeSite,
+        materialCode: materialCode,
+      );
+      if (erpRecords.isNotEmpty) {
+        final candidate =
+            erpRecords.first['erpStoreroom']?.toString().trim();
+        if (candidate != null && candidate.isNotEmpty) {
+          erpStore = candidate;
+        }
+      }
+    }
+
+    if (expectedErp.isNotEmpty && erpStore != null && erpStore.isNotEmpty) {
+      if (expectedErp != erpStore) {
+        throw Exception(
+          '任务要求子库【$expectedErp】与当前库位子库【$erpStore】不一致，请确认',
+        );
+      }
+    }
+
+    return _InventoryValidationResult(
+      availableQuantity: availableQty,
+      collectedQuantity: collectedQty.toDouble(),
+      erpStore: erpStore?.isNotEmpty == true ? erpStore : expectedErp,
+    );
+  }
+
+  String _resolveBatchNo(
+    OnlinePickBarcodeContent? barcode,
+    OnlinePickTaskItem currentItem,
+  ) {
+    final candidates = <String?>[
+      barcode?.batchNo,
+      currentItem.batchNo,
+      currentItem.hintBatchNo,
+    ];
+    for (final value in candidates) {
+      final trimmed = value?.trim();
+      if (trimmed != null && trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+    return '';
+  }
+
+  String _resolveSerialNumber(
+    OnlinePickBarcodeContent? barcode,
+    OnlinePickTaskItem currentItem,
+  ) {
+    final candidates = <String?>[
+      barcode?.serialNumber,
+      currentItem.serialNumber,
+    ];
+    for (final value in candidates) {
+      final trimmed = value?.trim();
+      if (trimmed != null && trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+    return '';
+  }
+
+  bool _isSerialControlled(
+    OnlinePickBarcodeContent? barcode,
+    OnlinePickTaskItem currentItem,
+  ) {
+    final control = (barcode?.sequenceControl ?? '').trim();
+    if (control.isEmpty) {
+      return (currentItem.serialNumber ?? '').trim().isNotEmpty;
+    }
+
+    return control != '1' && control != '2';
+  }
+
+  String _composeInventoryKey({
+    required String storeSite,
+    required String materialCode,
+    String? batchNo,
+    String? serialNumber,
+  }) {
+    final normalizedSite = storeSite.trim();
+    final normalizedMaterial = materialCode.trim();
+    final normalizedBatch = (batchNo ?? '').trim();
+    final normalizedSerial = (serialNumber ?? '').trim();
+    final suffix = normalizedBatch.isNotEmpty ? normalizedBatch : normalizedSerial;
+    return [normalizedSite, normalizedMaterial, suffix].join('|');
+  }
+
+  double _parseQty(dynamic value) {
+    if (value == null) {
+      return 0;
+    }
+    if (value is num) {
+      return value.toDouble();
+    }
+    return double.tryParse(value.toString()) ?? 0;
+  }
+
+  Future<void> _onStocksSynced(
+    OnlinePickCollectionStocksSynced event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    final stocks = event.payload
+        .map((item) => OnlinePickCollectionStock.fromJson(item))
+        .toList();
+
+    final cache = _rebuildCachesFromStocks(stocks);
+    final detailList = _deriveDetailListFromRemote(stocks);
+    final collecting = _buildCollectingListFromDetail(detailList);
+
+    emit(
+      state.copyWith(
+        collectedStocks: stocks,
+        detailList: detailList,
+        collectingList: collecting,
+        serialMap: cache.serialMap,
+        materialQtyMap: cache.materialQtyMap,
+        inventoryQtyMap: cache.inventoryQtyMap,
+        expectedErpStore: cache.expectedErpStore,
+        status: const CollectionStatus.success('采集结果已同步'),
+        clearBarcode: true,
+        clearCurrentItem: true,
+        clearPendingQuantity: true,
+        focus: true,
+      ),
+    );
+    await _persistCache();
+  }
+
+  void _onResetStatus(
+    OnlinePickCollectionResetStatus event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) {
+    emit(state.copyWith(status: CollectionStatus.normal()));
+  }
+
+  void _onChangeTab(
+    OnlinePickCollectionChangeTab event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) {
+    emit(state.copyWith(currentTab: event.index));
+  }
+
+  void _onSelectionChanged(
+    OnlinePickCollectionSelectionChanged event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) {
+    final ids = event.selectedItems.map((e) => e.outTaskItemId).toList();
+    emit(state.copyWith(selectedDetailIds: ids));
+  }
+
+  void _onFocusRequested(
+    OnlinePickCollectionFocusRequested event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) {
+    emit(state.copyWith(focus: event.focus));
+  }
+
+  Future<void> _onDeleteStocksRequested(
+    OnlinePickCollectionDeleteStocksRequested event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    if (event.stockIds.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请选择要删除的采集记录'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final remaining = state.collectedStocks
+        .where((stock) => !event.stockIds.contains(stock.stockId))
+        .toList();
+
+    final cache = _rebuildCachesFromStocks(remaining);
+    final detailList = _deriveDetailListFromRemote(remaining);
+    final collecting = _buildCollectingListFromDetail(detailList);
+
+    emit(
+      state.copyWith(
+        collectedStocks: remaining,
+        detailList: detailList,
+        collectingList: collecting,
+        serialMap: cache.serialMap,
+        materialQtyMap: cache.materialQtyMap,
+        inventoryQtyMap: cache.inventoryQtyMap,
+        expectedErpStore: cache.expectedErpStore,
+        status: const CollectionStatus.success('已删除选中采集记录'),
+        focus: true,
+      ),
+    );
+    await _persistCache();
+  }
+
+  Future<void> _onResultRemoved(
+    OnlinePickCollectionResultRemoved event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    if (event.removedStocks.isEmpty) {
+      return;
+    }
+
+    final removedIds = event.removedStocks.map((e) => e.stockId).toSet();
+    final remaining = state.collectedStocks
+        .where((stock) => !removedIds.contains(stock.stockId))
+        .toList();
+
+    final cache = _rebuildCachesFromStocks(remaining);
+    final detailList = _deriveDetailListFromRemote(remaining);
+    final collecting = _buildCollectingListFromDetail(detailList);
+
+    emit(
+      state.copyWith(
+        collectedStocks: remaining,
+        detailList: detailList,
+        collectingList: collecting,
+        serialMap: cache.serialMap,
+        materialQtyMap: cache.materialQtyMap,
+        inventoryQtyMap: cache.inventoryQtyMap,
+        expectedErpStore: cache.expectedErpStore,
+        status: const CollectionStatus.success('采集结果已更新'),
+        focus: true,
+      ),
+    );
+    await _persistCache();
+  }
+
+  Future<void> _onDetailsRefreshRequested(
+    OnlinePickCollectionDetailsRefreshRequested event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    await _refreshTaskData(
+      emit,
+      showLoading: event.showLoading,
+      successMessage: event.successMessage,
+    );
+  }
+
+  Future<void> _onSubmitRequested(
+    OnlinePickCollectionSubmitRequested event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    if (state.collectedStocks.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('暂无采集记录可提交'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: CollectionStatus.loading(), focus: true));
+    try {
+      final downShelvesInfos = state.collectedStocks.map((stock) {
+        return {
+          'stockid': stock.stockId,
+          'matcode': stock.materialCode,
+          'batchno': stock.batchNo,
+          'sn': stock.serialNumber,
+          'taskQty': stock.taskQty,
+          'collectQty': stock.collectQty,
+          'outtaskitemid': stock.outTaskItemId,
+          'taskid': stock.taskId,
+          'storeRoom': stock.storeRoom,
+          'storeSite': stock.storeSite,
+          'erpStore': stock.erpStore,
+          'trayNo': stock.trayNo,
+        };
+      }).toList();
+
+      final itemInfos = state.collectedStocks.map((stock) {
+        return {
+          'outtaskitemid': stock.outTaskItemId,
+          'collectQty': stock.collectQty,
+          'matcode': stock.materialCode,
+          'storeSite': stock.storeSite,
+          'trayNo': stock.trayNo,
+        };
+      }).toList();
+
+      await _submitCollection(downShelvesInfos, itemInfos);
+      await _clearCollectionAfterSubmit(emit);
+      await _refreshTaskData(
+        emit,
+        successMessage: '${state.submitChannel.label}提交成功',
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _clearCollectionAfterSubmit(
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    final box = _cacheBox;
+    if (box != null) {
+      await box.clear();
+    }
+
+    final detailList = _deriveDetailListFromRemote(const []);
+    final collectingList = _buildCollectingListFromDetail(detailList);
+
+    emit(
+      state.copyWith(
+        collectedStocks: const [],
+        detailList: detailList,
+        collectingList: collectingList,
+        serialMap: const {},
+        materialQtyMap: const {},
+        inventoryQtyMap: const {},
+        step: OnlinePickCollectionStep.location,
+        placeholder: _placeholderForStep(OnlinePickCollectionStep.location),
+        focus: true,
+        clearBarcode: true,
+        clearCurrentItem: true,
+        clearPendingQuantity: true,
+      ),
+    );
+  }
+
+  Future<void> _submitCollection(
+    List<Map<String, dynamic>> downShelvesInfos,
+    List<Map<String, dynamic>> itemInfos,
+  ) async {
+    switch (state.submitChannel) {
+      case OnlinePickSubmissionChannel.standard:
+        await _collectionService.commitDownShelves(
+          downShelvesInfos: downShelvesInfos,
+          itemListInfos: itemInfos,
+        );
+        break;
+      case OnlinePickSubmissionChannel.tray:
+        await _collectionService.commitTrayDownShelves(
+          downShelvesInfos: downShelvesInfos,
+          itemListInfos: itemInfos,
+        );
+        break;
+      case OnlinePickSubmissionChannel.aswh:
+        await _collectionService.commitAswhDownShelves(
+          downShelvesInfos: downShelvesInfos,
+          itemListInfos: itemInfos,
+        );
+        break;
+    }
+  }
+
+  Future<void> _onCacheCleared(
+    OnlinePickCollectionCacheCleared event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    final box = _cacheBox;
+    if (box == null) return;
+    await box.clear();
+    emit(
+      state.copyWith(
+        status: const CollectionStatus.success('已清空采集缓存'),
+        focus: true,
+      ),
+    );
+  }
+
+  void _onModeChanged(
+    OnlinePickCollectionModeChanged event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        mode: event.mode.type,
+        status: CollectionStatus.success('已切换至 ${event.mode.label} 模式'),
+        focus: true,
+      ),
+    );
+  }
+
+  void _onLocationSelected(
+    OnlinePickCollectionLocationSelected event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) {
+    emit(
+      state.copyWith(
+        selectedLocation: event.location,
+        status:
+            CollectionStatus.success('拣选口已切换为 ${event.location.label}'),
+        focus: true,
+      ),
+    );
+  }
+
+  Future<void> _onPalletsCallRequested(
+    OnlinePickCollectionPalletsCallRequested event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    if (event.count <= 0) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('托盘数量需大于 0'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    if (state.collectedStocks.isNotEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('存在未提交的采集记录，无法下发托盘'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final location = state.selectedLocation;
+    if (location == null) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请先选择拣选口位置'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final taskNo = state.task.outTaskNo ?? '';
+    if (taskNo.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('任务凭证号为空，无法下发托盘'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final uniqueTrays = _uniqueTrayItems().where((item) {
+      final tray = (item.palletNo ?? '').trim();
+      if (tray.isEmpty) return false;
+      return !state.requestedPallets.contains(tray);
+    }).toList();
+
+    if (uniqueTrays.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('暂无可下发的托盘记录'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final targetItems = uniqueTrays.take(event.count).toList();
+    emit(state.copyWith(status: CollectionStatus.loading(), focus: true));
+
+    final processedTrays = <String>[];
+    try {
+      for (final item in targetItems) {
+        final tray = (item.palletNo ?? '').trim();
+        final startAddr = (item.storeSiteNo ?? '').trim();
+        if (tray.isEmpty || startAddr.isEmpty) {
+          continue;
+        }
+
+        await _collectionService.commitDownWmsToWcs(
+          taskId: item.outTaskId.toString(),
+          taskNo: taskNo,
+          trayNo: tray,
+          startAddr: startAddr,
+          endAddr: location.value,
+          singleFlag: event.count == 1 ? '1' : '0',
+          isInventory: state.mode == OnlinePickCollectionModeType.inventory,
+        );
+        processedTrays.add(tray);
+      }
+
+      if (processedTrays.isEmpty) {
+        emit(
+          state.copyWith(
+            status: CollectionStatus.error('托盘数据不完整，未能下发指令'),
+            focus: true,
+          ),
+        );
+        return;
+      }
+
+      final updatedTrays = {
+        ...state.requestedPallets,
+        ...processedTrays,
+      }.toList();
+
+      final message = '已下发 ${processedTrays.length} 个托盘指令';
+      emit(
+        state.copyWith(
+          status: CollectionStatus.success(message),
+          requestedPallets: updatedTrays,
+          focus: true,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onExceptionSubmitted(
+    OnlinePickCollectionExceptionSubmitted event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    final submission = event.submission;
+    final materialCode = submission.materialCode.trim();
+    if (materialCode.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请输入异常物料编码'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    if (submission.quantity <= 0) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('异常数量必须大于 0'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final storeSite = (submission.storeSite.isNotEmpty
+            ? submission.storeSite
+            : state.location)
+        .trim();
+    if (storeSite.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请输入异常库位'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final exceptionType = submission.exceptionType.trim();
+    if (exceptionType.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请选择异常类型'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: CollectionStatus.loading(), focus: true));
+    try {
+      final user = _userManager.userInfo;
+      final operatorName =
+          (user?.userName ?? '').isNotEmpty ? user!.userName : user?.nickName ?? '';
+      final trayNo =
+          submission.trayNo.isNotEmpty ? submission.trayNo.trim() : state.trayNo;
+      final materialName = submission.materialName.trim();
+      final batchNo = submission.batchNo.trim();
+      final serialNumber = submission.serialNumber.trim();
+      final unit = submission.unit.trim();
+      final description = submission.description.trim();
+      final proofNo = (state.task.taskComment ?? '').trim();
+      var storeRoomNo = (state.task.storeRoomNo ?? '').trim();
+
+      final request = <String, dynamic>{
+        'taskNo': state.task.outTaskNo ?? '',
+        'taskno': state.task.outTaskNo ?? '',
+        'taskid': state.task.outTaskId.toString(),
+        'matCode': materialCode,
+        'matcode': materialCode,
+        'collectQty': submission.quantity,
+        'quantity': submission.quantity,
+        'storeSiteNo': storeSite,
+        'storesiteno': storeSite,
+        'storeRoomNo': storeRoomNo,
+        'storeroomno': storeRoomNo,
+        'excepttype': exceptionType,
+        'protype': exceptionType,
+      };
+
+      if (materialName.isNotEmpty) {
+        request['matName'] = materialName;
+        request['matname'] = materialName;
+      }
+
+      if (batchNo.isNotEmpty) {
+        request['batchNo'] = batchNo;
+        request['batchno'] = batchNo;
+      }
+
+      if (serialNumber.isNotEmpty) {
+        request['sn'] = serialNumber;
+      }
+
+      if (unit.isNotEmpty) {
+        request['unit'] = unit;
+      }
+
+      if (description.isNotEmpty) {
+        request['exceptdesc'] = description;
+      }
+
+      if (trayNo.isNotEmpty) {
+        request['palletno'] = trayNo;
+      }
+
+      if (proofNo.isNotEmpty) {
+        request['proofNo'] = proofNo;
+      }
+
+      final currentItem = state.currentItem;
+      if (currentItem != null) {
+        request['taskQty'] = currentItem.taskQty;
+        if (storeRoomNo.isEmpty && (currentItem.storeRoomNo ?? '').isNotEmpty) {
+          storeRoomNo = currentItem.storeRoomNo!.trim();
+          request['storeRoomNo'] = storeRoomNo;
+          request['storeroomno'] = storeRoomNo;
+        }
+      }
+
+      if (operatorName.isNotEmpty) {
+        request['operator'] = operatorName;
+      }
+
+      await _collectionService.commitExceptionShelves(
+        exceptionInfos: [request],
+      );
+
+      emit(
+        state.copyWith(
+          status: const CollectionStatus.success('异常补录已提交'),
+          focus: true,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onEmptyTrayOutboundRequested(
+    OnlinePickCollectionEmptyTrayOutboundRequested event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    if (state.collectedStocks.isNotEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('采集数据未提交，不允许下发指令'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final trayNo = state.trayNo.trim();
+    if (trayNo.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请采集托盘号'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final location = state.selectedLocation?.value.trim() ?? '';
+    if (location.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请先选择拣选口位置'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final taskNo = (state.task.outTaskNo ?? '').trim();
+    if (taskNo.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('凭证号为空，请确认'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: CollectionStatus.loading(), focus: true));
+    try {
+      await _collectionService.commitEmptyTrayWmsToWcs(
+        taskId: state.task.outTaskId.toString(),
+        taskNo: taskNo,
+        trayNo: trayNo,
+        startAddr: location,
+        endAddr: '1111',
+        singleFlag: '1',
+      );
+
+      emit(
+        state.copyWith(
+          status: const CollectionStatus.success('空托盘出库指令已下发，请等待'),
+          focus: true,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onTrayReturnRequested(
+    OnlinePickCollectionTrayReturnRequested event,
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    if (state.collectedStocks.isNotEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('采集数据未提交，不允许下发回库指令'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final trayNo = state.trayNo.trim();
+    if (trayNo.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请采集托盘号'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final location = state.selectedLocation?.value.trim() ?? '';
+    if (location.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('请先选择拣选口位置'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final taskNo = (state.task.outTaskNo ?? '').trim();
+    if (taskNo.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('凭证号为空，请确认'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    final trayItem = _findTrayItem(trayNo);
+    final targetSite = trayItem?.storeSiteNo?.trim() ?? '';
+    if (targetSite.isEmpty) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error('未找到托盘对应的目标库位，请确认'),
+          focus: true,
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(status: CollectionStatus.loading(), focus: true));
+    try {
+      await _collectionService.commitResetWmsToWcs(
+        taskId: state.task.outTaskId.toString(),
+        taskNo: taskNo,
+        trayNo: trayNo,
+        startAddr: location,
+        endAddr: targetSite,
+        isInventory: state.mode == OnlinePickCollectionModeType.inventory,
+      );
+
+      emit(
+        state.copyWith(
+          status: const CollectionStatus.success('托盘回库指令已下发，请等待'),
+          focus: true,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  OnlinePickTaskItem? _findTrayItem(String trayNo) {
+    final normalized = trayNo.trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+
+    final candidates = <OnlinePickTaskItem>{};
+    candidates.addAll(state.detailList);
+    candidates.addAll(state.collectingList);
+    candidates.addAll(_remoteDetails);
+
+    for (final item in candidates) {
+      final tray = (item.palletNo ?? '').trim();
+      if (tray.isEmpty) {
+        continue;
+      }
+      if (tray == normalized) {
+        return item;
+      }
+    }
+
+    return null;
+  }
+
+  Future<void> _openCacheBox() async {
+    if (_cacheBox != null) return;
+    _cacheBox = await _hive.openBox<OnlinePickCollectionCacheSnapshot>(
+      'aswh_down_collect_${state.task.outTaskId}',
+    );
+  }
+
+  Future<void> _restoreFromCache(
+    Emitter<OnlinePickCollectionState> emit,
+  ) async {
+    final box = _cacheBox;
+    if (box == null) return;
+    final snapshot = box.get('snapshot');
+    if (snapshot == null) return;
+
+    final cache = _rebuildCachesFromStocks(snapshot.stocks);
+    final detailList = _deriveDetailListFromRemote(snapshot.stocks);
+    final collecting = _buildCollectingListFromDetail(detailList);
+
+    emit(
+      state.copyWith(
+        collectedStocks: snapshot.stocks,
+        detailList: detailList,
+        collectingList: collecting,
+        serialMap: cache.serialMap,
+        materialQtyMap: cache.materialQtyMap,
+        inventoryQtyMap: cache.inventoryQtyMap,
+        expectedErpStore: snapshot.expectedErpStore,
+        location: snapshot.location,
+        trayNo: snapshot.trayNo,
+        barcodeContent: snapshot.lastBarcode,
+        pendingQuantity: snapshot.pendingQuantity,
+        status: const CollectionStatus.success('已恢复采集缓存'),
+        focus: true,
+        wcsCommands: state.wcsCommands,
+      ),
+    );
+  }
+
+  Future<void> _persistCache() async {
+    final box = _cacheBox;
+    if (box == null) return;
+    final snapshot = OnlinePickCollectionCacheSnapshot(
+      stocks: state.collectedStocks,
+      dicSeq: state.serialMap,
+      dicMtlQty: state.materialQtyMap,
+      dicInvMtlQty: state.inventoryQtyMap,
+      lastBarcode: state.barcodeContent,
+      location: state.location,
+      trayNo: state.trayNo,
+      userId: _userManager.userInfo?.userId ?? 0,
+      pendingQuantity: state.pendingQuantity,
+      mode: state.mode.name,
+      expectedErpStore: state.expectedErpStore,
+    );
+    await box.put('snapshot', snapshot);
+  }
+
+  Future<void> _refreshTaskData(
+    Emitter<OnlinePickCollectionState> emit, {
+    bool showLoading = false,
+    String? successMessage,
+  }) async {
+    final query = _currentQuery;
+    if (query == null) {
+      return;
+    }
+
+    if (showLoading) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.loading(),
+          focus: true,
+        ),
+      );
+    }
+
+    try {
+      final itemsFuture = _collectionService.fetchCollectionTaskItems(
+        query: query,
+      );
+      final wcsFuture = _collectionService.fetchWcsCommands(
+        taskComment: state.task.taskComment ?? '',
+        taskId: state.task.outTaskId.toString(),
+      );
+
+      final items = await itemsFuture;
+      final wcsCommands = await wcsFuture;
+
+      _remoteDetails = items;
+
+      var expectedErpStore = state.expectedErpStore;
+      if (items.isNotEmpty) {
+        expectedErpStore = items.first.subInventoryCode ?? expectedErpStore;
+      }
+
+      final detailList = _deriveDetailListFromRemote(state.collectedStocks);
+      final collectingList = _buildCollectingListFromDetail(detailList);
+
+      emit(
+        state.copyWith(
+          detailList: detailList,
+          collectingList: collectingList,
+          expectedErpStore: expectedErpStore,
+          wcsCommands: wcsCommands,
+          status: successMessage != null
+              ? CollectionStatus.success(successMessage)
+              : const CollectionStatus.success(),
+          focus: true,
+        ),
+      );
+    } catch (error) {
+      emit(
+        state.copyWith(
+          status: CollectionStatus.error(ErrorHandler.handleError(error)),
+          focus: true,
+        ),
+      );
+    }
+  }
+
+  OnlinePickTaskItem? _matchTaskItem(String materialCode) {
+    final trimmed = materialCode.trim();
+    if (trimmed.isEmpty) return null;
+    try {
+      return state.detailList.firstWhere(
+        (item) => (item.materialCode ?? '').trim() == trimmed,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  _CollectionCache _rebuildCachesFromStocks(
+    List<OnlinePickCollectionStock> stocks,
+  ) {
+    final serialMap = <String, String>{};
+    final materialQtyMap = <String, List<double>>{};
+    final inventoryQtyMap = <String, double>{};
+    var expectedErpStore = '';
+
+    for (final stock in stocks) {
+      final serialKey =
+          '${stock.materialCode}@${stock.serialNumber ?? ''}'.trim();
+      if ((stock.serialNumber ?? '').isNotEmpty) {
+        serialMap[serialKey] = stock.stockId;
+      }
+
+      final materialKey = _materialKey(stock);
+      final existing = materialQtyMap[materialKey];
+      final first = existing != null ? existing.first : stock.collectQty.toDouble();
+      final total =
+          (existing != null ? existing.last : 0) + stock.collectQty.toDouble();
+      materialQtyMap[materialKey] = [first, total];
+
+      final inventoryKey = _inventoryKey(stock);
+      inventoryQtyMap[inventoryKey] =
+          (inventoryQtyMap[inventoryKey] ?? 0) + stock.collectQty.toDouble();
+
+      if (expectedErpStore.isEmpty && (stock.erpStore?.isNotEmpty ?? false)) {
+        expectedErpStore = stock.erpStore!;
+      }
+    }
+
+    return _CollectionCache(
+      serialMap: serialMap,
+      materialQtyMap: materialQtyMap,
+      inventoryQtyMap: inventoryQtyMap,
+      expectedErpStore: expectedErpStore,
+    );
+  }
+
+  OnlinePickLocationOption? _resolveSelectedLocation(
+    List<OnlinePickLocationOption> options,
+  ) {
+    if (options.isEmpty) {
+      return null;
+    }
+    final current = state.selectedLocation;
+    if (current == null) {
+      return options.first;
+    }
+    return options.firstWhere(
+      (option) => option.value == current.value,
+      orElse: () => options.first,
+    );
+  }
+
+  List<OnlinePickTaskItem> _uniqueTrayItems() {
+    final seen = <String>{};
+    final result = <OnlinePickTaskItem>[];
+    for (final item in _remoteDetails) {
+      final tray = (item.palletNo ?? '').trim();
+      if (tray.isEmpty || seen.contains(tray)) {
+        continue;
+      }
+      seen.add(tray);
+      result.add(item);
+    }
+    return result;
+  }
+
+  List<OnlinePickTaskItem> _deriveDetailListFromRemote(
+    List<OnlinePickCollectionStock> stocks,
+  ) {
+    final base = List<OnlinePickTaskItem>.from(_remoteDetails);
+    if (stocks.isEmpty) {
+      return base;
+    }
+
+    final additionMap = _aggregateStockQuantities(stocks);
+    if (additionMap.isEmpty) {
+      return base;
+    }
+
+    return base
+        .map((item) {
+          final addition = additionMap[item.outTaskItemId];
+          if (addition == null || addition == 0) {
+            return item;
+          }
+          final updatedCollected =
+              item.collectedQty.toDouble() + addition.toDouble();
+          return item.copyWith(collectedQty: updatedCollected);
+        })
+        .toList();
+  }
+
+  List<OnlinePickTaskItem> _buildCollectingListFromDetail(
+    List<OnlinePickTaskItem> detailList,
+  ) {
+    return detailList
+        .where((item) => item.collectedQty.toDouble() > 0)
+        .toList();
+  }
+
+  Map<int, double> _aggregateStockQuantities(
+    List<OnlinePickCollectionStock> stocks,
+  ) {
+    final map = <int, double>{};
+    for (final stock in stocks) {
+      final id = int.tryParse(stock.outTaskItemId);
+      if (id == null) continue;
+      map[id] = (map[id] ?? 0) + stock.collectQty.toDouble();
+    }
+    return map;
+  }
+
+  String _placeholderForStep(OnlinePickCollectionStep step) {
+    switch (step) {
+      case OnlinePickCollectionStep.location:
+        return '请扫描库位条码';
+      case OnlinePickCollectionStep.tray:
+        return '请扫描托盘条码';
+      case OnlinePickCollectionStep.material:
+        return '请扫描物料二维码';
+      case OnlinePickCollectionStep.quantity:
+        return '请扫描或输入采集数量';
+      case OnlinePickCollectionStep.review:
+        return '请检查采集结果';
+    }
+  }
+
+  String _materialKey(OnlinePickCollectionStock stock) {
+    return [
+      stock.materialCode ?? '',
+      stock.batchNo ?? '',
+      stock.storeSite ?? '',
+      stock.trayNo ?? '',
+    ].join('|');
+  }
+
+  String _inventoryKey(OnlinePickCollectionStock stock) {
+    return _composeInventoryKey(
+      storeSite: stock.storeSite ?? '',
+      materialCode: stock.materialCode,
+      batchNo: stock.batchNo,
+      serialNumber: stock.serialNumber,
+    );
+  }
+
+  static OnlinePickSubmissionChannel _resolveInitialSubmissionChannel(
+    OnlinePickTask task,
+    String? submissionHint,
+  ) {
+    final normalizedHint = submissionHint?.trim().toLowerCase() ?? '';
+    if (normalizedHint.isNotEmpty) {
+      if (_matchesTrayType(normalizedHint)) {
+        return OnlinePickSubmissionChannel.tray;
+      }
+      if (_matchesStandardType(normalizedHint)) {
+        return OnlinePickSubmissionChannel.standard;
+      }
+      if (_matchesAswhType(normalizedHint)) {
+        return OnlinePickSubmissionChannel.aswh;
+      }
+    }
+
+    final candidates = <String?>[
+      task.taskComment,
+      task.storeRoomNo,
+      task.workStation,
+      task.scheduleGroupName,
+      task.urgentFlag,
+    ];
+
+    for (final value in candidates) {
+      if (_matchesTrayType(value)) {
+        return OnlinePickSubmissionChannel.tray;
+      }
+    }
+
+    for (final value in candidates) {
+      if (_matchesStandardType(value)) {
+        return OnlinePickSubmissionChannel.standard;
+      }
+    }
+
+    for (final value in candidates) {
+      if (_matchesAswhType(value)) {
+        return OnlinePickSubmissionChannel.aswh;
+      }
+    }
+
+    return OnlinePickSubmissionChannel.aswh;
+  }
+
+  static bool _matchesTrayType(String? value) {
+    if (value == null || value.isEmpty) {
+      return false;
+    }
+    final lower = value.toLowerCase();
+    return lower.contains('tray') ||
+        lower.contains('pallet') ||
+        lower.contains('托盘') ||
+        lower.contains('整托') ||
+        lower.contains('traydown') ||
+        _containsCode(lower, '02');
+  }
+
+  static bool _matchesStandardType(String? value) {
+    if (value == null || value.isEmpty) {
+      return false;
+    }
+    final lower = value.toLowerCase();
+    return lower.contains('flat') ||
+        lower.contains('平库') ||
+        lower.contains('standard') ||
+        (lower.contains('commitdown') && !lower.contains('tray')) ||
+        (lower.contains('downshelves') && !lower.contains('tray')) ||
+        lower.contains('wms') ||
+        _containsCode(lower, '00') ||
+        _containsCode(lower, '01');
+  }
+
+  static bool _matchesAswhType(String? value) {
+    if (value == null || value.isEmpty) {
+      return false;
+    }
+    final lower = value.toLowerCase();
+    return lower.contains('aswh') ||
+        lower.contains('as/rs') ||
+        lower.contains('自动化') ||
+        lower.contains('立库') ||
+        _containsCode(lower, '03');
+  }
+
+  static bool _containsCode(String source, String code) {
+    final pattern = RegExp(
+        '(^|[^0-9a-z])${RegExp.escape(code.toLowerCase())}($|[^0-9a-z])');
+    return pattern.hasMatch(source.toLowerCase());
+  }
+}
+
+class _CollectionCache {
+  const _CollectionCache({
+    required this.serialMap,
+    required this.materialQtyMap,
+    required this.inventoryQtyMap,
+    required this.expectedErpStore,
+  });
+
+  final Map<String, String> serialMap;
+  final Map<String, List<double>> materialQtyMap;
+  final Map<String, double> inventoryQtyMap;
+  final String expectedErpStore;
+}
+
+class _InventoryValidationResult {
+  const _InventoryValidationResult({
+    required this.availableQuantity,
+    required this.collectedQuantity,
+    this.erpStore,
+  });
+
+  final double availableQuantity;
+  final double collectedQuantity;
+  final String? erpStore;
+}

--- a/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_event.dart
+++ b/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_event.dart
@@ -1,0 +1,164 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
+
+abstract class OnlinePickCollectionEvent extends Equatable {
+  const OnlinePickCollectionEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class OnlinePickCollectionStarted extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionStarted({this.restoreCache = true});
+
+  final bool restoreCache;
+
+  @override
+  List<Object?> get props => [restoreCache];
+}
+
+class OnlinePickCollectionScanPerformed extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionScanPerformed(this.rawValue);
+
+  final String rawValue;
+
+  @override
+  List<Object?> get props => [rawValue];
+}
+
+class OnlinePickCollectionQuantitySubmitted extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionQuantitySubmitted(this.quantity);
+
+  final num quantity;
+
+  @override
+  List<Object?> get props => [quantity];
+}
+
+class OnlinePickCollectionStocksSynced extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionStocksSynced(this.payload);
+
+  final List<Map<String, dynamic>> payload;
+
+  @override
+  List<Object?> get props => [payload];
+}
+
+class OnlinePickCollectionResetStatus extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionResetStatus();
+}
+
+class OnlinePickCollectionChangeTab extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionChangeTab(this.index);
+
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}
+
+class OnlinePickCollectionSelectionChanged extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionSelectionChanged(this.selectedItems);
+
+  final List<OnlinePickTaskItem> selectedItems;
+
+  @override
+  List<Object?> get props => [selectedItems];
+}
+
+class OnlinePickCollectionFocusRequested extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionFocusRequested(this.focus);
+
+  final bool focus;
+
+  @override
+  List<Object?> get props => [focus];
+}
+
+class OnlinePickCollectionDeleteStocksRequested
+    extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionDeleteStocksRequested(this.stockIds);
+
+  final List<String> stockIds;
+
+  @override
+  List<Object?> get props => [stockIds];
+}
+
+class OnlinePickCollectionResultRemoved extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionResultRemoved(this.removedStocks);
+
+  final List<OnlinePickCollectionStock> removedStocks;
+
+  @override
+  List<Object?> get props => [removedStocks];
+}
+
+class OnlinePickCollectionDetailsRefreshRequested
+    extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionDetailsRefreshRequested({
+    this.showLoading = false,
+    this.successMessage,
+  });
+
+  final bool showLoading;
+  final String? successMessage;
+
+  @override
+  List<Object?> get props => [showLoading, successMessage];
+}
+
+class OnlinePickCollectionSubmitRequested extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionSubmitRequested();
+}
+
+class OnlinePickCollectionCacheCleared extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionCacheCleared();
+}
+
+class OnlinePickCollectionModeChanged extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionModeChanged(this.mode);
+
+  final OnlinePickCollectionMode mode;
+
+  @override
+  List<Object?> get props => [mode];
+}
+
+class OnlinePickCollectionLocationSelected extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionLocationSelected(this.location);
+
+  final OnlinePickLocationOption location;
+
+  @override
+  List<Object?> get props => [location];
+}
+
+class OnlinePickCollectionPalletsCallRequested extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionPalletsCallRequested(this.count);
+
+  final int count;
+
+  @override
+  List<Object?> get props => [count];
+}
+
+class OnlinePickCollectionExceptionSubmitted extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionExceptionSubmitted(this.submission);
+
+  final OnlinePickExceptionSubmission submission;
+
+  @override
+  List<Object?> get props => [submission];
+}
+
+class OnlinePickCollectionEmptyTrayOutboundRequested
+    extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionEmptyTrayOutboundRequested();
+}
+
+class OnlinePickCollectionTrayReturnRequested
+    extends OnlinePickCollectionEvent {
+  const OnlinePickCollectionTrayReturnRequested();
+}

--- a/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart
+++ b/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart
@@ -1,0 +1,195 @@
+import 'package:equatable/equatable.dart';
+import 'package:wms_app/models/page_status.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_wcs_models.dart';
+
+/// 提交接口通道枚举。
+enum OnlinePickSubmissionChannel {
+  /// 自动化立库下架（CommitASWHDownShelves）。
+  aswh,
+
+  /// 平库/常规下架（commitDownShelves）。
+  standard,
+
+  /// 整托托盘下架（commitTrayDownShelves）。
+  tray,
+}
+
+extension OnlinePickSubmissionChannelX on OnlinePickSubmissionChannel {
+  String get label {
+    switch (this) {
+      case OnlinePickSubmissionChannel.aswh:
+        return 'ASWH 下架';
+      case OnlinePickSubmissionChannel.standard:
+        return '平库下架';
+      case OnlinePickSubmissionChannel.tray:
+        return '整托下架';
+    }
+  }
+}
+
+class OnlinePickCollectionState extends Equatable {
+  const OnlinePickCollectionState({
+    required this.task,
+    this.status = const CollectionStatus(CollectionStatusType.normal),
+    this.detailList = const [],
+    this.collectingList = const [],
+    this.collectedStocks = const [],
+    this.barcodeContent,
+    this.currentItem,
+    this.location = '',
+    this.trayNo = '',
+    this.expectedErpStore = '',
+    this.mode = OnlinePickCollectionModeType.outbound,
+    this.step = OnlinePickCollectionStep.location,
+    this.serialMap = const {},
+    this.materialQtyMap = const {},
+    this.inventoryQtyMap = const {},
+    this.pendingQuantity,
+    this.currentTab = 0,
+    this.placeholder = '请扫描库位条码',
+    this.focus = false,
+    this.selectedDetailIds = const [],
+    this.wcsCommands = const [],
+    this.availableModes = const [
+      OnlinePickCollectionMode(code: 'outbound', label: '正常采集'),
+      OnlinePickCollectionMode(code: 'inventory', label: '库存核对', type: OnlinePickCollectionModeType.inventory),
+      OnlinePickCollectionMode(code: 'exception', label: '异常补录', type: OnlinePickCollectionModeType.exception),
+    ],
+    this.locationOptions = const [],
+    this.selectedLocation,
+    this.requestedPallets = const [],
+    this.submitChannel = OnlinePickSubmissionChannel.aswh,
+  });
+
+  factory OnlinePickCollectionState.initial(
+    OnlinePickTask task, {
+    OnlinePickSubmissionChannel submitChannel =
+        OnlinePickSubmissionChannel.aswh,
+  }) {
+    return OnlinePickCollectionState(
+      task: task,
+      submitChannel: submitChannel,
+    );
+  }
+
+  final OnlinePickTask task;
+  final CollectionStatus status;
+  final List<OnlinePickTaskItem> detailList;
+  final List<OnlinePickTaskItem> collectingList;
+  final List<OnlinePickCollectionStock> collectedStocks;
+  final OnlinePickBarcodeContent? barcodeContent;
+  final OnlinePickTaskItem? currentItem;
+  final String location;
+  final String trayNo;
+  final String expectedErpStore;
+  final OnlinePickCollectionModeType mode;
+  final OnlinePickCollectionStep step;
+  final Map<String, String> serialMap;
+  final Map<String, List<double>> materialQtyMap;
+  final Map<String, double> inventoryQtyMap;
+  final num? pendingQuantity;
+  final int currentTab;
+  final String placeholder;
+  final bool focus;
+  final List<int> selectedDetailIds;
+  final List<OnlinePickWcsCommand> wcsCommands;
+  final List<OnlinePickCollectionMode> availableModes;
+  final List<OnlinePickLocationOption> locationOptions;
+  final OnlinePickLocationOption? selectedLocation;
+  final List<String> requestedPallets;
+  final OnlinePickSubmissionChannel submitChannel;
+
+  OnlinePickCollectionState copyWith({
+    CollectionStatus? status,
+    List<OnlinePickTaskItem>? detailList,
+    List<OnlinePickTaskItem>? collectingList,
+    List<OnlinePickCollectionStock>? collectedStocks,
+    OnlinePickBarcodeContent? barcodeContent,
+    OnlinePickTaskItem? currentItem,
+    String? location,
+    String? trayNo,
+    String? expectedErpStore,
+    OnlinePickCollectionModeType? mode,
+    OnlinePickCollectionStep? step,
+    Map<String, String>? serialMap,
+    Map<String, List<double>>? materialQtyMap,
+    Map<String, double>? inventoryQtyMap,
+    num? pendingQuantity,
+    int? currentTab,
+    String? placeholder,
+    bool? focus,
+    List<int>? selectedDetailIds,
+    List<OnlinePickWcsCommand>? wcsCommands,
+    List<OnlinePickCollectionMode>? availableModes,
+    List<OnlinePickLocationOption>? locationOptions,
+    OnlinePickLocationOption? selectedLocation,
+    List<String>? requestedPallets,
+    OnlinePickSubmissionChannel? submitChannel,
+    bool clearBarcode = false,
+    bool clearCurrentItem = false,
+    bool clearPendingQuantity = false,
+  }) {
+    return OnlinePickCollectionState(
+      task: task,
+      status: status ?? this.status,
+      detailList: detailList ?? this.detailList,
+      collectingList: collectingList ?? this.collectingList,
+      collectedStocks: collectedStocks ?? this.collectedStocks,
+      barcodeContent: clearBarcode ? null : barcodeContent ?? this.barcodeContent,
+      currentItem: clearCurrentItem ? null : currentItem ?? this.currentItem,
+      location: location ?? this.location,
+      trayNo: trayNo ?? this.trayNo,
+      expectedErpStore: expectedErpStore ?? this.expectedErpStore,
+      mode: mode ?? this.mode,
+      step: step ?? this.step,
+      serialMap: serialMap ?? this.serialMap,
+      materialQtyMap: materialQtyMap ?? this.materialQtyMap,
+      inventoryQtyMap: inventoryQtyMap ?? this.inventoryQtyMap,
+      pendingQuantity:
+          clearPendingQuantity ? null : pendingQuantity ?? this.pendingQuantity,
+      currentTab: currentTab ?? this.currentTab,
+      placeholder: placeholder ?? this.placeholder,
+      focus: focus ?? this.focus,
+      selectedDetailIds: selectedDetailIds ?? this.selectedDetailIds,
+      wcsCommands: wcsCommands ?? this.wcsCommands,
+      availableModes: availableModes ?? this.availableModes,
+      locationOptions: locationOptions ?? this.locationOptions,
+      selectedLocation: selectedLocation ?? this.selectedLocation,
+      requestedPallets: requestedPallets ?? this.requestedPallets,
+      submitChannel: submitChannel ?? this.submitChannel,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        task,
+        status,
+        detailList,
+        collectingList,
+        collectedStocks,
+        barcodeContent,
+        currentItem,
+        location,
+        trayNo,
+        expectedErpStore,
+        mode,
+        step,
+        serialMap,
+        materialQtyMap,
+        inventoryQtyMap,
+        pendingQuantity,
+        currentTab,
+        placeholder,
+        focus,
+        selectedDetailIds,
+        wcsCommands,
+        availableModes,
+        locationOptions,
+        selectedLocation,
+        requestedPallets,
+        submitChannel,
+      ];
+}

--- a/lib/modules/aswh_down/collection_task/config/online_pick_collection_grid_config.dart
+++ b/lib/modules/aswh_down/collection_task/config/online_pick_collection_grid_config.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
+
+class OnlinePickCollectionGridConfig {
+  static List<GridColumnConfig<OnlinePickTaskItem>> taskColumns() {
+    return [
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'matcode',
+        headerText: '物料编码',
+        valueGetter: (row) => row.materialCode ?? '',
+        width: 140,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'matname',
+        headerText: '物料名称',
+        valueGetter: (row) => row.materialName ?? '',
+        width: 180,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'storesite',
+        headerText: '库位',
+        valueGetter: (row) => row.storeSiteNo ?? '-',
+        width: 110,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'tray',
+        headerText: '托盘',
+        valueGetter: (row) => row.palletNo ?? '-',
+        width: 120,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'taskqty',
+        headerText: '任务数量',
+        valueGetter: (row) => row.taskQty,
+        width: 100,
+        textAlign: TextAlign.right,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'collectedqty',
+        headerText: '采集数量',
+        valueGetter: (row) => row.collectedQty,
+        width: 100,
+        textAlign: TextAlign.right,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'batchno',
+        headerText: '批次',
+        valueGetter: (row) => row.batchNo ?? row.hintBatchNo ?? '-',
+        width: 120,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'sn',
+        headerText: '序列号',
+        valueGetter: (row) => row.serialNumber ?? '-',
+        width: 140,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'subinventory',
+        headerText: 'ERP 子库',
+        valueGetter: (row) => row.subInventoryCode ?? '-',
+        width: 120,
+      ),
+      GridColumnConfig<OnlinePickTaskItem>(
+        name: 'remark',
+        headerText: '备注',
+        valueGetter: (row) => row.taskComment ?? '-',
+        width: 160,
+      ),
+    ];
+  }
+
+  static List<GridColumnConfig<OnlinePickCollectionStock>> collectedColumns() {
+    return [
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'matcode',
+        headerText: '物料编码',
+        valueGetter: (row) => row.materialCode,
+        width: 140,
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'collectQty',
+        headerText: '采集数量',
+        valueGetter: (row) => row.collectQty,
+        width: 100,
+        textAlign: TextAlign.right,
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'taskQty',
+        headerText: '任务数量',
+        valueGetter: (row) => row.taskQty,
+        width: 100,
+        textAlign: TextAlign.right,
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'storeSite',
+        headerText: '库位',
+        valueGetter: (row) => row.storeSite ?? '-',
+        width: 110,
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'trayNo',
+        headerText: '托盘',
+        valueGetter: (row) => row.trayNo ?? '-',
+        width: 120,
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'batchno',
+        headerText: '批次',
+        valueGetter: (row) => row.batchNo ?? '-',
+        width: 120,
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'sn',
+        headerText: '序列号',
+        valueGetter: (row) => row.serialNumber ?? '-',
+        width: 140,
+      ),
+      GridColumnConfig<OnlinePickCollectionStock>(
+        name: 'erpStore',
+        headerText: 'ERP 子库',
+        valueGetter: (row) => row.erpStore ?? '-',
+        width: 120,
+      ),
+    ];
+  }
+}

--- a/lib/modules/aswh_down/collection_task/online_pick_collection_page.dart
+++ b/lib/modules/aswh_down/collection_task/online_pick_collection_page.dart
@@ -1,0 +1,966 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_config.dart';
+import 'package:wms_app/common_widgets/scanner_widget/scanner_widget.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_bloc.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_event.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/config/online_pick_collection_grid_config.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/widgets/online_pick_collection_info_card.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_models.dart';
+
+class OnlinePickCollectionPage extends StatefulWidget {
+  const OnlinePickCollectionPage({
+    super.key,
+    required this.task,
+    this.initialArgs = const {},
+  });
+
+  final OnlinePickTask task;
+  final Map<String, dynamic> initialArgs;
+
+  @override
+  State<OnlinePickCollectionPage> createState() =>
+      _OnlinePickCollectionPageState();
+}
+
+class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
+    with SingleTickerProviderStateMixin {
+  late final OnlinePickCollectionBloc _bloc;
+  late final TabController _tabController;
+  final ScannerController _scannerController = ScannerController();
+
+  static const List<Map<String, String>> _exceptionTypeOptions = [
+    {'value': '010', 'label': '小包装发料'},
+    {'value': '006', 'label': '整包装多料'},
+    {'value': '007', 'label': '整包装少料'},
+    {'value': '008', 'label': '混料'},
+    {'value': '009', 'label': '质量问题'},
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = BlocProvider.of<OnlinePickCollectionBloc>(context);
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  bool _canPop() {
+    return _bloc.state.collectedStocks.isEmpty;
+  }
+
+  Future<void> _handleBackPress() async {
+    if (_canPop()) {
+      Modular.to.pop();
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('返回确认'),
+            content: const Text('返回将丢失未提交的采集记录，是否继续？'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('取消'),
+              ),
+              ElevatedButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('确认'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (confirmed) {
+      Modular.to.pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: _canPop(),
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        _handleBackPress();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: const Color(0xFF1976D2),
+          centerTitle: true,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: _handleBackPress,
+          ),
+          title: const Text(
+            'AS/RS 下架采集',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          actions: [
+            IconButton(
+              onPressed: () {
+                _bloc.add(const OnlinePickCollectionCacheCleared());
+              },
+              icon: const Icon(Icons.cleaning_services_outlined,
+                  color: Colors.white),
+              tooltip: '清空缓存',
+            ),
+          ],
+        ),
+        backgroundColor: const Color(0xFFF6F6F6),
+        body:
+            BlocConsumer<OnlinePickCollectionBloc, OnlinePickCollectionState>(
+          listener: (context, state) {
+            LoadingDialogManager.instance.hideLoadingDialog(context);
+
+            if (state.status.isLoading) {
+              LoadingDialogManager.instance.showLoadingDialog(context);
+            } else if (state.status.isError) {
+              LoadingDialogManager.instance.showErrorDialog(
+                context,
+                state.status.message ?? '操作失败',
+              );
+              _bloc.add(const OnlinePickCollectionResetStatus());
+            } else if (state.status.isSuccess &&
+                state.status.message?.isNotEmpty == true) {
+              LoadingDialogManager.instance.showSnackSuccessMsg(
+                context,
+                state.status.message!,
+                duration: const Duration(milliseconds: 900),
+              );
+              _bloc.add(const OnlinePickCollectionResetStatus());
+            }
+
+            if (state.currentTab != _tabController.index) {
+              _tabController.index = state.currentTab;
+            }
+
+            if (state.focus) {
+              _scannerController.requestFocus();
+              _bloc.add(const OnlinePickCollectionFocusRequested(false));
+            }
+
+            _scannerController.clear();
+          },
+          builder: (context, state) {
+            return Column(
+              children: [
+                _buildScanner(state),
+                OnlinePickCollectionInfoCard(state: state),
+                Container(
+                  decoration: const BoxDecoration(color: Colors.white),
+                  height: 44,
+                  child: TabBar(
+                    controller: _tabController,
+                    labelColor: const Color(0xFF1976D2),
+                    unselectedLabelColor: const Color(0xFF78909C),
+                    indicatorColor: const Color(0xFF1976D2),
+                    indicatorWeight: 3,
+                    labelStyle: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    tabs: const [
+                      Tab(text: '任务列表'),
+                      Tab(text: '正在采集'),
+                    ],
+                    onTap: (index) {
+                      _bloc.add(OnlinePickCollectionChangeTab(index));
+                    },
+                  ),
+                ),
+                Expanded(
+                  child: TabBarView(
+                    controller: _tabController,
+                    children: [
+                      _buildTaskGrid(state.detailList, state.selectedDetailIds),
+                      _buildCollectingGrid(state.collectingList),
+                    ],
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+        bottomNavigationBar:
+            BlocBuilder<OnlinePickCollectionBloc, OnlinePickCollectionState>(
+          buildWhen: (previous, current) =>
+              previous.collectedStocks != current.collectedStocks ||
+              previous.mode != current.mode ||
+              previous.selectedLocation != current.selectedLocation ||
+              previous.locationOptions != current.locationOptions ||
+              previous.status != current.status,
+          builder: (context, state) {
+            return _buildBottomBar(state);
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScanner(OnlinePickCollectionState state) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+      child: ScannerWidget(
+        controller: _scannerController,
+        autofocus: true,
+        config: ScannerConfig(
+          showKeyboardToggle: true,
+          placeholder: state.placeholder,
+        ),
+        onBarcodeScanned: (value) {
+          _bloc.add(OnlinePickCollectionScanPerformed(value));
+        },
+      ),
+    );
+  }
+
+  Widget _buildTaskGrid(
+    List<OnlinePickTaskItem> items,
+    List<int> selectedIds,
+  ) {
+    final selectedRows = _selectedIndicesFor(items, selectedIds);
+    return CommonDataGrid<OnlinePickTaskItem>(
+      columns: OnlinePickCollectionGridConfig.taskColumns(),
+      datas: items,
+      allowPager: false,
+      allowSelect: true,
+      currentPage: 1,
+      totalPages: 1,
+      selectedRows: selectedRows,
+      onLoadData: (_) async {},
+      onSelectionChanged: (indices) {
+        final selectedItems = indices
+            .where((index) => index >= 0 && index < items.length)
+            .map((index) => items[index])
+            .toList();
+        _bloc.add(OnlinePickCollectionSelectionChanged(selectedItems));
+      },
+    );
+  }
+
+  Widget _buildCollectingGrid(List<OnlinePickTaskItem> items) {
+    return CommonDataGrid<OnlinePickTaskItem>(
+      columns: OnlinePickCollectionGridConfig.taskColumns(),
+      datas: items,
+      allowPager: false,
+      allowSelect: false,
+      currentPage: 1,
+      totalPages: 1,
+      onLoadData: (_) async {},
+      selectedRows: const [],
+    );
+  }
+
+  Future<void> _openExceptionDialog(OnlinePickCollectionState state) async {
+    final formKey = GlobalKey<FormState>();
+    final currentItem = state.currentItem;
+    final barcode = state.barcodeContent;
+
+    final materialCodeController = TextEditingController(
+      text: barcode?.materialCode ?? currentItem?.materialCode ?? '',
+    );
+    final materialNameController = TextEditingController(
+      text: barcode?.materialName ?? currentItem?.materialName ?? '',
+    );
+    final batchController = TextEditingController(
+      text: barcode?.batchNo ?? currentItem?.batchNo ?? currentItem?.hintBatchNo ?? '',
+    );
+    final serialController = TextEditingController(
+      text: barcode?.serialNumber ?? currentItem?.serialNumber ?? '',
+    );
+    final unitController = TextEditingController();
+    final descriptionController = TextEditingController();
+    final initialQuantity = state.pendingQuantity ?? barcode?.quantity;
+    final quantityController = TextEditingController(
+      text: initialQuantity == null || initialQuantity == 0
+          ? ''
+          : initialQuantity.toString(),
+    );
+    final storeSiteController = TextEditingController(
+      text: state.location.isNotEmpty
+          ? state.location
+          : (currentItem?.storeSiteNo ?? ''),
+    );
+
+    final defaultType = _exceptionTypeOptions.first['value']!;
+    var selectedType = defaultType;
+
+    final submission = await showDialog<OnlinePickExceptionSubmission>(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: const Text('异常补录'),
+              content: SingleChildScrollView(
+                child: Form(
+                  key: formKey,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      TextFormField(
+                        controller: materialCodeController,
+                        decoration: const InputDecoration(
+                          labelText: '物料编码',
+                          border: OutlineInputBorder(),
+                        ),
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return '请输入物料编码';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: materialNameController,
+                        decoration: const InputDecoration(
+                          labelText: '物料名称',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: quantityController,
+                        keyboardType:
+                            const TextInputType.numberWithOptions(decimal: true),
+                        decoration: const InputDecoration(
+                          labelText: '异常数量',
+                          border: OutlineInputBorder(),
+                        ),
+                        validator: (value) {
+                          final parsed = num.tryParse(value ?? '');
+                          if (parsed == null || parsed <= 0) {
+                            return '请输入有效的数量';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: storeSiteController,
+                        decoration: const InputDecoration(
+                          labelText: '库位',
+                          border: OutlineInputBorder(),
+                        ),
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return '请输入库位';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      DropdownButtonFormField<String>(
+                        value: selectedType,
+                        items: _exceptionTypeOptions
+                            .map(
+                              (option) => DropdownMenuItem<String>(
+                                value: option['value'],
+                                child: Text(option['label'] ?? option['value']!),
+                              ),
+                            )
+                            .toList(),
+                        onChanged: (value) {
+                          if (value == null) return;
+                          setState(() {
+                            selectedType = value;
+                          });
+                        },
+                        decoration: const InputDecoration(
+                          labelText: '异常类型',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: batchController,
+                        decoration: const InputDecoration(
+                          labelText: '批次',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: serialController,
+                        decoration: const InputDecoration(
+                          labelText: '序列号',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: unitController,
+                        decoration: const InputDecoration(
+                          labelText: '单位',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: descriptionController,
+                        maxLines: 3,
+                        decoration: const InputDecoration(
+                          labelText: '异常描述',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('取消'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    if (formKey.currentState?.validate() ?? false) {
+                      final quantity =
+                          num.parse(quantityController.text.trim());
+                      Navigator.of(context).pop(
+                        OnlinePickExceptionSubmission(
+                          materialCode: materialCodeController.text.trim(),
+                          materialName: materialNameController.text.trim(),
+                          quantity: quantity,
+                          unit: unitController.text.trim(),
+                          storeSite: storeSiteController.text.trim(),
+                          batchNo: batchController.text.trim(),
+                          serialNumber: serialController.text.trim(),
+                          exceptionType: selectedType,
+                          description: descriptionController.text.trim(),
+                          trayNo: state.trayNo,
+                        ),
+                      );
+                    }
+                  },
+                  child: const Text('提交'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    materialCodeController.dispose();
+    materialNameController.dispose();
+    batchController.dispose();
+    serialController.dispose();
+    unitController.dispose();
+    descriptionController.dispose();
+    quantityController.dispose();
+    storeSiteController.dispose();
+
+    if (submission != null) {
+      _bloc.add(OnlinePickCollectionExceptionSubmitted(submission));
+    }
+  }
+
+  Future<void> _confirmEmptyOut(OnlinePickCollectionState state) async {
+    final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (context) {
+            return AlertDialog(
+              title: const Text('空托盘出库'),
+              content: const Text('请确认空托盘出库吗？'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('取消'),
+                ),
+                ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(true),
+                  child: const Text('确认'),
+                ),
+              ],
+            );
+          },
+        ) ??
+        false;
+
+    if (confirmed) {
+      _bloc.add(const OnlinePickCollectionEmptyTrayOutboundRequested());
+    }
+  }
+
+  Future<void> _confirmTrayReturn(OnlinePickCollectionState state) async {
+    final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (context) {
+            final tray = state.trayNo.isEmpty ? '当前托盘' : state.trayNo;
+            return AlertDialog(
+              title: const Text('托盘回库'),
+              content: Text('确认将托盘【$tray】回库吗？'),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: const Text('取消'),
+                ),
+                ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(true),
+                  child: const Text('确认'),
+                ),
+              ],
+            );
+          },
+        ) ??
+        false;
+
+    if (confirmed) {
+      _bloc.add(const OnlinePickCollectionTrayReturnRequested());
+    }
+  }
+
+  Widget _buildMenuItem(IconData icon, String text) {
+    return Row(
+      children: [
+        Icon(icon, size: 20, color: const Color(0xFF546E7A)),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            text,
+            style: const TextStyle(fontSize: 14),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _handleMoreAction(
+    _MoreAction action,
+    OnlinePickCollectionState state,
+  ) {
+    switch (action) {
+      case _MoreAction.mode:
+        _openModePicker(state);
+        break;
+      case _MoreAction.wcs:
+        Modular.to.pushNamed('/aswh-down/wcs', arguments: {
+          'taskId': widget.task.outTaskId,
+          'taskNo': widget.task.outTaskNo,
+        });
+        break;
+      case _MoreAction.exception:
+        _openExceptionDialog(state);
+        break;
+      case _MoreAction.allTray:
+        _openTrayConfirm(state);
+        break;
+      case _MoreAction.emptyOut:
+        _confirmEmptyOut(state);
+        break;
+      case _MoreAction.emptyIn:
+      case _MoreAction.singleTray:
+        _showNotImplemented();
+        break;
+      case _MoreAction.reset:
+        _confirmTrayReturn(state);
+        break;
+    }
+  }
+
+  Future<void> _openLocationPicker(OnlinePickCollectionState state) async {
+    final options = state.locationOptions;
+    if (options.isEmpty) {
+      _showSnack('暂无可用的拣选口配置');
+      return;
+    }
+
+    final selected = await showModalBottomSheet<OnlinePickLocationOption>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Padding(
+                padding: EdgeInsets.fromLTRB(20, 16, 20, 8),
+                child: Text(
+                  '选择拣选口',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              ...options.map((option) {
+                final isActive = option.value == state.selectedLocation?.value;
+                return ListTile(
+                  leading: Icon(
+                    isActive ? Icons.check_circle : Icons.circle_outlined,
+                    color: isActive
+                        ? const Color(0xFF1976D2)
+                        : const Color(0xFFB0BEC5),
+                  ),
+                  title: Text(option.label),
+                  onTap: () => Navigator.of(context).pop(option),
+                );
+              }).toList(),
+              const SizedBox(height: 12),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (selected != null) {
+      _bloc.add(OnlinePickCollectionLocationSelected(selected));
+    }
+  }
+
+  Future<void> _openModePicker(OnlinePickCollectionState state) async {
+    final modes = state.availableModes;
+    final selected = await showModalBottomSheet<OnlinePickCollectionMode>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Padding(
+                padding: EdgeInsets.fromLTRB(20, 16, 20, 8),
+                child: Text(
+                  '切换采集模式',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              ...modes.map((mode) {
+                final isActive = mode.type == state.mode;
+                return ListTile(
+                  leading: Icon(
+                    isActive ? Icons.check_circle : Icons.circle_outlined,
+                    color: isActive
+                        ? const Color(0xFF1976D2)
+                        : const Color(0xFFB0BEC5),
+                  ),
+                  title: Text(mode.label),
+                  subtitle: Text(mode.code),
+                  onTap: () => Navigator.of(context).pop(mode),
+                );
+              }).toList(),
+              const SizedBox(height: 12),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (selected != null) {
+      _bloc.add(OnlinePickCollectionModeChanged(selected));
+    }
+  }
+
+  Future<void> _openTrayConfirm(OnlinePickCollectionState state) async {
+    if (state.selectedLocation == null) {
+      _showSnack('请先选择拣选口位置');
+      return;
+    }
+
+    final formKey = GlobalKey<FormState>();
+    final controller = TextEditingController(text: '1');
+
+    final count = await showModalBottomSheet<int>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(context).viewInsets.bottom + 24,
+            left: 20,
+            right: 20,
+            top: 20,
+          ),
+          child: Form(
+            key: formKey,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  '托盘数量确认',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: controller,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(
+                    labelText: '下发托盘数量',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    final parsed = int.tryParse(value ?? '');
+                    if (parsed == null || parsed <= 0) {
+                      return '请输入有效的托盘数量';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(),
+                      child: const Text('取消'),
+                    ),
+                    const SizedBox(width: 12),
+                    ElevatedButton(
+                      onPressed: () {
+                        if (formKey.currentState?.validate() ?? false) {
+                          final parsed = int.parse(controller.text);
+                          Navigator.of(context).pop(parsed);
+                        }
+                      },
+                      child: const Text('确认'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+
+    if (count != null) {
+      _bloc.add(OnlinePickCollectionPalletsCallRequested(count));
+    }
+  }
+
+  void _showNotImplemented() {
+    _showSnack('功能建设中，敬请期待');
+  }
+
+  void _showSnack(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  Widget _buildBottomBar(OnlinePickCollectionState state) {
+    final locationLabel = state.selectedLocation?.label ?? '选择拣选口';
+    final hasStocks = state.collectedStocks.isNotEmpty;
+
+    return Container(
+      height: 68,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black12,
+            offset: Offset(0, -1),
+            blurRadius: 4,
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton(
+              onPressed: () => _openLocationPicker(state),
+              style: OutlinedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                foregroundColor: const Color(0xFF1976D2),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.place_outlined, size: 18),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      locationLabel,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  const Icon(Icons.expand_more, size: 18),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: ElevatedButton.icon(
+              onPressed: _openCollectionResult,
+              icon: const Icon(Icons.list_alt_outlined),
+              label: const Text('采集结果'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF1976D2),
+                foregroundColor: Colors.white,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: ElevatedButton.icon(
+              onPressed: hasStocks
+                  ? () =>
+                      _bloc.add(const OnlinePickCollectionSubmitRequested())
+                  : null,
+              icon: const Icon(Icons.cloud_upload_outlined),
+              label: const Text('提交采集'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF43A047),
+                foregroundColor: Colors.white,
+                disabledBackgroundColor: const Color(0xFFB0BEC5),
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: PopupMenuButton<_MoreAction>(
+              onSelected: (action) => _handleMoreAction(action, state),
+              itemBuilder: (context) => [
+                PopupMenuItem(
+                  value: _MoreAction.mode,
+                  child: _buildMenuItem(Icons.swap_horiz, '采集模式'),
+                ),
+                PopupMenuItem(
+                  value: _MoreAction.wcs,
+                  child: _buildMenuItem(
+                    Icons.precision_manufacturing_outlined,
+                    '查询指令',
+                  ),
+                ),
+                PopupMenuItem(
+                  value: _MoreAction.exception,
+                  child: _buildMenuItem(Icons.error_outline, '异常补录'),
+                ),
+                const PopupMenuDivider(),
+                PopupMenuItem(
+                  value: _MoreAction.emptyOut,
+                  child: _buildMenuItem(Icons.outbox_outlined, '空盘出库'),
+                ),
+                PopupMenuItem(
+                  value: _MoreAction.emptyIn,
+                  enabled: false,
+                  child: _buildMenuItem(Icons.move_to_inbox_outlined, '空盘入库'),
+                ),
+                PopupMenuItem(
+                  value: _MoreAction.singleTray,
+                  enabled: false,
+                  child: _buildMenuItem(Icons.one_k_plus_outlined, '单个托盘'),
+                ),
+                PopupMenuItem(
+                  value: _MoreAction.reset,
+                  child: _buildMenuItem(Icons.restart_alt, '回库'),
+                ),
+                const PopupMenuDivider(),
+                PopupMenuItem(
+                  value: _MoreAction.allTray,
+                  child: _buildMenuItem(Icons.inventory_2_outlined, '全部托盘'),
+                ),
+              ],
+              position: PopupMenuPosition.over,
+              offset: const Offset(0, -4),
+              child: Container(
+                height: 44,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: const Color(0xFFB0BEC5)),
+                  color: Colors.white,
+                ),
+                alignment: Alignment.center,
+                child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.more_horiz, color: Color(0xFF607D8B)),
+                    SizedBox(width: 6),
+                    Text(
+                      '更多',
+                      style: TextStyle(
+                        color: Color(0xFF607D8B),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openCollectionResult() async {
+    final stocks = _bloc.state.collectedStocks;
+    final result = await Modular.to.pushNamed<List<OnlinePickCollectionStock>>(
+      '/aswh-down/collect/result',
+      arguments: {
+        'stocks': stocks,
+      },
+    );
+    if (result != null && result.isNotEmpty) {
+      _bloc.add(OnlinePickCollectionResultRemoved(result));
+    }
+    _bloc.add(
+      const OnlinePickCollectionDetailsRefreshRequested(
+        successMessage: '任务明细已刷新',
+      ),
+    );
+  }
+
+  List<int> _selectedIndicesFor(
+    List<OnlinePickTaskItem> items,
+    List<int> selectedIds,
+  ) {
+    if (selectedIds.isEmpty) {
+      return const [];
+    }
+    final idToIndex = <int, int>{};
+    for (var i = 0; i < items.length; i++) {
+      idToIndex[items[i].outTaskItemId] = i;
+    }
+    return selectedIds
+        .where(idToIndex.containsKey)
+        .map((id) => idToIndex[id]!)
+        .toList();
+  }
+}
+
+enum _MoreAction {
+  mode,
+  wcs,
+  exception,
+  emptyOut,
+  emptyIn,
+  singleTray,
+  reset,
+  allTray,
+}

--- a/lib/modules/aswh_down/collection_task/online_pick_collection_result_page.dart
+++ b/lib/modules/aswh_down/collection_task/online_pick_collection_result_page.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/common_widgets/common_grid/common_data_grid.dart';
+import 'package:wms_app/common_widgets/loading_dialog_manager.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/config/online_pick_collection_grid_config.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+
+class OnlinePickCollectionResultPage extends StatefulWidget {
+  const OnlinePickCollectionResultPage({
+    super.key,
+    required this.initialStocks,
+  });
+
+  final List<OnlinePickCollectionStock> initialStocks;
+
+  @override
+  State<OnlinePickCollectionResultPage> createState() =>
+      _OnlinePickCollectionResultPageState();
+}
+
+class _OnlinePickCollectionResultPageState
+    extends State<OnlinePickCollectionResultPage> {
+  late List<OnlinePickCollectionStock> _stocks;
+  List<int> _selectedIndices = const [];
+  final List<OnlinePickCollectionStock> _deletedBuffer = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _stocks = List<OnlinePickCollectionStock>.from(widget.initialStocks);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) return;
+        _finishWithPayload();
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: const Color(0xFF1976D2),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
+            onPressed: _finishWithPayload,
+          ),
+          title: const Text(
+            '采集结果',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          centerTitle: true,
+        ),
+        backgroundColor: const Color(0xFFF6F6F6),
+        body: Column(
+          children: [
+            Expanded(
+              child: CommonDataGrid<OnlinePickCollectionStock>(
+                columns: OnlinePickCollectionGridConfig.collectedColumns(),
+                datas: _stocks,
+                allowPager: false,
+                allowSelect: true,
+                currentPage: 1,
+                totalPages: 1,
+                onLoadData: (_) async {},
+                selectedRows: _selectedIndices,
+                onSelectionChanged: (indices) {
+                  setState(() {
+                    _selectedIndices = indices;
+                  });
+                },
+              ),
+            ),
+            _buildBottomBar(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBottomBar() {
+    final total = _stocks.length;
+    final selected = _selectedIndices.length;
+    if (total == 0) {
+      return Container(
+        height: 60,
+        color: Colors.white,
+        alignment: Alignment.center,
+        child: const Text('暂无采集记录'),
+      );
+    }
+
+    return Container(
+      height: 60,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black12,
+            offset: Offset(0, -1),
+            blurRadius: 4,
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          Text('已选 $selected / $total'),
+          const Spacer(),
+          TextButton(
+            onPressed: selected == total
+                ? () => setState(() => _selectedIndices = const [])
+                : () => setState(
+                      () => _selectedIndices =
+                          List<int>.generate(total, (index) => index),
+                    ),
+            child: Text(selected == total ? '取消全选' : '全选'),
+          ),
+          const SizedBox(width: 12),
+          ElevatedButton.icon(
+            onPressed: selected == 0 ? null : () => _confirmDelete(context),
+            icon: const Icon(Icons.delete_outline),
+            label: const Text('删除'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFD32F2F),
+              foregroundColor: Colors.white,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmDelete(BuildContext context) {
+    if (_selectedIndices.isEmpty) {
+      LoadingDialogManager.instance
+          .showErrorDialog(context, '请选择需要删除的记录');
+      return;
+    }
+
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('删除采集记录'),
+        content: Text('确定要删除选中的 ${_selectedIndices.length} 条记录吗？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('取消'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              _performDelete();
+            },
+            child: const Text('确认'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _performDelete() {
+    final toDelete = _selectedIndices
+        .where((index) => index >= 0 && index < _stocks.length)
+        .map((index) => _stocks[index])
+        .toList();
+    if (toDelete.isEmpty) {
+      LoadingDialogManager.instance
+          .showErrorDialog(context, '请选择有效的记录');
+      return;
+    }
+
+    setState(() {
+      _stocks = _stocks
+          .asMap()
+          .entries
+          .where((entry) => !_selectedIndices.contains(entry.key))
+          .map((entry) => entry.value)
+          .toList();
+      _selectedIndices = const [];
+    });
+
+    _deletedBuffer.addAll(toDelete);
+
+    LoadingDialogManager.instance.showSnackSuccessMsg(
+      context,
+      '已删除 ${toDelete.length} 条记录',
+    );
+  }
+
+  void _finishWithPayload() {
+    Navigator.of(context).pop(_deletedBuffer);
+  }
+}

--- a/lib/modules/aswh_down/collection_task/widgets/online_pick_collection_info_card.dart
+++ b/lib/modules/aswh_down/collection_task/widgets/online_pick_collection_info_card.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+
+class OnlinePickCollectionInfoCard extends StatelessWidget {
+  const OnlinePickCollectionInfoCard({
+    super.key,
+    required this.state,
+  });
+
+  final OnlinePickCollectionState state;
+
+  Color _stepColor(OnlinePickCollectionStep step) {
+    return state.step == step ? const Color(0xFF1976D2) : const Color(0xFF90A4AE);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final task = state.task;
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Wrap(
+              spacing: 16,
+              runSpacing: 8,
+              children: [
+                _buildChip('任务号', task.outTaskNo),
+                _buildChip('库房', task.storeRoomNo ?? '-'),
+                _buildChip('工位', task.workStation ?? '-'),
+                _buildChip('凭证号', task.taskComment ?? '-'),
+                _buildChip('采集模式', _modeLabel(state.mode)),
+                _buildChip('提交接口', state.submitChannel.label),
+                _buildChip('拣选口', state.selectedLocation?.label ?? '-'),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                _buildStepBadge('库位', state.location.isEmpty ? '待扫描' : state.location,
+                    color: _stepColor(OnlinePickCollectionStep.location)),
+                _buildStepBadge('托盘', state.trayNo.isEmpty ? '待扫描' : state.trayNo,
+                    color: _stepColor(OnlinePickCollectionStep.tray)),
+                _buildStepBadge(
+                  '物料',
+                  state.currentItem?.materialCode ??
+                      state.barcodeContent?.materialCode ??
+                      '待扫描',
+                  color: _stepColor(OnlinePickCollectionStep.material),
+                ),
+                _buildStepBadge(
+                  '数量',
+                  state.pendingQuantity?.toString() ?? '待录入',
+                  color: _stepColor(OnlinePickCollectionStep.quantity),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChip(String label, String value) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: const Color(0xFFE3F2FD),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            '$label：',
+            style: const TextStyle(
+              fontSize: 12,
+              color: Color(0xFF1976D2),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          Text(
+            value.isEmpty ? '-' : value,
+            style: const TextStyle(
+              fontSize: 12,
+              color: Color(0xFF0D47A1),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStepBadge(String label, String value, {required Color color}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: color.withOpacity(0.4)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              color: color,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value.isEmpty ? '-' : value,
+            style: const TextStyle(
+              fontSize: 14,
+              color: Color(0xFF263238),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _modeLabel(OnlinePickCollectionModeType mode) {
+    switch (mode) {
+      case OnlinePickCollectionModeType.outbound:
+        return '正常采集';
+      case OnlinePickCollectionModeType.inventory:
+        return '库存核对';
+      case OnlinePickCollectionModeType.exception:
+        return '异常补录';
+    }
+  }
+}

--- a/lib/modules/aswh_down/models/online_pick_collection_models.dart
+++ b/lib/modules/aswh_down/models/online_pick_collection_models.dart
@@ -134,6 +134,52 @@ class OnlinePickTrayConfirm with _$OnlinePickTrayConfirm {
       _$OnlinePickTrayConfirmFromJson(json);
 }
 
+/// 异常补录提交信息。
+class OnlinePickExceptionSubmission {
+  const OnlinePickExceptionSubmission({
+    required this.materialCode,
+    required this.quantity,
+    this.materialName = '',
+    this.unit = '',
+    this.storeSite = '',
+    this.batchNo = '',
+    this.serialNumber = '',
+    this.exceptionType = '',
+    this.description = '',
+    this.trayNo = '',
+  });
+
+  /// 物料编码。
+  final String materialCode;
+
+  /// 物料名称。
+  final String materialName;
+
+  /// 异常数量。
+  final num quantity;
+
+  /// 计量单位。
+  final String unit;
+
+  /// 库位编码。
+  final String storeSite;
+
+  /// 批次号。
+  final String batchNo;
+
+  /// 序列号。
+  final String serialNumber;
+
+  /// 异常类型编码。
+  final String exceptionType;
+
+  /// 异常描述。
+  final String description;
+
+  /// 托盘号。
+  final String trayNo;
+}
+
 /// 采集缓存快照，用于 Hive 存储与恢复。
 @freezed
 @HiveType(typeId: 42)

--- a/lib/modules/aswh_down/services/aswh_down_collection_service.dart
+++ b/lib/modules/aswh_down/services/aswh_down_collection_service.dart
@@ -55,6 +55,51 @@ class AswhDownCollectionService {
     );
   }
 
+  /// 获取拣选出/入口配置列表（对应 `getInOutLocation`）。
+  Future<List<OnlinePickLocationOption>> fetchInOutLocations({
+    String locationType = '1',
+  }) async {
+    final response = await _dio.get<Map<String, dynamic>>(
+      '/system/terminal/getInOutLocation',
+      queryParameters: {
+        'locationType': locationType,
+      },
+    );
+
+    return ApiResponseHandler.handleResponse(
+      response: response,
+      dataExtractor: (data) {
+        if (data is! List) {
+          throw Exception('拣选口数据格式异常');
+        }
+
+        return data
+            .map((item) {
+              if (item is Map<String, dynamic>) {
+                final label =
+                    (item['label'] ?? item['text'] ?? item['value'] ?? '')
+                        .toString();
+                final value =
+                    (item['value'] ?? item['code'] ?? item['label'] ?? label)
+                        .toString();
+                if (label.isEmpty && value.isEmpty) {
+                  return null;
+                }
+                return OnlinePickLocationOption(label: label, value: value);
+              }
+
+              final text = item?.toString() ?? '';
+              if (text.isEmpty) {
+                return null;
+              }
+              return OnlinePickLocationOption(label: text, value: text);
+            })
+            .whereType<OnlinePickLocationOption>()
+            .toList();
+      },
+    );
+  }
+
   /// 获取物料控制模式（对应 `GetMatControl`）。
   Future<String> getMatControl(String materialCode) async {
     final response = await _dio.get<Map<String, dynamic>>(
@@ -69,26 +114,35 @@ class AswhDownCollectionService {
   }
 
   /// 根据库位查询库存（对应 `getRepertoryByStoresiteNo`）。
-  Future<Map<String, dynamic>> getRepertoryByStoreSite({
+  Future<List<Map<String, dynamic>>> getRepertoryByStoreSite({
     required String storeSiteNo,
     required String materialCode,
+    String? erpStoreroom,
+    String? batchNo,
+    String? serialNumber,
   }) async {
     final response = await _dio.get<Map<String, dynamic>>(
       '/system/terminal/getRepertoryByStoresiteNo',
       queryParameters: {
         'storesiteno': storeSiteNo,
         'matcode': materialCode,
+        if (erpStoreroom != null && erpStoreroom.isNotEmpty)
+          'erpStoreroom': erpStoreroom,
+        if (batchNo != null && batchNo.isNotEmpty) 'batchno': batchNo,
+        if (serialNumber != null && serialNumber.isNotEmpty) 'sn': serialNumber,
       },
     );
 
     return ApiResponseHandler.handleResponse(
       response: response,
-      dataExtractor: (data) => data as Map<String, dynamic>,
+      dataExtractor: (data) => (data as List<dynamic>)
+          .map((item) => item as Map<String, dynamic>)
+          .toList(),
     );
   }
 
   /// 根据库位查询库存（对应 `getMtlRepertoryByStoresiteNoSn`）。
-  Future<Map<String, dynamic>> getRepertoryByStoreSiteSn({
+  Future<List<Map<String, dynamic>>> getRepertoryByStoreSiteSn({
     required String storeSiteNo,
     required String materialCode,
     String? erpStoreroom,
@@ -108,12 +162,14 @@ class AswhDownCollectionService {
 
     return ApiResponseHandler.handleResponse(
       response: response,
-      dataExtractor: (data) => data as Map<String, dynamic>,
+      dataExtractor: (data) => (data as List<dynamic>)
+          .map((item) => item as Map<String, dynamic>)
+          .toList(),
     );
   }
 
   /// 根据库位查询库存（ERP 子库校验，`getRepertoryByStoresiteNoErp`）。
-  Future<Map<String, dynamic>> getRepertoryByStoreSiteErp({
+  Future<List<Map<String, dynamic>>> getRepertoryByStoreSiteErp({
     required String storeSiteNo,
     required String materialCode,
   }) async {
@@ -127,7 +183,9 @@ class AswhDownCollectionService {
 
     return ApiResponseHandler.handleResponse(
       response: response,
-      dataExtractor: (data) => data as Map<String, dynamic>,
+      dataExtractor: (data) => (data as List<dynamic>)
+          .map((item) => item as Map<String, dynamic>)
+          .toList(),
     );
   }
 

--- a/test/modules/aswh_down/collection_task/online_pick_collection_bloc_exception_actions_test.dart
+++ b/test/modules/aswh_down/collection_task/online_pick_collection_bloc_exception_actions_test.dart
@@ -1,0 +1,260 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:wms_app/models/page_status.dart';
+import 'package:wms_app/models/user_info_model.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_bloc.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_event.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_models.dart';
+import 'package:wms_app/modules/aswh_down/services/aswh_down_collection_service.dart';
+import 'package:wms_app/modules/aswh_down/services/aswh_down_task_service.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+class _RecordingCollectionService extends AswhDownCollectionService {
+  _RecordingCollectionService() : super(Dio());
+
+  List<Map<String, dynamic>>? exceptionInfos;
+  Map<String, String>? emptyTrayCall;
+  Map<String, String>? resetCall;
+
+  @override
+  Future<Map<String, dynamic>> commitExceptionShelves({
+    required List<Map<String, dynamic>> exceptionInfos,
+  }) async {
+    this.exceptionInfos = exceptionInfos;
+    return {'code': '200'};
+  }
+
+  @override
+  Future<Map<String, dynamic>> commitEmptyTrayWmsToWcs({
+    required String taskId,
+    required String taskNo,
+    required String trayNo,
+    required String startAddr,
+    required String endAddr,
+    String singleFlag = 'N',
+  }) async {
+    emptyTrayCall = {
+      'taskId': taskId,
+      'taskNo': taskNo,
+      'trayNo': trayNo,
+      'startAddr': startAddr,
+      'endAddr': endAddr,
+      'singleFlag': singleFlag,
+    };
+    return {'code': '200'};
+  }
+
+  @override
+  Future<Map<String, dynamic>> commitResetWmsToWcs({
+    required String taskId,
+    required String taskNo,
+    required String trayNo,
+    required String startAddr,
+    required String endAddr,
+    bool isInventory = false,
+  }) async {
+    resetCall = {
+      'taskId': taskId,
+      'taskNo': taskNo,
+      'trayNo': trayNo,
+      'startAddr': startAddr,
+      'endAddr': endAddr,
+      'isInventory': isInventory.toString(),
+    };
+    return {'code': '200'};
+  }
+}
+
+class _MockTaskService extends Mock implements AswhDownTaskService {}
+
+class _MockUserManager extends Mock implements UserManager {}
+
+class _TestableBloc extends OnlinePickCollectionBloc {
+  _TestableBloc({
+    required OnlinePickTask task,
+    required AswhDownTaskService taskService,
+    required AswhDownCollectionService collectionService,
+    required UserManager userManager,
+  }) : super(
+          task: task,
+          taskService: taskService,
+          collectionService: collectionService,
+          userManager: userManager,
+        );
+
+  void seed(OnlinePickCollectionState seededState) {
+    emit(seededState);
+  }
+}
+
+Future<void> _pumpBloc() async {
+  await Future<void>.delayed(Duration.zero);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const task = OnlinePickTask(
+    outTaskId: 99,
+    outTaskNo: 'TASK-99',
+    storeRoomNo: 'ROOM-1',
+    taskComment: 'COMMENT-1',
+  );
+
+  final baseItem = OnlinePickTaskItem(
+    outTaskItemId: 1,
+    outTaskId: task.outTaskId,
+    outTaskNo: task.outTaskNo,
+    materialCode: 'MAT-001',
+    materialName: '物料A',
+    storeSiteNo: 'LOC-01',
+    palletNo: 'TP-01',
+    taskQty: 5,
+  );
+
+  late _RecordingCollectionService collectionService;
+  late _MockTaskService taskService;
+  late _MockUserManager userManager;
+  late _TestableBloc bloc;
+
+  setUp(() {
+    collectionService = _RecordingCollectionService();
+    taskService = _MockTaskService();
+    userManager = _MockUserManager();
+    when(() => userManager.userInfo).thenReturn(
+      const UserInfoModel(
+        userId: 1,
+        deptId: 1,
+        userName: 'tester',
+        nickName: 'tester',
+        sex: '1',
+        status: '0',
+        delFlag: '0',
+      ),
+    );
+
+    bloc = _TestableBloc(
+      task: task,
+      taskService: taskService,
+      collectionService: collectionService,
+      userManager: userManager,
+    );
+  });
+
+  tearDown(() async {
+    await bloc.close();
+  });
+
+  test('提交异常补录时会调用异常接口并返回成功状态', () async {
+    bloc.seed(
+      OnlinePickCollectionState.initial(task).copyWith(
+        location: 'LOC-01',
+        trayNo: 'TP-01',
+        currentItem: baseItem,
+      ),
+    );
+
+    bloc.add(
+      OnlinePickCollectionExceptionSubmitted(
+        const OnlinePickExceptionSubmission(
+          materialCode: 'MAT-001',
+          materialName: '物料A',
+          quantity: 2,
+          storeSite: 'LOC-01',
+          exceptionType: '006',
+          description: '测试异常',
+        ),
+      ),
+    );
+
+    await _pumpBloc();
+
+    expect(bloc.state.status.type, CollectionStatusType.success);
+    expect(collectionService.exceptionInfos, isNotNull);
+    final payload = collectionService.exceptionInfos!.single;
+    expect(payload['matCode'], 'MAT-001');
+    expect(payload['excepttype'], '006');
+    expect(payload['collectQty'], 2);
+  });
+
+  test('物料编码为空时异常补录会提示错误', () async {
+    bloc.seed(OnlinePickCollectionState.initial(task));
+
+    bloc.add(
+      OnlinePickCollectionExceptionSubmitted(
+        const OnlinePickExceptionSubmission(
+          materialCode: '',
+          quantity: 1,
+          storeSite: 'LOC-01',
+          exceptionType: '006',
+        ),
+      ),
+    );
+
+    await _pumpBloc();
+
+    expect(bloc.state.status.type, CollectionStatusType.error);
+    expect(collectionService.exceptionInfos, isNull);
+  });
+
+  test('空盘出库会写入WCS指令', () async {
+    bloc.seed(
+      OnlinePickCollectionState.initial(task).copyWith(
+        trayNo: 'TP-02',
+        selectedLocation: const OnlinePickLocationOption(
+          label: '拣选口A',
+          value: 'OUT-01',
+        ),
+      ),
+    );
+
+    bloc.add(const OnlinePickCollectionEmptyTrayOutboundRequested());
+    await _pumpBloc();
+
+    expect(bloc.state.status.type, CollectionStatusType.success);
+    expect(collectionService.emptyTrayCall, isNotNull);
+    expect(collectionService.emptyTrayCall!['endAddr'], '1111');
+  });
+
+  test('托盘回库会写入重置指令', () async {
+    bloc.seed(
+      OnlinePickCollectionState.initial(task).copyWith(
+        trayNo: 'TP-01',
+        selectedLocation: const OnlinePickLocationOption(
+          label: '拣选口A',
+          value: 'OUT-01',
+        ),
+        detailList: [baseItem],
+      ),
+    );
+
+    bloc.add(const OnlinePickCollectionTrayReturnRequested());
+    await _pumpBloc();
+
+    expect(bloc.state.status.type, CollectionStatusType.success);
+    expect(collectionService.resetCall, isNotNull);
+    expect(collectionService.resetCall!['endAddr'], 'LOC-01');
+  });
+
+  test('找不到托盘原始库位时回库会提示错误', () async {
+    bloc.seed(
+      OnlinePickCollectionState.initial(task).copyWith(
+        trayNo: 'UNKNOWN',
+        selectedLocation: const OnlinePickLocationOption(
+          label: '拣选口A',
+          value: 'OUT-01',
+        ),
+      ),
+    );
+
+    bloc.add(const OnlinePickCollectionTrayReturnRequested());
+    await _pumpBloc();
+
+    expect(bloc.state.status.type, CollectionStatusType.error);
+    expect(collectionService.resetCall, isNull);
+  });
+}

--- a/test/modules/aswh_down/collection_task/online_pick_collection_bloc_inventory_test.dart
+++ b/test/modules/aswh_down/collection_task/online_pick_collection_bloc_inventory_test.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:wms_app/models/page_status.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_bloc.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_event.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_models.dart';
+import 'package:wms_app/modules/aswh_down/services/aswh_down_collection_service.dart';
+import 'package:wms_app/modules/aswh_down/services/aswh_down_task_service.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+class _MockCollectionService extends Mock implements AswhDownCollectionService {}
+
+class _MockTaskService extends Mock implements AswhDownTaskService {}
+
+class _MockUserManager extends Mock implements UserManager {}
+
+class _TestableOnlinePickCollectionBloc extends OnlinePickCollectionBloc {
+  _TestableOnlinePickCollectionBloc({
+    required OnlinePickTask task,
+    required AswhDownTaskService taskService,
+    required AswhDownCollectionService collectionService,
+    required UserManager userManager,
+  }) : super(
+          task: task,
+          taskService: taskService,
+          collectionService: collectionService,
+          userManager: userManager,
+        );
+
+  void seed(OnlinePickCollectionState seededState) {
+    emit(seededState);
+  }
+}
+
+Future<void> _pumpBloc() async {
+  await Future<void>.delayed(Duration.zero);
+}
+
+void main() {
+  final task = const OnlinePickTask(
+    outTaskId: 1,
+    outTaskNo: 'TASK-001',
+    storeRoomNo: 'RM-1',
+    taskComment: 'COMMENT-1',
+  );
+
+  final baseItem = OnlinePickTaskItem(
+    outTaskItemId: 10,
+    outTaskId: task.outTaskId,
+    outTaskNo: task.outTaskNo,
+    materialCode: 'MAT-001',
+    storeSiteNo: 'LOC-01',
+    storeRoomNo: 'RM-1',
+    subInventoryCode: 'ERP-1',
+    taskQty: 10,
+    collectedQty: 0,
+    batchNo: 'B01',
+  );
+
+  final barcode = OnlinePickBarcodeContent(
+    materialCode: 'MAT-001',
+    batchNo: 'B01',
+    quantity: 2,
+  );
+
+  group('inventory validation', () {
+    late _MockCollectionService collectionService;
+    late _TestableOnlinePickCollectionBloc bloc;
+
+    setUp(() {
+      collectionService = _MockCollectionService();
+      bloc = _TestableOnlinePickCollectionBloc(
+        task: task,
+        taskService: _MockTaskService(),
+        collectionService: collectionService,
+        userManager: _MockUserManager(),
+      );
+    });
+
+    tearDown(() async {
+      await bloc.close();
+    });
+
+    test('emits error when available inventory is insufficient', () async {
+      when(
+        () => collectionService.getRepertoryByStoreSite(
+          storeSiteNo: 'LOC-01',
+          materialCode: 'MAT-001',
+          erpStoreroom: any(named: 'erpStoreroom'),
+          batchNo: any(named: 'batchNo'),
+          serialNumber: any(named: 'serialNumber'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          {
+            'batchno': 'B01',
+            'repqty': 5,
+            'erpStoreroom': 'ERP-1',
+          },
+        ],
+      );
+
+      final seeded = OnlinePickCollectionState.initial(task).copyWith(
+        location: 'LOC-01',
+        trayNo: 'TP-01',
+        currentItem: baseItem,
+        barcodeContent: barcode,
+        expectedErpStore: 'ERP-1',
+        inventoryQtyMap: {'LOC-01|MAT-001|B01': 4},
+      );
+
+      bloc.seed(seeded);
+
+      bloc.add(const OnlinePickCollectionQuantitySubmitted(2));
+      await _pumpBloc();
+
+      final state = bloc.state;
+      expect(state.status.type, equals(CollectionStatusType.error));
+      expect(state.collectedStocks, isEmpty);
+      expect(state.pendingQuantity, isNull);
+    });
+
+    test('records stock when inventory validation passes', () async {
+      when(
+        () => collectionService.getRepertoryByStoreSite(
+          storeSiteNo: 'LOC-01',
+          materialCode: 'MAT-001',
+          erpStoreroom: any(named: 'erpStoreroom'),
+          batchNo: any(named: 'batchNo'),
+          serialNumber: any(named: 'serialNumber'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          {
+            'batchno': 'B01',
+            'repqty': 8,
+            'erpStoreroom': 'ERP-1',
+          },
+        ],
+      );
+
+      final existingStock = OnlinePickCollectionStock(
+        stockId: 'S-1',
+        materialCode: 'MAT-001',
+        batchNo: 'B01',
+        collectQty: 3,
+        outTaskItemId: baseItem.outTaskItemId.toString(),
+        taskId: baseItem.outTaskId.toString(),
+        storeRoom: baseItem.storeRoomNo,
+        storeSite: 'LOC-01',
+        erpStore: 'ERP-1',
+        trayNo: 'TP-01',
+      );
+
+      final seeded = OnlinePickCollectionState.initial(task).copyWith(
+        location: 'LOC-01',
+        trayNo: 'TP-01',
+        currentItem: baseItem,
+        barcodeContent: barcode,
+        expectedErpStore: 'ERP-1',
+        inventoryQtyMap: {'LOC-01|MAT-001|B01': 3},
+        collectedStocks: [existingStock],
+      );
+
+      bloc.seed(seeded);
+
+      bloc.add(const OnlinePickCollectionQuantitySubmitted(2));
+      await _pumpBloc();
+
+      final state = bloc.state;
+      expect(state.status.type, equals(CollectionStatusType.success));
+      expect(state.collectedStocks, hasLength(2));
+      expect(state.collectedStocks.last.collectQty, equals(2));
+      expect(state.collectedStocks.last.erpStore, equals('ERP-1'));
+      expect(state.inventoryQtyMap['LOC-01|MAT-001|B01'], closeTo(5, 0.0001));
+      expect(state.pendingQuantity, isNull);
+    });
+  });
+}

--- a/test/modules/aswh_down/collection_task/online_pick_collection_bloc_submit_test.dart
+++ b/test/modules/aswh_down/collection_task/online_pick_collection_bloc_submit_test.dart
@@ -1,0 +1,269 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:wms_app/models/user_info_model.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_bloc.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_event.dart';
+import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_item_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_wcs_models.dart';
+import 'package:wms_app/modules/aswh_down/services/aswh_down_collection_service.dart';
+import 'package:wms_app/modules/aswh_down/services/aswh_down_task_service.dart';
+import 'package:wms_app/services/user_manager.dart';
+
+class _StubCollectionService extends AswhDownCollectionService {
+  _StubCollectionService({
+    required this.items,
+    required this.wcsCommands,
+    required this.locations,
+  }) : super(Dio());
+
+  List<OnlinePickTaskItem> items;
+  List<OnlinePickWcsCommand> wcsCommands;
+  List<OnlinePickLocationOption> locations;
+  OnlinePickCollectionQuery? lastQuery;
+  String? lastTaskComment;
+  String? lastTaskId;
+  List<Map<String, dynamic>>? lastDownShelvesInfos;
+  List<Map<String, dynamic>>? lastItemListInfos;
+  OnlinePickSubmissionChannel? lastSubmitChannel;
+  int fetchItemsCount = 0;
+  int fetchWcsCount = 0;
+
+  @override
+  Future<List<OnlinePickTaskItem>> fetchCollectionTaskItems({
+    required OnlinePickCollectionQuery query,
+  }) async {
+    lastQuery = query;
+    fetchItemsCount++;
+    return items;
+  }
+
+  @override
+  Future<List<OnlinePickWcsCommand>> fetchWcsCommands({
+    required String taskComment,
+    required String taskId,
+    String taskType = '03',
+    String queryStr = '',
+  }) async {
+    lastTaskComment = taskComment;
+    lastTaskId = taskId;
+    fetchWcsCount++;
+    return wcsCommands;
+  }
+
+  @override
+  Future<List<OnlinePickLocationOption>> fetchInOutLocations({
+    String locationType = '1',
+  }) async {
+    return locations;
+  }
+
+  Future<Map<String, dynamic>> _recordSubmit(
+    OnlinePickSubmissionChannel channel,
+    List<Map<String, dynamic>> downShelvesInfos,
+    List<Map<String, dynamic>> itemListInfos,
+  ) async {
+    lastSubmitChannel = channel;
+    lastDownShelvesInfos = downShelvesInfos;
+    lastItemListInfos = itemListInfos;
+    return {'code': '0'};
+  }
+
+  @override
+  Future<Map<String, dynamic>> commitAswhDownShelves({
+    required List<Map<String, dynamic>> downShelvesInfos,
+    required List<Map<String, dynamic>> itemListInfos,
+    List<Map<String, dynamic>> inventoryCheckInfos = const [],
+  }) {
+    return _recordSubmit(
+      OnlinePickSubmissionChannel.aswh,
+      downShelvesInfos,
+      itemListInfos,
+    );
+  }
+
+  @override
+  Future<Map<String, dynamic>> commitDownShelves({
+    required List<Map<String, dynamic>> downShelvesInfos,
+    required List<Map<String, dynamic>> itemListInfos,
+  }) {
+    return _recordSubmit(
+      OnlinePickSubmissionChannel.standard,
+      downShelvesInfos,
+      itemListInfos,
+    );
+  }
+
+  @override
+  Future<Map<String, dynamic>> commitTrayDownShelves({
+    required List<Map<String, dynamic>> downShelvesInfos,
+    required List<Map<String, dynamic>> itemListInfos,
+  }) {
+    return _recordSubmit(
+      OnlinePickSubmissionChannel.tray,
+      downShelvesInfos,
+      itemListInfos,
+    );
+  }
+}
+
+class _MockTaskService extends Mock implements AswhDownTaskService {}
+
+class _MockUserManager extends Mock implements UserManager {}
+
+void main() {
+  late Directory tempDir;
+  late _StubCollectionService collectionService;
+  late OnlinePickCollectionBloc bloc;
+  late _MockTaskService taskService;
+  late _MockUserManager userManager;
+
+  const task = OnlinePickTask(
+    outTaskId: 101,
+    outTaskNo: 'TASK-101',
+    storeRoomNo: 'RM-1',
+    taskComment: 'COMMENT-1',
+  );
+
+  final baseItem = OnlinePickTaskItem(
+    outTaskItemId: 11,
+    outTaskId: task.outTaskId,
+    outTaskNo: task.outTaskNo,
+    materialCode: 'MAT-001',
+    materialName: '物料A',
+    storeSiteNo: 'SITE-1',
+    storeRoomNo: 'RM-1',
+    subInventoryCode: 'ERP-1',
+    taskQty: 5,
+    collectedQty: 0,
+    palletNo: 'PAL-1',
+  );
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+  });
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('aswh_down_submit_test');
+    Hive.init(tempDir.path);
+    if (!Hive.isAdapterRegistered(40)) {
+      Hive.registerAdapter(OnlinePickBarcodeContentAdapter());
+    }
+    if (!Hive.isAdapterRegistered(41)) {
+      Hive.registerAdapter(OnlinePickCollectionStockAdapter());
+    }
+    if (!Hive.isAdapterRegistered(42)) {
+      Hive.registerAdapter(OnlinePickCollectionCacheSnapshotAdapter());
+    }
+
+    collectionService = _StubCollectionService(
+      items: [baseItem],
+      wcsCommands: const [OnlinePickWcsCommand(commandId: 'CMD-1')],
+      locations: const [OnlinePickLocationOption(label: '口1', value: 'LOC-1')],
+    );
+
+    taskService = _MockTaskService();
+    userManager = _MockUserManager();
+    when(() => userManager.userInfo).thenReturn(
+      const UserInfoModel(
+        userId: 7,
+        deptId: 1,
+        userName: 'tester',
+        nickName: 'Tester',
+        sex: 'M',
+        status: '0',
+        delFlag: '0',
+      ),
+    );
+
+    bloc = OnlinePickCollectionBloc(
+      task: task,
+      taskService: taskService,
+      collectionService: collectionService,
+      userManager: userManager,
+      hive: Hive,
+    );
+
+    bloc.add(const OnlinePickCollectionStarted(restoreCache: false));
+    await bloc.stream.firstWhere(
+      (state) => state.status.isSuccess && state.detailList.isNotEmpty,
+    );
+
+    final stock = OnlinePickCollectionStock(
+      stockId: 'STK-1',
+      materialCode: baseItem.materialCode ?? '',
+      batchNo: baseItem.batchNo,
+      serialNumber: baseItem.serialNumber,
+      taskQty: baseItem.taskQty,
+      collectQty: 2,
+      outTaskItemId: baseItem.outTaskItemId.toString(),
+      taskId: baseItem.outTaskId.toString(),
+      storeRoom: baseItem.storeRoomNo,
+      storeSite: baseItem.storeSiteNo,
+      erpStore: baseItem.subInventoryCode,
+      trayNo: 'TRAY-1',
+    );
+
+    bloc.add(OnlinePickCollectionStocksSynced([stock.toJson()]));
+    await bloc.stream.firstWhere(
+      (state) => state.collectedStocks.isNotEmpty,
+    );
+
+    final cacheBox = Hive.box<OnlinePickCollectionCacheSnapshot>(
+      'aswh_down_collect_${task.outTaskId}',
+    );
+    expect(cacheBox.isEmpty, isFalse);
+  });
+
+  tearDown(() async {
+    await bloc.close();
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('submit clears caches and refreshes task detail state', () async {
+    collectionService.items = [
+      baseItem.copyWith(collectedQty: 3),
+    ];
+    collectionService.wcsCommands = const [
+      OnlinePickWcsCommand(commandId: 'CMD-2'),
+    ];
+
+    final successFuture = bloc.stream.firstWhere(
+      (state) =>
+          state.status.isSuccess &&
+          state.status.message == 'ASWH 下架提交成功',
+    );
+
+    bloc.add(const OnlinePickCollectionSubmitRequested());
+    final successState = await successFuture;
+
+    expect(collectionService.lastSubmitChannel,
+        equals(OnlinePickSubmissionChannel.aswh));
+    expect(collectionService.lastDownShelvesInfos, isNotNull);
+    expect(collectionService.lastDownShelvesInfos, isNotEmpty);
+    expect(collectionService.lastItemListInfos, isNotNull);
+    expect(collectionService.lastItemListInfos, isNotEmpty);
+    expect(collectionService.fetchItemsCount, equals(2));
+    expect(collectionService.fetchWcsCount, equals(2));
+
+    expect(successState.collectedStocks, isEmpty);
+    expect(successState.serialMap, isEmpty);
+    expect(successState.materialQtyMap, isEmpty);
+    expect(successState.inventoryQtyMap, isEmpty);
+    expect(successState.detailList.first.collectedQty, equals(3));
+    expect(successState.collectingList, isNotEmpty);
+    expect(successState.wcsCommands.first.commandId, equals('CMD-2'));
+
+    final cacheBox = Hive.box<OnlinePickCollectionCacheSnapshot>(
+      'aswh_down_collect_${task.outTaskId}',
+    );
+    expect(cacheBox.isEmpty, isTrue);
+  });
+}

--- a/test/modules/aswh_down/collection_task/online_pick_collection_bloc_sync_test.dart
+++ b/test/modules/aswh_down/collection_task/online_pick_collection_bloc_sync_test.dart
@@ -7,6 +7,7 @@ import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_colle
 import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_event.dart';
 import 'package:wms_app/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart';
 import 'package:wms_app/modules/aswh_down/models/online_pick_collection_models.dart';
+import 'package:wms_app/modules/aswh_down/models/online_pick_task_models.dart';
 import 'package:wms_app/modules/aswh_down/services/aswh_down_collection_service.dart';
 import 'package:wms_app/modules/aswh_down/services/aswh_down_task_service.dart';
 import 'package:wms_app/services/user_manager.dart';
@@ -22,6 +23,10 @@ void main() {
 
   setUp(() {
     bloc = OnlinePickCollectionBloc(
+      task: const OnlinePickTask(
+        outTaskId: 1,
+        outTaskNo: 'TASK-001',
+      ),
       taskService: _MockTaskService(),
       collectionService: _MockCollectionService(),
       userManager: _MockUserManager(),


### PR DESCRIPTION
## Summary
- add OnlinePickCollection events and logic for exception submission, empty tray outbound, and tray return flows including validation
- expose UI dialogs for abnormal submission and wire bottom menu actions to invoke the new behaviors
- add bloc unit tests that cover exception submission, empty tray outbound, and tray return commands

## Testing
- not run (Flutter CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_6901424bd63483309e698373579325df