### PR TITLE
feat: align online pick inventory flow with legacy behavior

### DIFF
--- a/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart
+++ b/lib/modules/aswh_down/collection_task/bloc/online_pick_collection_state.dart
@@ -29,6 +29,8 @@ class OnlinePickCollectionState extends Equatable {
     this.isScannerFocused = false,
     this.expectedErpStore,
     this.selectedDestination = '',
+    this.isInventoryEntryPending = false,
+    this.pendingInventoryDetail,
   });
 
   final CollectionStatus status;
@@ -51,6 +53,8 @@ class OnlinePickCollectionState extends Equatable {
   final bool isScannerFocused;
   final String? expectedErpStore;
   final String selectedDestination;
+  final bool isInventoryEntryPending;
+  final OnlinePickInventoryCheckDetail? pendingInventoryDetail;
 
   OnlinePickCollectionState copyWith({
     CollectionStatus? status,
@@ -75,6 +79,9 @@ class OnlinePickCollectionState extends Equatable {
     bool? isScannerFocused,
     String? expectedErpStore,
     String? selectedDestination,
+    bool? isInventoryEntryPending,
+    OnlinePickInventoryCheckDetail? pendingInventoryDetail,
+    bool clearPendingInventoryDetail = false,
   }) {
     return OnlinePickCollectionState(
       status: status ?? this.status,
@@ -98,6 +105,11 @@ class OnlinePickCollectionState extends Equatable {
       isScannerFocused: isScannerFocused ?? this.isScannerFocused,
       expectedErpStore: expectedErpStore ?? this.expectedErpStore,
       selectedDestination: selectedDestination ?? this.selectedDestination,
+      isInventoryEntryPending:
+          isInventoryEntryPending ?? this.isInventoryEntryPending,
+      pendingInventoryDetail: clearPendingInventoryDetail
+          ? null
+          : (pendingInventoryDetail ?? this.pendingInventoryDetail),
     );
   }
 
@@ -123,5 +135,7 @@ class OnlinePickCollectionState extends Equatable {
         isScannerFocused,
         expectedErpStore,
         selectedDestination,
+        isInventoryEntryPending,
+        pendingInventoryDetail,
       ];
 }

--- a/lib/modules/aswh_down/collection_task/online_pick_collection_page.dart
+++ b/lib/modules/aswh_down/collection_task/online_pick_collection_page.dart
@@ -54,7 +54,7 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
   void initState() {
     super.initState();
     _scannerController = ScannerController();
-    _tabController = TabController(length: 2, vsync: this);
+    _tabController = TabController(length: 3, vsync: this);
     _bloc = BlocProvider.of<OnlinePickCollectionBloc>(context);
     _bloc.add(OnlinePickCollectionInitialized(widget.task));
   }
@@ -165,6 +165,7 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
                     tabs: const [
                       Tab(text: '任务列表'),
                       Tab(text: '正在采集'),
+                      Tab(text: '库存核对'),
                     ],
                     onTap: (index) =>
                         _bloc.add(OnlinePickCollectionTabChanged(index)),
@@ -176,6 +177,7 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
                     children: [
                       _buildTaskGrid(state.taskItems),
                       _buildCollectingGrid(state.collectingItems),
+                      _buildInventoryGrid(state.inventoryCheckDetails),
                     ],
                   ),
                 ),
@@ -393,6 +395,51 @@ class _OnlinePickCollectionPageState extends State<OnlinePickCollectionPage>
       totalPages: 1,
       onLoadData: (_) async {},
       selectedRows: const [],
+    );
+  }
+
+  Widget _buildInventoryGrid(
+    List<OnlinePickInventoryCheckDetail> details,
+  ) {
+    if (details.isEmpty) {
+      return const Center(child: Text('暂无结余记录'));
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      itemBuilder: (context, index) {
+        final detail = details[index];
+        final subtitleParts = <String>[];
+        if (detail.batchNo?.isNotEmpty ?? false) {
+          subtitleParts.add('批次 ${detail.batchNo}');
+        }
+        if (detail.trayNo?.isNotEmpty ?? false) {
+          subtitleParts.add('托盘 ${detail.trayNo}');
+        }
+        return ListTile(
+          dense: true,
+          title: Text(
+            '库位 ${detail.storeSite} · 物料 ${detail.materialCode}',
+            style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+          ),
+          subtitle: subtitleParts.isEmpty
+              ? null
+              : Text(
+                  subtitleParts.join(' · '),
+                  style: const TextStyle(fontSize: 12, color: Color(0xFF666666)),
+                ),
+          trailing: Text(
+            detail.quantity.toFormatString(),
+            style: const TextStyle(
+              fontSize: 13,
+              color: Color(0xFF1976D2),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        );
+      },
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemCount: details.length,
     );
   }
 

--- a/lib/modules/aswh_down/models/online_pick_collection_models.dart
+++ b/lib/modules/aswh_down/models/online_pick_collection_models.dart
@@ -24,6 +24,7 @@ enum OnlinePickCollectionStep {
   material,
   quantity,
   review,
+  inventory,
 }
 
 /// 扫码解析后的条码信息。
@@ -215,6 +216,11 @@ class OnlinePickCollectionCacheSnapshot
     @HiveField(11) @Default(<Map<String, dynamic>>[])
     List<Map<String, dynamic>> inventoryChecks,
     @HiveField(12) @Default('') String destination,
+    @HiveField(13) @Default(false) bool inventoryPending,
+    @HiveField(14) String? pendingStoreSite,
+    @HiveField(15) String? pendingMaterialCode,
+    @HiveField(16) String? pendingBatchNo,
+    @HiveField(17) String? pendingTrayNo,
   }) = _OnlinePickCollectionCacheSnapshot;
 
   factory OnlinePickCollectionCacheSnapshot.fromJson(

--- a/lib/modules/aswh_down/models/online_pick_collection_models.freezed.dart
+++ b/lib/modules/aswh_down/models/online_pick_collection_models.freezed.dart
@@ -1852,6 +1852,16 @@ mixin _$OnlinePickCollectionCacheSnapshot {
       throw _privateConstructorUsedError;
   @HiveField(12)
   String get destination => throw _privateConstructorUsedError;
+  @HiveField(13)
+  bool get inventoryPending => throw _privateConstructorUsedError;
+  @HiveField(14)
+  String? get pendingStoreSite => throw _privateConstructorUsedError;
+  @HiveField(15)
+  String? get pendingMaterialCode => throw _privateConstructorUsedError;
+  @HiveField(16)
+  String? get pendingBatchNo => throw _privateConstructorUsedError;
+  @HiveField(17)
+  String? get pendingTrayNo => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -1880,7 +1890,12 @@ abstract class $OnlinePickCollectionCacheSnapshotCopyWith<$Res> {
       @HiveField(9) String mode,
       @HiveField(10) String expectedErpStore,
       @HiveField(11) List<Map<String, dynamic>> inventoryChecks,
-      @HiveField(12) String destination});
+      @HiveField(12) String destination,
+      @HiveField(13) bool inventoryPending,
+      @HiveField(14) String? pendingStoreSite,
+      @HiveField(15) String? pendingMaterialCode,
+      @HiveField(16) String? pendingBatchNo,
+      @HiveField(17) String? pendingTrayNo});
 
   $OnlinePickBarcodeContentCopyWith<$Res>? get lastBarcode;
 }
@@ -1912,6 +1927,11 @@ class _$OnlinePickCollectionCacheSnapshotCopyWithImpl<$Res,
     Object? expectedErpStore = null,
     Object? inventoryChecks = null,
     Object? destination = null,
+    Object? inventoryPending = null,
+    Object? pendingStoreSite = freezed,
+    Object? pendingMaterialCode = freezed,
+    Object? pendingBatchNo = freezed,
+    Object? pendingTrayNo = freezed,
   }) {
     return _then(_value.copyWith(
       stocks: null == stocks
@@ -1966,6 +1986,26 @@ class _$OnlinePickCollectionCacheSnapshotCopyWithImpl<$Res,
           ? _value.destination
           : destination // ignore: cast_nullable_to_non_nullable
               as String,
+      inventoryPending: null == inventoryPending
+          ? _value.inventoryPending
+          : inventoryPending // ignore: cast_nullable_to_non_nullable
+              as bool,
+      pendingStoreSite: freezed == pendingStoreSite
+          ? _value.pendingStoreSite
+          : pendingStoreSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pendingMaterialCode: freezed == pendingMaterialCode
+          ? _value.pendingMaterialCode
+          : pendingMaterialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pendingBatchNo: freezed == pendingBatchNo
+          ? _value.pendingBatchNo
+          : pendingBatchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pendingTrayNo: freezed == pendingTrayNo
+          ? _value.pendingTrayNo
+          : pendingTrayNo // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 
@@ -2005,7 +2045,12 @@ abstract class _$$OnlinePickCollectionCacheSnapshotImplCopyWith<$Res>
       @HiveField(9) String mode,
       @HiveField(10) String expectedErpStore,
       @HiveField(11) List<Map<String, dynamic>> inventoryChecks,
-      @HiveField(12) String destination});
+      @HiveField(12) String destination,
+      @HiveField(13) bool inventoryPending,
+      @HiveField(14) String? pendingStoreSite,
+      @HiveField(15) String? pendingMaterialCode,
+      @HiveField(16) String? pendingBatchNo,
+      @HiveField(17) String? pendingTrayNo});
 
   @override
   $OnlinePickBarcodeContentCopyWith<$Res>? get lastBarcode;
@@ -2037,6 +2082,11 @@ class __$$OnlinePickCollectionCacheSnapshotImplCopyWithImpl<$Res>
     Object? expectedErpStore = null,
     Object? inventoryChecks = null,
     Object? destination = null,
+    Object? inventoryPending = null,
+    Object? pendingStoreSite = freezed,
+    Object? pendingMaterialCode = freezed,
+    Object? pendingBatchNo = freezed,
+    Object? pendingTrayNo = freezed,
   }) {
     return _then(_$OnlinePickCollectionCacheSnapshotImpl(
       stocks: null == stocks
@@ -2091,6 +2141,26 @@ class __$$OnlinePickCollectionCacheSnapshotImplCopyWithImpl<$Res>
           ? _value.destination
           : destination // ignore: cast_nullable_to_non_nullable
               as String,
+      inventoryPending: null == inventoryPending
+          ? _value.inventoryPending
+          : inventoryPending // ignore: cast_nullable_to_non_nullable
+              as bool,
+      pendingStoreSite: freezed == pendingStoreSite
+          ? _value.pendingStoreSite
+          : pendingStoreSite // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pendingMaterialCode: freezed == pendingMaterialCode
+          ? _value.pendingMaterialCode
+          : pendingMaterialCode // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pendingBatchNo: freezed == pendingBatchNo
+          ? _value.pendingBatchNo
+          : pendingBatchNo // ignore: cast_nullable_to_non_nullable
+              as String?,
+      pendingTrayNo: freezed == pendingTrayNo
+          ? _value.pendingTrayNo
+          : pendingTrayNo // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -2117,7 +2187,12 @@ class _$OnlinePickCollectionCacheSnapshotImpl
       @HiveField(11)
       final List<Map<String, dynamic>> inventoryChecks =
           const <Map<String, dynamic>>[],
-      @HiveField(12) this.destination = ''})
+      @HiveField(12) this.destination = '',
+      @HiveField(13) this.inventoryPending = false,
+      @HiveField(14) this.pendingStoreSite,
+      @HiveField(15) this.pendingMaterialCode,
+      @HiveField(16) this.pendingBatchNo,
+      @HiveField(17) this.pendingTrayNo})
       : _stocks = stocks,
         _dicSeq = dicSeq,
         _dicMtlQty = dicMtlQty,
@@ -2210,10 +2285,26 @@ class _$OnlinePickCollectionCacheSnapshotImpl
   @JsonKey()
   @HiveField(12)
   final String destination;
+  @override
+  @JsonKey()
+  @HiveField(13)
+  final bool inventoryPending;
+  @override
+  @HiveField(14)
+  final String? pendingStoreSite;
+  @override
+  @HiveField(15)
+  final String? pendingMaterialCode;
+  @override
+  @HiveField(16)
+  final String? pendingBatchNo;
+  @override
+  @HiveField(17)
+  final String? pendingTrayNo;
 
   @override
   String toString() {
-    return 'OnlinePickCollectionCacheSnapshot(stocks: $stocks, dicSeq: $dicSeq, dicMtlQty: $dicMtlQty, dicInvMtlQty: $dicInvMtlQty, lastBarcode: $lastBarcode, location: $location, trayNo: $trayNo, userId: $userId, pendingQuantity: $pendingQuantity, mode: $mode, expectedErpStore: $expectedErpStore, inventoryChecks: $inventoryChecks, destination: $destination)';
+    return 'OnlinePickCollectionCacheSnapshot(stocks: $stocks, dicSeq: $dicSeq, dicMtlQty: $dicMtlQty, dicInvMtlQty: $dicInvMtlQty, lastBarcode: $lastBarcode, location: $location, trayNo: $trayNo, userId: $userId, pendingQuantity: $pendingQuantity, mode: $mode, expectedErpStore: $expectedErpStore, inventoryChecks: $inventoryChecks, destination: $destination, inventoryPending: $inventoryPending, pendingStoreSite: $pendingStoreSite, pendingMaterialCode: $pendingMaterialCode, pendingBatchNo: $pendingBatchNo, pendingTrayNo: $pendingTrayNo)';
   }
 
   @override
@@ -2241,7 +2332,17 @@ class _$OnlinePickCollectionCacheSnapshotImpl
             const DeepCollectionEquality()
                 .equals(other._inventoryChecks, _inventoryChecks) &&
             (identical(other.destination, destination) ||
-                other.destination == destination));
+                other.destination == destination) &&
+            (identical(other.inventoryPending, inventoryPending) ||
+                other.inventoryPending == inventoryPending) &&
+            (identical(other.pendingStoreSite, pendingStoreSite) ||
+                other.pendingStoreSite == pendingStoreSite) &&
+            (identical(other.pendingMaterialCode, pendingMaterialCode) ||
+                other.pendingMaterialCode == pendingMaterialCode) &&
+            (identical(other.pendingBatchNo, pendingBatchNo) ||
+                other.pendingBatchNo == pendingBatchNo) &&
+            (identical(other.pendingTrayNo, pendingTrayNo) ||
+                other.pendingTrayNo == pendingTrayNo));
   }
 
   @JsonKey(ignore: true)
@@ -2260,7 +2361,12 @@ class _$OnlinePickCollectionCacheSnapshotImpl
           mode,
           expectedErpStore,
           const DeepCollectionEquality().hash(_inventoryChecks),
-          destination);
+          destination,
+          inventoryPending,
+          pendingStoreSite,
+          pendingMaterialCode,
+          pendingBatchNo,
+          pendingTrayNo);
 
   @JsonKey(ignore: true)
   @override
@@ -2293,7 +2399,12 @@ abstract class _OnlinePickCollectionCacheSnapshot
           @HiveField(9) final String mode,
           @HiveField(10) final String expectedErpStore,
           @HiveField(11) final List<Map<String, dynamic>> inventoryChecks,
-          @HiveField(12) final String destination}) =
+          @HiveField(12) final String destination,
+          @HiveField(13) final bool inventoryPending,
+          @HiveField(14) final String? pendingStoreSite,
+          @HiveField(15) final String? pendingMaterialCode,
+          @HiveField(16) final String? pendingBatchNo,
+          @HiveField(17) final String? pendingTrayNo}) =
       _$OnlinePickCollectionCacheSnapshotImpl;
 
   factory _OnlinePickCollectionCacheSnapshot.fromJson(
@@ -2339,6 +2450,21 @@ abstract class _OnlinePickCollectionCacheSnapshot
   @override
   @HiveField(12)
   String get destination;
+  @override
+  @HiveField(13)
+  bool get inventoryPending;
+  @override
+  @HiveField(14)
+  String? get pendingStoreSite;
+  @override
+  @HiveField(15)
+  String? get pendingMaterialCode;
+  @override
+  @HiveField(16)
+  String? get pendingBatchNo;
+  @override
+  @HiveField(17)
+  String? get pendingTrayNo;
   @override
   @JsonKey(ignore: true)
   _$$OnlinePickCollectionCacheSnapshotImplCopyWith<

--- a/lib/modules/aswh_down/models/online_pick_collection_models.g.dart
+++ b/lib/modules/aswh_down/models/online_pick_collection_models.g.dart
@@ -158,13 +158,18 @@ class OnlinePickCollectionCacheSnapshotAdapter
               .toList() ??
           const <Map<String, dynamic>>[],
       destination: fields[12] as String? ?? '',
+      inventoryPending: fields[13] as bool? ?? false,
+      pendingStoreSite: fields[14] as String?,
+      pendingMaterialCode: fields[15] as String?,
+      pendingBatchNo: fields[16] as String?,
+      pendingTrayNo: fields[17] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, OnlinePickCollectionCacheSnapshot obj) {
     writer
-      ..writeByte(13)
+      ..writeByte(18)
       ..writeByte(0)
       ..write(obj.stocks)
       ..writeByte(1)
@@ -190,7 +195,17 @@ class OnlinePickCollectionCacheSnapshotAdapter
       ..writeByte(11)
       ..write(obj.inventoryChecks)
       ..writeByte(12)
-      ..write(obj.destination);
+      ..write(obj.destination)
+      ..writeByte(13)
+      ..write(obj.inventoryPending)
+      ..writeByte(14)
+      ..write(obj.pendingStoreSite)
+      ..writeByte(15)
+      ..write(obj.pendingMaterialCode)
+      ..writeByte(16)
+      ..write(obj.pendingBatchNo)
+      ..writeByte(17)
+      ..write(obj.pendingTrayNo);
   }
 
   @override
@@ -379,6 +394,11 @@ _$OnlinePickCollectionCacheSnapshotImpl
                   .toList() ??
               const <Map<String, dynamic>>[],
           destination: json['destination'] as String? ?? '',
+          inventoryPending: json['inventoryPending'] as bool? ?? false,
+          pendingStoreSite: json['pendingStoreSite'] as String?,
+          pendingMaterialCode: json['pendingMaterialCode'] as String?,
+          pendingBatchNo: json['pendingBatchNo'] as String?,
+          pendingTrayNo: json['pendingTrayNo'] as String?,
         );
 
 Map<String, dynamic> _$$OnlinePickCollectionCacheSnapshotImplToJson(
@@ -397,4 +417,9 @@ Map<String, dynamic> _$$OnlinePickCollectionCacheSnapshotImplToJson(
       'expectedErpStore': instance.expectedErpStore,
       'inventoryChecks': instance.inventoryChecks,
       'destination': instance.destination,
+      'inventoryPending': instance.inventoryPending,
+      'pendingStoreSite': instance.pendingStoreSite,
+      'pendingMaterialCode': instance.pendingMaterialCode,
+      'pendingBatchNo': instance.pendingBatchNo,
+      'pendingTrayNo': instance.pendingTrayNo,
     };


### PR DESCRIPTION
## Summary
- adjust scan handling to differentiate outbound vs inventory flows, enforce residual entry, and auto-submit serial-controlled materials
- update task item aggregation and expose an inventory tab to surface recorded residuals during collection
- persist pending inventory context in cache snapshots so resumed sessions continue the residual workflow

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69018688aa848330ab2e24505b1c951c